### PR TITLE
All prompts now work as arguments from the cli

### DIFF
--- a/packages/neo-one-server-plugin-wallet/src/crud/smartContract/CreateSmartContractCRUD.js
+++ b/packages/neo-one-server-plugin-wallet/src/crud/smartContract/CreateSmartContractCRUD.js
@@ -114,7 +114,7 @@ export default class CreateSmartContractCRUD extends CreateCRUD<
       author,
       email,
       description,
-    } = await cli.vorpal.activeCommand.prompt([
+    } = await cli.prompt([
       {
         type: 'input',
         name: 'contractName',

--- a/packages/neo-one-server-plugin-wallet/src/crud/wallet/common.js
+++ b/packages/neo-one-server-plugin-wallet/src/crud/wallet/common.js
@@ -51,18 +51,20 @@ const promptPassword = async ({
   cli: InteractiveCLI,
   prompt: string,
 |}) => {
-  const { password } = await cli.vorpal.activeCommand.prompt({
-    type: 'password',
-    name: 'password',
-    message: prompt,
-    validate: input => {
-      if (typeof input !== 'string' || input.length < 8) {
-        return 'Password must be at least 8 characters';
-      }
+  const { password } = await cli.prompt([
+    {
+      type: 'password',
+      name: 'password',
+      message: prompt,
+      validate: input => {
+        if (typeof input !== 'string' || input.length < 8) {
+          return 'Password must be at least 8 characters';
+        }
 
-      return true;
+        return true;
+      },
     },
-  });
+  ]);
   return password;
 };
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change
Wallet password prompt & smart contract creation prompt now work as arguments from the cli.  The change was to use inquirer.js instead of vorpal's prompt method.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Test Plan
Did not.
<!-- Explain how this was tested. Reviewer should be able to patch your changes and execute your test plan to verify that the code works as expected. -->

### Applicable Issues
Related to #20
<!-- Enter any applicable Issues here -->
