### PR TITLE
Delete prompt now works as argument from cli

### DIFF
--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -55,6 +55,7 @@
     "figures": "^2.0.0",
     "fs-extra": "^5.0.0",
     "indent-string": "^3.2.0",
+    "inquirer": "^5.0.1",
     "log-symbols": "^2.2.0",
     "log-update": "^2.3.0",
     "ora": "^1.4.0",

--- a/packages/neo-one-cli/src/InteractiveCLI.js
+++ b/packages/neo-one-cli/src/InteractiveCLI.js
@@ -35,6 +35,7 @@ import {
   switchMap,
   take,
 } from 'rxjs/operators';
+import inquirer from 'inquirer';
 import ora from 'ora';
 
 import {
@@ -420,5 +421,9 @@ export default class InteractiveCLI {
       ],
       ['Interactive CLI Config Path', this.clientConfig._configPath],
     ];
+  }
+
+  prompt(questions: Array<Object>): Promise<Object> {
+    return inquirer.prompt(questions);
   }
 }

--- a/packages/neo-one-cli/src/interactive/createCRUD.js
+++ b/packages/neo-one-cli/src/interactive/createCRUD.js
@@ -11,6 +11,7 @@ import {
   type GetCRUD,
   type Plugin,
   type TaskStatus,
+  type InteractiveCLI,
   getTasksError,
   areTasksDone,
 } from '@neo-one/server-plugin';
@@ -26,8 +27,6 @@ import stripAnsi from 'strip-ansi';
 import { empty } from 'rxjs/observable/empty';
 import logUpdate from 'log-update';
 import { timer } from 'rxjs/observable/timer';
-
-import type InteractiveCLI from '../InteractiveCLI';
 
 const pointer = chalk.yellow(figures.pointer);
 const skipped = chalk.yellow(figures.arrowDown);
@@ -159,14 +158,16 @@ const promptDelete = ({
   crud: CRUDResource<*, *>,
   name: string,
 |}) =>
-  cli.vorpal.activeCommand.prompt({
-    type: 'confirm',
-    name: 'continue',
-    default: false,
-    message: `Are you sure you want to delete ${
-      crud.resourceType.name
-    } ${name}?`,
-  });
+  cli.prompt([
+    {
+      type: 'confirm',
+      name: 'continue',
+      default: false,
+      message: `Are you sure you want to delete ${
+        crud.resourceType.name
+      } ${name}?`,
+    },
+  ]);
 
 const createResource = ({
   cli,
@@ -182,12 +183,12 @@ const createResource = ({
       cancel$ = new ReplaySubject();
 
       if (crud instanceof DeleteCRUD) {
-        const delresponse = await promptDelete({
+        const response = await promptDelete({
           cli,
           crud,
           name: args.name,
         });
-        if (!delresponse.continue) {
+        if (!response.continue) {
           cli.vorpal.activeCommand.log('Aborting...');
           return;
         }

--- a/packages/neo-one-server-plugin/src/types.js
+++ b/packages/neo-one-server-plugin/src/types.js
@@ -160,6 +160,7 @@ export type InteractiveCLI = {
   +addDelimiter: (key: string, name: string) => void,
   +removeDelimiter: (key: string) => void,
   +resetDelimiter: () => void,
+  +prompt: (questions: Array<Object>) => Promise<Object>,
   +log: (message: LogMessage) => void,
   +exec: (command: string) => Promise<void>,
   +printDescribe: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,7 +4109,7 @@ extend@^3.0.0, extend@^3.0.1, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.4:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
   dependencies:
@@ -5431,6 +5431,24 @@ inquirer@3.3.0, inquirer@^3.0.6, inquirer@^3.2.2:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.1.tgz#5c0396c974fd98df4cab9afd26ed85874b563550"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -9702,7 +9720,7 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.4.2, rxjs@^5.5.6:
+rxjs@^5.4.2, rxjs@^5.5.2, rxjs@^5.5.6:
   version "5.5.6"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
   dependencies:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change
Previously, delete prompt only worked in interactive cli and hung when delete command passed as an argument (e.g. neo-one delete net altest).  Now the prompt works the same in both cases.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Test Plan
Tested delete command and all prompt options in both interactive and as an argument.
<!-- Explain how this was tested. Reviewer should be able to patch your changes and execute your test plan to verify that the code works as expected. -->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Prompts in both use cases
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#20 
<!-- Enter any applicable Issues here -->
