### PR TITLE
Keep track of metrics in MetricsFactoryProxy

### DIFF
--- a/packages/neo-one-monitor/src/MetricsFactoryProxy.ts
+++ b/packages/neo-one-monitor/src/MetricsFactoryProxy.ts
@@ -93,38 +93,58 @@ export class SummaryProxy extends MetricProxy<SummaryBase> implements Summary {
 }
 
 export class MetricsFactoryProxy implements MetricsFactory {
+  protected mutableCounters: { [K in string]?: Counter } = {};
+  protected mutableHistograms: { [K in string]?: Histogram } = {};
+  protected mutableGauges: { [K in string]?: Gauge } = {};
+  protected mutableSummaries: { [K in string]?: Summary } = {};
+
   private mutableFactory: MetricsFactory | undefined;
 
+  public reset_forTest(): void {
+    this.mutableCounters = {};
+    this.mutableHistograms = {};
+    this.mutableGauges = {};
+    this.mutableSummaries = {};
+  }
+
   public createCounter(options: MetricOptions): Counter {
-    if (this.mutableFactory !== undefined) {
-      return this.mutableFactory.createCounter(options);
+    let counter = this.mutableCounters[options.name];
+    if (counter === undefined) {
+      counter = this.createCounterHelper(options);
+      this.mutableCounters[options.name] = counter;
     }
 
-    return this.createCounterInternal(options);
+    return counter;
   }
 
   public createGauge(options: MetricOptions): Gauge {
-    if (this.mutableFactory !== undefined) {
-      return this.mutableFactory.createGauge(options);
+    let gauge = this.mutableGauges[options.name];
+    if (gauge === undefined) {
+      gauge = this.createGaugeHelper(options);
+      this.mutableGauges[options.name] = gauge;
     }
 
-    return this.createGaugeInternal(options);
+    return gauge;
   }
 
-  public createHistogram(options: BucketedMetricOptions): Histogram {
-    if (this.mutableFactory !== undefined) {
-      return this.mutableFactory.createHistogram(options);
+  public createHistogram(options: MetricOptions): Histogram {
+    let histogram = this.mutableHistograms[options.name];
+    if (histogram === undefined) {
+      histogram = this.createHistogramHelper(options);
+      this.mutableHistograms[options.name] = histogram;
     }
 
-    return this.createHistogramInternal(options);
+    return histogram;
   }
 
-  public createSummary(options: PercentiledMetricOptions): Summary {
-    if (this.mutableFactory !== undefined) {
-      return this.mutableFactory.createSummary(options);
+  public createSummary(options: MetricOptions): Summary {
+    let summary = this.mutableSummaries[options.name];
+    if (summary === undefined) {
+      summary = this.createSummaryHelper(options);
+      this.mutableSummaries[options.name] = summary;
     }
 
-    return this.createSummaryInternal(options);
+    return summary;
   }
 
   public setFactory(mutableFactory: MetricsFactory): void {
@@ -160,5 +180,37 @@ export class MetricsFactoryProxy implements MetricsFactory {
     }
 
     return construct;
+  }
+
+  private createCounterHelper(options: MetricOptions): Counter {
+    if (this.mutableFactory !== undefined) {
+      return this.mutableFactory.createCounter(options);
+    }
+
+    return this.createCounterInternal(options);
+  }
+
+  private createGaugeHelper(options: MetricOptions): Gauge {
+    if (this.mutableFactory !== undefined) {
+      return this.mutableFactory.createGauge(options);
+    }
+
+    return this.createGaugeInternal(options);
+  }
+
+  private createHistogramHelper(options: BucketedMetricOptions): Histogram {
+    if (this.mutableFactory !== undefined) {
+      return this.mutableFactory.createHistogram(options);
+    }
+
+    return this.createHistogramInternal(options);
+  }
+
+  private createSummaryHelper(options: PercentiledMetricOptions): Summary {
+    if (this.mutableFactory !== undefined) {
+      return this.mutableFactory.createSummary(options);
+    }
+
+    return this.createSummaryInternal(options);
   }
 }

--- a/packages/neo-one-monitor/src/__tests__/BrowserMonitor.test.ts
+++ b/packages/neo-one-monitor/src/__tests__/BrowserMonitor.test.ts
@@ -99,17 +99,18 @@ describe('BrowserMonitor', () => {
   };
 
   let logger = new CollectingLogger();
-  let reporter: Reporter | null;
+  let reporter: Reporter | undefined;
   beforeEach(() => {
     logger = new CollectingLogger();
-    reporter = null;
+    reporter = undefined;
     metrics.setFactory(collectingMetrics);
   });
 
   afterEach(() => {
     collectingMetrics.reset_forTest();
+    metrics.reset_forTest();
     prom.register.clear();
-    if (reporter != undefined) {
+    if (reporter !== undefined) {
       reporter.close();
     }
   });
@@ -163,7 +164,8 @@ describe('BrowserMonitor', () => {
   });
 
   test('Reporter - POST success', async () => {
-    (global as any).fetch = jest.fn(() => Promise.resolve({ ok: true }));
+    // tslint:disable-next-line no-object-mutation no-any
+    (global as any).fetch = jest.fn(async () => Promise.resolve({ ok: true }));
 
     reporter = new Reporter({
       logger,
@@ -196,7 +198,7 @@ describe('BrowserMonitor', () => {
 
     expect((fetch as any).mock.calls).toMatchSnapshot();
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise<void>((resolve) => setTimeout(resolve, 2000));
     expect((fetch as any).mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 

--- a/packages/neo-one-monitor/src/types.ts
+++ b/packages/neo-one-monitor/src/types.ts
@@ -238,6 +238,7 @@ export interface Summary extends SummaryBase {
 export type Metric = Counter | Gauge | Histogram | Summary;
 
 export interface MetricsFactory {
+  readonly reset_forTest: () => void;
   readonly createCounter: (options: MetricOptions) => Counter;
   readonly createGauge: (options: MetricOptions) => Gauge;
   readonly createHistogram: (options: BucketedMetricOptions) => Histogram;


### PR DESCRIPTION
### Description of the Change
Previously, ReportHandler kept track of which metrics it had forwarded to the NodeMetricsFactory.  This caused issues where in some cases the NodeMetricsFactory had already registered some of those metrics with prometheus.  Now, the MetricsFactoryProxy keeps track of all metrics which have been registered, so there should be no issue when forwarding metrics from the browser.  
