### PR TITLE
Update CircleCI & AppVeyor to run tests agains Node 8.9.0, 9 & 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,9 @@ jobs:
           name: TryNode9
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-            find /home/circleci/.nvm/
-            /home/circleci/.nvm/nvm i 9
+            export NVM_DIR="/home/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            nvm i 9
 
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ jobs:
       - run: *yarn
       - save-cache: *save-yarn-cache
       - run:
+          name: TryNode9
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            find /home/circleci/.nvm/
+            /home/circleci/.nvm/nvm i 9
+
+      - run:
           name: Build
           command: yarn build
       - run:
@@ -56,6 +63,7 @@ jobs:
           name: Node9Test
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            ls -ltr
             /home/circleci/.nvm/nvm i 9 && yarn test-ci
       - run:
           name: Node10Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,23 +58,23 @@ jobs:
           name: Typescript
           command: yarn tsc
       - run:
-          name: Test against Node 9.11
+          name: Test against Node 8.9.0
           command: |
             export NVM_DIR="/home/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            nvm i 8.9.0 && yarn test-ci
+      - run:
+          name: Test against Node 9.11
+          command: |
+            export NVM_DIR="/home/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm i 9 && yarn test-ci
       - run:
           name: Test against Node 10
           command: |
             export NVM_DIR="/home/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm i 10 && yarn test-ci
-      - run:
-          name: Test against Node 8.9.4
-          command: |
-            export NVM_DIR="/home/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            nvm i 8.9.4 && yarn test-ci
       - run:
           name: E2E
           command: yarn e2e-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
             export NVM_DIR="/home/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
       - run:
           name: Build
           command: yarn build
@@ -59,14 +58,23 @@ jobs:
           name: Typescript
           command: yarn tsc
       - run:
-          name: Node9Test
-          command: nvm i 9 && yarn test-ci
+          name: Test against Node 9.11
+          command: |
+            export NVM_DIR="/home/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            nvm i 9 && yarn test-ci
       - run:
-          name: Node10Test
-          command:  nvm i 9 && yarn test-ci
+          name: Test against Node 10
+          command: |
+            export NVM_DIR="/home/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            nvm i 10 && yarn test-ci
       - run:
-          name: Test
-          command:  nvm i 8.9.4 && yarn test-ci
+          name: Test against Node 8.9.4
+          command: |
+            export NVM_DIR="/home/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            nvm i 8.9.4 && yarn test-ci
       - run:
           name: E2E
           command: yarn e2e-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,18 +53,18 @@ jobs:
           name: Typescript
           command: yarn tsc
       - run:
-          name: Test
-          command: yarn test-ci
-      - run:
           name: Node9Test
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            . ~/.bashrc
             nvm i 9 && yarn test-ci
       - run:
           name: Node10Test
           command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
             nvm i 10 && yarn test-ci
+      - run:
+          name: Test
+          command: yarn test-ci
       - run:
           name: E2E
           command: yarn e2e-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,11 @@ jobs:
       - run: *yarn
       - save-cache: *save-yarn-cache
       - run:
-          name: TryNode9
+          name: Install NVM
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
             export NVM_DIR="/home/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            nvm i 9
-
       - run:
           name: Build
           command: yarn build
@@ -62,17 +60,13 @@ jobs:
           command: yarn tsc
       - run:
           name: Node9Test
-          command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-            ls -ltr
-            /home/circleci/.nvm/nvm i 9 && yarn test-ci
+          command: nvm i 9 && yarn test-ci
       - run:
           name: Node10Test
-          command: |
-            /home/circleci/.nvm/nvmnvm i 10 && yarn test-ci
+          command:  nvm i 9 && yarn test-ci
       - run:
           name: Test
-          command: /home/circleci/.nvm/nvm 8.9.4 yarn test-ci
+          command:  nvm i 8.9.4 && yarn test-ci
       - run:
           name: E2E
           command: yarn e2e-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,15 +56,14 @@ jobs:
           name: Node9Test
           command: |
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-            . ~/.bashrc
-            nvm i 9 && yarn test-ci
+            /home/circleci/.nvm/nvm i 9 && yarn test-ci
       - run:
           name: Node10Test
           command: |
-            nvm i 10 && yarn test-ci
+            /home/circleci/.nvm/nvmnvm i 10 && yarn test-ci
       - run:
           name: Test
-          command: yarn test-ci
+          command: /home/circleci/.nvm/nvm 8.9.4 yarn test-ci
       - run:
           name: E2E
           command: yarn e2e-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,16 @@ jobs:
           name: Test
           command: yarn test-ci
       - run:
+          name: Node9Test
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            nvm i 9 && yarn test-ci
+      - run:
+          name: Node10Test
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            nvm i 10 && yarn test-ci
+      - run:
           name: E2E
           command: yarn e2e-ci
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,16 +17,16 @@ install:
   - yarn --version
   - yarn install --non-interactive --frozen-lockfile
   - yarn run build
-  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash && export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 cache:
   - node_modules
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 9 && yarn run test --verbose
-  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 10 && yarn run test --verbose
-  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 8.9.0 && yarn run test --verbose
+  - nvm i 9 && yarn run test --verbose
+  - nvm i 10 && yarn run test --verbose
+  - nvm i 8.9.0 && yarn run test --verbose
   - yarn run e2e --verbose
 
 # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - nodejs_version: "8.9.0"
-    - nodejs_version: "9"
 
 branches:
   only:
@@ -24,9 +23,9 @@ cache:
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - nvm i 9 && run test --verbose
-  - nvm i 10 && run test --verbose
-  - nvm i 8.9.4 && run test --verbose
+  - nvm i 9 && yarn run test --verbose
+  - nvm i 10 && yarn run test --verbose
+  - nvm i 8.9.0 && yarn run test --verbose
   - yarn run test --verbose
   - yarn run e2e --verbose
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,15 +17,16 @@ install:
   - yarn --version
   - yarn install --non-interactive --frozen-lockfile
   - yarn run build
+  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
 cache:
   - node_modules
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - nvm i 9 && yarn run test --verbose
-  - nvm i 10 && yarn run test --verbose
-  - nvm i 8.9.0 && yarn run test --verbose
+  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 9 && yarn run test --verbose
+  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 10 && yarn run test --verbose
+  - export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm i 8.9.0 && yarn run test --verbose
   - yarn run e2e --verbose
 
 # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 environment:
   matrix:
     - nodejs_version: "8.9.0"
+    - nodejs_version: "9"
+    - nodejs_version: "10"
 
 branches:
   only:
@@ -23,14 +25,14 @@ cache:
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - ps: Install-Product node 10.0.0 x64
-  - node --version
+  - ps: Install-Product node 8.9.0 x64
+  - node --version  
   - yarn run test --verbose
   - ps: Install-Product node 9.0.0 x64
   - node --version
   - yarn run test --verbose
-  - ps: Install-Product node 8.9.0 x64
-  - node --version  
+  - ps: Install-Product node 10.0.0 x64
+  - node --version
   - yarn run test --verbose
   - yarn run e2e --verbose
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,23 @@ install:
   - yarn --version
   - yarn install --non-interactive --frozen-lockfile
   - yarn run build
-  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash && export NVM_DIR="/home/circleci/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 cache:
   - node_modules
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - nvm i 9 && yarn run test --verbose
-  - nvm i 10 && yarn run test --verbose
-  - nvm i 8.9.0 && yarn run test --verbose
+  - ps: Install-Product node 10.0.0 x64
+  - node --version
+  - yarn run test --verbose
+  - ps: Install-Product node 9.0.0 x64
+  - node --version
+  - yarn run test --verbose
+  - ps: Install-Product node 8.9.0 x64
+  - node --version  
+  - yarn run test --verbose
   - yarn run e2e --verbose
+
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,14 +25,6 @@ cache:
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - ps: Install-Product node 8.9.0 x64
-  - node --version  
-  - yarn run test --verbose
-  - ps: Install-Product node 9.0.0 x64
-  - node --version
-  - yarn run test --verbose
-  - ps: Install-Product node 10.0.0 x64
-  - node --version
   - yarn run test --verbose
   - yarn run e2e --verbose
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,9 @@ cache:
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
+  - nvm i 9 && run test --verbose
+  - nvm i 10 && run test --verbose
+  - nvm i 8.9.4 && run test --verbose
   - yarn run test --verbose
   - yarn run e2e --verbose
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ test_script:
   - nvm i 9 && yarn run test --verbose
   - nvm i 10 && yarn run test --verbose
   - nvm i 8.9.0 && yarn run test --verbose
-  - yarn run test --verbose
   - yarn run e2e --verbose
 
 # Don't actually build.


### PR DESCRIPTION
Card# 173
Update CircleCI to tests built against 8.9.4 shall now run against Node versions 8.9.0, 9.x & 10.x

## Solution:
Added step "Install NVM"
and...
   - loading NVM for each test run
   - installing the appropriate version of node.

## Current Issues:
###  CircleCI & AppVeyor
The goal was to build against 8.9.0, and test against 9 & 10, however, tests are failing because...
    The module '/home/circleci/neo-one/node_modules/leveldown/build/Release/leveldown.node'
    was compiled against a different Node.js version using
    NODE_MODULE_VERSION 57. This version of Node.js requires
    NODE_MODULE_VERSION 59. Please try re-compiling or re-installing
    the module (for instance, using `npm rebuild` or `npm install`).

## >> DO NOT MERGE <<

