### PR TITLE
Converting neo-one-node-neo-settings form JS to TS

### DIFF
--- a/packages/neo-one-node-neo-settings/package.json
+++ b/packages/neo-one-node-neo-settings/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
+  "typings": "./src/index.ts",
   "engines": {
     "node": ">=8.9.0"
   },

--- a/packages/neo-one-node-neo-settings/src/index.ts
+++ b/packages/neo-one-node-neo-settings/src/index.ts
@@ -1,6 +1,5 @@
-/* @flow */
-import mainFunc from './main';
-import testFunc from './test';
+import { mainFunc } from './main';
+import { testFunc } from './test';
 
 export const main = mainFunc();
 export const test = testFunc();

--- a/packages/neo-one-node-neo-settings/src/main.ts
+++ b/packages/neo-one-node-neo-settings/src/main.ts
@@ -1,21 +1,13 @@
-/* @flow */
-import { TRANSACTION_TYPE, type Settings, common } from '@neo-one/client-core';
+import { common, Settings, TRANSACTION_TYPE } from '@neo-one/client-core';
+import { createCommon } from './common';
 
-import createCommon from './common';
-
-export default (options?: {|
-  privateNet?: boolean,
-  secondsPerBlock?: number,
-  standbyValidators?: Array<string>,
-  address?: string,
-|}): Settings => {
-  const {
-    privateNet,
-    secondsPerBlock,
-    standbyValidators: standbyValidatorsIn,
-    address,
-  } =
-    options || {};
+export default (options?: {
+  readonly privateNet?: boolean;
+  readonly secondsPerBlock?: number;
+  readonly standbyValidators?: ReadonlyArray<string>;
+  readonly address?: string;
+}): Settings => {
+  const { privateNet, secondsPerBlock, standbyValidators: standbyValidatorsIn, address } = options || {};
   const standbyValidators = (
     standbyValidatorsIn || [
       '03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c',
@@ -30,18 +22,16 @@ export default (options?: {|
   const commonSettings = createCommon({
     privateNet,
     standbyValidators,
-    address: address == null ? undefined : common.stringToUInt160(address),
+    address: address == undefined ? undefined : common.stringToUInt160(address),
   });
+
   return {
     genesisBlock: commonSettings.genesisBlock,
     governingToken: commonSettings.governingToken,
     utilityToken: commonSettings.utilityToken,
     decrementInterval: commonSettings.decrementInterval,
     generationAmount: commonSettings.generationAmount,
-    secondsPerBlock:
-      secondsPerBlock == null
-        ? commonSettings.secondsPerBlock
-        : secondsPerBlock,
+    secondsPerBlock: secondsPerBlock == undefined ? commonSettings.secondsPerBlock : secondsPerBlock,
     maxTransactionsPerBlock: commonSettings.maxTransactionsPerBlock,
     memPoolSize: commonSettings.memPoolSize,
     fees: {
@@ -50,6 +40,7 @@ export default (options?: {|
       [TRANSACTION_TYPE.PUBLISH]: common.fixed8FromDecimal(500),
       [TRANSACTION_TYPE.REGISTER]: common.fixed8FromDecimal(10000),
     },
+
     registerValidatorFee: common.fixed8FromDecimal(1000),
     messageMagic: 7630401,
     addressVersion: common.NEO_ADDRESS_VERSION,

--- a/packages/neo-one-node-neo-settings/src/test.ts
+++ b/packages/neo-one-node-neo-settings/src/test.ts
@@ -1,21 +1,13 @@
-/* @flow */
-import { TRANSACTION_TYPE, type Settings, common } from '@neo-one/client-core';
+import { common, Settings, TRANSACTION_TYPE } from '@neo-one/client-core';
+import { createCommon } from './common';
 
-import createCommon from './common';
-
-export default (options?: {|
-  privateNet?: boolean,
-  secondsPerBlock?: number,
-  standbyValidators?: Array<string>,
-  address?: string,
-|}): Settings => {
-  const {
-    privateNet,
-    secondsPerBlock,
-    standbyValidators: standbyValidatorsIn,
-    address,
-  } =
-    options || {};
+export const test = (options?: {
+  readonly privateNet?: boolean;
+  readonly secondsPerBlock?: number;
+  readonly standbyValidators?: ReadonlyArray<string>;
+  readonly address?: string;
+}): Settings => {
+  const { privateNet, secondsPerBlock, standbyValidators: standbyValidatorsIn, address } = options || {};
   const standbyValidators = (
     standbyValidatorsIn || [
       '0327da12b5c40200e9f65569476bbff2218da4f32548ff43b6387ec1416a231ee8',
@@ -26,22 +18,20 @@ export default (options?: {|
       '02d02b1873a0863cd042cc717da31cea0d7cf9db32b74d4c72c01b0011503e2e22',
       '034ff5ceeac41acf22cd5ed2da17a6df4dd8358fcb2bfb1a43208ad0feaab2746b',
     ]
-  ).map((value) => common.stringToECPoint(value));
+  ).map((value: string) => common.stringToECPoint(value));
   const commonSettings = createCommon({
     privateNet,
     standbyValidators,
-    address: address == null ? undefined : common.stringToUInt160(address),
+    address: address == undefined ? undefined : common.stringToUInt160(address),
   });
+
   return {
     genesisBlock: commonSettings.genesisBlock,
     governingToken: commonSettings.governingToken,
     utilityToken: commonSettings.utilityToken,
     decrementInterval: commonSettings.decrementInterval,
     generationAmount: commonSettings.generationAmount,
-    secondsPerBlock:
-      secondsPerBlock == null
-        ? commonSettings.secondsPerBlock
-        : secondsPerBlock,
+    secondsPerBlock: secondsPerBlock == undefined ? commonSettings.secondsPerBlock : secondsPerBlock,
     maxTransactionsPerBlock: commonSettings.maxTransactionsPerBlock,
     memPoolSize: commonSettings.memPoolSize,
     fees: {
@@ -50,6 +40,7 @@ export default (options?: {|
       [TRANSACTION_TYPE.PUBLISH]: common.fixed8FromDecimal(5),
       [TRANSACTION_TYPE.REGISTER]: common.fixed8FromDecimal(100),
     },
+
     registerValidatorFee: common.fixed8FromDecimal(1000),
     messageMagic: 1953787457,
     addressVersion: common.NEO_ADDRESS_VERSION,

--- a/packages/neo-one-node-neo-settings/tsconfig.json
+++ b/packages/neo-one-node-neo-settings/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
packages/neo-one-node-neo-settings/src/common.ts

Blocking:
OPCODE_TO_BYTECODE
I don't know what to do with this, it's an imported object that has no matching export.

1.) export of "common" says
 [ts] Individual declarations in merged declaration 'common' must be all exported or all local.

Result: I renamed the import of common to coreCommon from @neo-one/client-core

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Test Plan

<!-- Explain how this was tested. Reviewer should be able to patch your changes and execute your test plan to verify that the code works as expected. -->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
