### PR TITLE
Add syscall: Neo.Blockchain.getTransactionHeight

### DIFF
--- a/packages/neo-one-client-core/src/index.d.ts
+++ b/packages/neo-one-client-core/src/index.d.ts
@@ -263,6 +263,7 @@ export declare type SysCallName =
   | 'Neo.Blockchain.GetHeader'
   | 'Neo.Blockchain.GetBlock'
   | 'Neo.Blockchain.GetTransaction'
+  | 'Neo.Blockchain.GetTransactionHeight'
   | 'Neo.Blockchain.GetAccount'
   | 'Neo.Blockchain.GetValidators'
   | 'Neo.Blockchain.GetAsset'

--- a/packages/neo-one-smart-contract-compiler/src/compile/syscalls.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/syscalls.ts
@@ -1091,7 +1091,7 @@ export const SYSCALLS = {
   }),
   'Neo.Blockchain.GetTransactionHeight': new SimpleSysCall({
     name: 'Neo.Blockchain.GetTransactionHeight',
-    args: [new SysCallArgument('transaction', TransactionValue)],
+    args: [new SysCallArgument('hash', BufferValue)],
     returnType: NumberValue,
   }),
   'Neo.Blockchain.GetAccount': new SimpleSysCall({

--- a/packages/neo-one-smart-contract-compiler/src/compile/syscalls.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/syscalls.ts
@@ -1089,6 +1089,11 @@ export const SYSCALLS = {
     args: [new SysCallArgument('hash', BufferValue)],
     returnType: TransactionValue,
   }),
+  'Neo.Blockchain.GetTransactionHeight': new SimpleSysCall({
+    name: 'Neo.Blockchain.GetTransactionHeight',
+    args: [new SysCallArgument('transaction', TransactionValue)],
+    returnType: NumberValue,
+  }),
   'Neo.Blockchain.GetAccount': new SimpleSysCall({
     name: 'Neo.Blockchain.GetAccount',
     args: [new SysCallArgument('hash', BufferValue)],


### PR DESCRIPTION
Addresses card#178 
Reviewed similar syscalls; current solution is based off Neo.Blockchain.GetTransacitonType
Added Entry in index.d.ts

Submitted for peer review 

                                                DO NOT MERGE