### PR TITLE
#144 - Support 'instanceof keyword in BinaryExpressionCompiler.ts

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler.test.ts
@@ -385,11 +385,11 @@ if (true && false) {
 
   test('dog instanceof Animal [InstanceOfKeyword]', async () => {
     await helpers.executeString(`
-    class Animal{};
+    class Animal {};
     let dog = new Animal();
     if (!(dog instanceof Animal )) {
-        throw 'Failure';
-      }
+      throw 'Failure';
+    }
     `);
   });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler.test.ts
@@ -382,4 +382,14 @@ if (true && false) {
       }
     `);
   });
+
+  test('dog instanceof Animal [InstanceOfKeyword]', async () => {
+    await helpers.executeString(`
+    class Animal{};
+    let dog = new Animal();
+    if (!(dog instanceof Animal )) {
+        throw 'Failure';
+      }
+    `);
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/compile/expression/BinaryExpressionCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/expression/BinaryExpressionCompiler.ts
@@ -483,6 +483,7 @@ export default class BinaryExpressionCompiler extends NodeCompiler<
         sb.visit(right, options);
         // [left instanceof right]
         sb.emitHelper(node, options, sb.helpers.instanceof);
+        // [booleanVal]
         sb.emitHelper(node, options, sb.helpers.createBoolean);
         break;
       case SyntaxKind.CommaToken:

--- a/packages/neo-one-smart-contract-compiler/src/compile/expression/BinaryExpressionCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/expression/BinaryExpressionCompiler.ts
@@ -477,7 +477,13 @@ export default class BinaryExpressionCompiler extends NodeCompiler<
         sb.reportUnsupported(node);
         break;
       case SyntaxKind.InstanceOfKeyword:
-        sb.reportUnsupported(node);
+        // [left]
+        sb.visit(left, options);
+        // [right, left]
+        sb.visit(right, options);
+        // [left instanceof right]
+        sb.emitHelper(node, options, sb.helpers.instanceof);
+        sb.emitHelper(node, options, sb.helpers.createBoolean);
         break;
       case SyntaxKind.CommaToken:
         sb.emitOp(node, 'DROP');

--- a/packages/neo-one-smart-contract-compiler/src/transpile/transpiler/NEOTranspiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/transpile/transpiler/NEOTranspiler.ts
@@ -6,7 +6,6 @@ import Ast, {
   Type,
   Symbol,
   TypeGuards,
-  ParameterDeclaration,
   Identifier,
   SyntaxKind,
   TypeNode,


### PR DESCRIPTION

Resolve #144

BinaryExpressionCompiler.ts
 + code for instanceOf

BinaryExpressionCompiler.ts
 + test for instanceof

Code Cleanup on NEOTranspiler.ts
 - Removed an unused import of: ParameterDeclaration


### Requirements
add functionality that supports instanceof in BinaryExpressionCompiler 

### Description of the Change


### Test Plan

Tested with an execution with by creating a class and creating an instance of this class.  
Then testing that instanceof returned the expected value.

### Alternate Designs
none, this collaborative effort with @dicarlo2 and we went with the standard solution.
 
### Benefits

the ability to use instanceof 

### Possible Drawbacks
none expected.
 
### Applicable Issues

This resolves Issue #144: Support `instanceof` keyword (BinaryExpressionCompiler.ts)
