### PR TITLE
Add bug fix for attempting multiple inputs on the same block

### DIFF
--- a/packages/neo-one-client/src/__tests__/user/__snapshots__/LocalUserAccountProvider.test.ts.snap
+++ b/packages/neo-one-client/src/__tests__/user/__snapshots__/LocalUserAccountProvider.test.ts.snap
@@ -6,13 +6,26 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider call with no options: provider.getBlockCount 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider call with no options: provider.getUnspentOutputs 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider call with no options: provider.relayTransaction 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider call with no options: provider.testInvoke 1`] = `
 Array [
   Array [
     "net1",
     "d1012200c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000001ff076e656f2d6f6e65000000",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider call: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
     undefined,
   ],
 ]
@@ -28,11 +41,22 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider call: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider call: provider.testInvoke 1`] = `
 Array [
   Array [
     "net1",
-    "d1012906706172616d3151c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d1012906706172616d3151c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim throws NothingToClaim error: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
     undefined,
   ],
 ]
@@ -58,6 +82,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider claim throws NothingToClaim error: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider claim without networkFee: keystore.sign 1`] = `
 Array [
   Array [
@@ -72,6 +98,8 @@ Array [
   ],
 ]
 `;
+
+exports[`LocalUserAccountProvider claim without networkFee: provider.getBlockCount 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider claim without networkFee: provider.getTransactionReceipt 1`] = `
 Array [
@@ -115,9 +143,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -158,7 +195,7 @@ exports[`LocalUserAccountProvider claim: provider.relayTransaction 1`] = `
 Array [
   Array [
     "net1",
-    "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -176,6 +213,10 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider deleteAccount: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider deleteAccount: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown on 2 script attributes when neither match script hash: keystore.sign 1`] = `
 Array [
   Array [
@@ -184,9 +225,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f02000320f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f02000320f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider error thrown on 2 script attributes when neither match script hash: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -211,6 +261,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider error thrown on 2 script attributes when neither match script hash: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown with 1 script attributes and no transaction scripts: keystore.sign 1`] = `
 Array [
   Array [
@@ -219,9 +271,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002203775292229eccdf904f16fff8e83e7dffdc0f0ceff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002203775292229eccdf904f16fff8e83e7dffdc0f0ceff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider error thrown with 1 script attributes and no transaction scripts: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -246,6 +307,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider error thrown with 1 script attributes and no transaction scripts: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown with 2 script attributes and no transaction scripts: keystore.sign 1`] = `
 Array [
   Array [
@@ -254,9 +317,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020003203775292229eccdf904f16fff8e83e7cffdc0f0ce20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020003203775292229eccdf904f16fff8e83e7cffdc0f0ce20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider error thrown with 2 script attributes and no transaction scripts: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -281,6 +353,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider error thrown with 2 script attributes and no transaction scripts: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown with 3+ script attributes: keystore.sign 1`] = `
 Array [
   Array [
@@ -289,9 +363,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f02000420f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec203775292229eccdf904f16fff8e83e7cffdc0f0ce20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f02000420f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec203775292229eccdf904f16fff8e83e7cffdc0f0ce20f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ecff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider error thrown with 3+ script attributes: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -316,6 +399,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider error thrown with 3+ script attributes: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown with with 0 script attributes, but nonzero transaction scripts: keystore.getCurrentAccount 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider error thrown with with 0 script attributes, but nonzero transaction scripts: keystore.sign 1`] = `
@@ -326,9 +411,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d1012200c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec000000000000000000015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d1012200c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec000000000000000000015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider error thrown with with 0 script attributes, but nonzero transaction scripts: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -348,11 +446,13 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider error thrown with with 0 script attributes, but nonzero transaction scripts: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider error thrown with with 0 script attributes, but nonzero transaction scripts: provider.testInvoke 1`] = `
 Array [
   Array [
     "net1",
-    "d1012200c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000000015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010d00c10a746573744d6574686f6400",
+    "d1012200c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000000015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010d00c10a746573744d6574686f6400",
     undefined,
   ],
 ]
@@ -364,17 +464,29 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider getAccounts: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider getAccounts: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider getCurrentAccount: keystore.getCurrentAccount 1`] = `
 Array [
   Array [],
 ]
 `;
 
+exports[`LocalUserAccountProvider getCurrentAccount: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider getCurrentAccount: provider.relayTransaction 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider getNetworks: provider.getBlockCount 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider getNetworks: provider.getNetworks 1`] = `
 Array [
   Array [],
 ]
 `;
+
+exports[`LocalUserAccountProvider getNetworks: provider.relayTransaction 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider invoke with no options: keystore.getCurrentAccount 1`] = `
 Array [
@@ -396,6 +508,8 @@ Array [
   ],
 ]
 `;
+
+exports[`LocalUserAccountProvider invoke with no options: provider.getBlockCount 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider invoke with no options: provider.getInvocationData 1`] = `
 Array [
@@ -461,6 +575,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider invoke: provider.getBlockCount 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider invoke: provider.getInvocationData 1`] = `
 Array [
   Array [
@@ -510,6 +626,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider issue throws error on no inputs: provider.getBlockCount 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider issue throws error on no inputs: provider.getNetworkSettings 1`] = `
 Array [
   Array [
@@ -519,6 +637,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider issue throws error on no inputs: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider issue: keystore.sign 1`] = `
 Array [
   Array [
@@ -527,9 +647,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "010002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c600008af2f000000003775292229eccdf904f16fff8e83e7cffdc0f0ce9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33",
+      "message": "010002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c600008af2f000000003775292229eccdf904f16fff8e83e7cffdc0f0ce9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider issue: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -569,7 +698,128 @@ exports[`LocalUserAccountProvider issue: provider.relayTransaction 1`] = `
 Array [
   Array [
     "net1",
-    "010002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c600008af2f000000003775292229eccdf904f16fff8e83e7cffdc0f0ce9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33010602028a99826e0602028a99826e",
+    "010002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c600008af2f000000003775292229eccdf904f16fff8e83e7cffdc0f0ce9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65025d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65025d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -583,9 +833,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider publish - result fault: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -630,7 +893,7 @@ exports[`LocalUserAccountProvider publish - result fault: provider.relayTransact
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -640,7 +903,7 @@ exports[`LocalUserAccountProvider publish - result fault: provider.testInvoke 1`
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374545701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
@@ -654,9 +917,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider publish - result success: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -701,7 +977,7 @@ exports[`LocalUserAccountProvider publish - result success: provider.relayTransa
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -711,13 +987,22 @@ exports[`LocalUserAccountProvider publish - result success: provider.testInvoke 
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374555701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
 `;
 
 exports[`LocalUserAccountProvider publish throws error on invoke fault: keystore.sign 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider publish throws error on invoke fault: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
 
 exports[`LocalUserAccountProvider publish throws error on invoke fault: provider.getUnspentOutputs 1`] = `
 Array [
@@ -729,11 +1014,13 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider publish throws error on invoke fault: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider publish throws error on invoke fault: provider.testInvoke 1`] = `
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374575701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374575701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
@@ -747,9 +1034,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider publish throws error when no contracts are created: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -794,7 +1094,7 @@ exports[`LocalUserAccountProvider publish throws error when no contracts are cre
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -804,11 +1104,13 @@ exports[`LocalUserAccountProvider publish throws error when no contracts are cre
 Array [
   Array [
     "net1",
-    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d101510f746573744465736372697074696f6e0974657374456d61696c0a74657374417574686f72027631086e616d6554657374565701070602028a99826e68134e656f2e436f6e74726163742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
 `;
+
+exports[`LocalUserAccountProvider read: provider.getBlockCount 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider read: provider.read 1`] = `
 Array [
@@ -818,6 +1120,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider read: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider registerAsset - result fault: keystore.sign 1`] = `
 Array [
   Array [
@@ -826,9 +1130,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider registerAsset - result fault: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -873,7 +1190,7 @@ exports[`LocalUserAccountProvider registerAsset - result fault: provider.relayTr
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -883,7 +1200,7 @@ exports[`LocalUserAccountProvider registerAsset - result fault: provider.testInv
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
@@ -897,9 +1214,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider registerAsset - result success: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -944,7 +1274,7 @@ exports[`LocalUserAccountProvider registerAsset - result success: provider.relay
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -954,7 +1284,7 @@ exports[`LocalUserAccountProvider registerAsset - result success: provider.testI
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
@@ -968,9 +1298,22 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider registerAsset throws error on missing asset: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -1015,7 +1358,7 @@ exports[`LocalUserAccountProvider registerAsset throws error on missing asset: p
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e437265617465000000000000000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -1025,7 +1368,7 @@ exports[`LocalUserAccountProvider registerAsset throws error on missing asset: p
 Array [
   Array [
     "net1",
-    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f030001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    "d1016f1459e75d652b5d3827bf04c165bbe9ef95cca4bf551459e75d652b5d3827bf04c165bbe9ef95cca4bf552102028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef00040065cd1d097465737441737365745868104e656f2e41737365742e4372656174650010a5d4e800000003f000ff076e656f2d6f6e65ff023130015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
     undefined,
   ],
 ]
@@ -1051,6 +1394,8 @@ Array [
   ],
 ]
 `;
+
+exports[`LocalUserAccountProvider registerAsset with no options: provider.getBlockCount 1`] = `Array []`;
 
 exports[`LocalUserAccountProvider registerAsset with no options: provider.getInvocationData 1`] = `
 Array [
@@ -1107,6 +1452,10 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider selectAccount: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider selectAccount: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider transfer 0: keystore.sign 1`] = `
 Array [
   Array [
@@ -1115,9 +1464,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0300029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500000000000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500000000000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transfer 0: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -1148,7 +1506,7 @@ exports[`LocalUserAccountProvider transfer 0: provider.relayTransaction 1`] = `
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0300029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500000000000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500000000000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -1160,9 +1518,26 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider transfer throws error on empty transfers: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider transfer throws error on empty transfers: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider transfer throws error on missing account: keystore.getCurrentAccount 1`] = `
 Array [
   Array [],
+]
+`;
+
+exports[`LocalUserAccountProvider transfer throws error on missing account: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider transfer throws error on missing account: provider.relayTransaction 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider transfer throws insufficient funds error: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
 ]
 `;
 
@@ -1176,6 +1551,8 @@ Array [
 ]
 `;
 
+exports[`LocalUserAccountProvider transfer throws insufficient funds error: provider.relayTransaction 1`] = `Array []`;
+
 exports[`LocalUserAccountProvider transfer without network fee: keystore.sign 1`] = `
 Array [
   Array [
@@ -1187,6 +1564,15 @@ Array [
       "message": "800002f000ff076e656f2d6f6e65055c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transfer without network fee: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -1231,9 +1617,18 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0300029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transfer: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
   ],
 ]
 `;
@@ -1264,7 +1659,7 @@ exports[`LocalUserAccountProvider transfer: provider.relayTransaction 1`] = `
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0300029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -1283,3 +1678,7 @@ Array [
   ],
 ]
 `;
+
+exports[`LocalUserAccountProvider updateAccountName: provider.getBlockCount 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider updateAccountName: provider.relayTransaction 1`] = `Array []`;

--- a/packages/neo-one-client/src/errors.ts
+++ b/packages/neo-one-client/src/errors.ts
@@ -61,6 +61,17 @@ export class InsufficientFundsError extends CustomError {
   }
 }
 
+export class FundsInUseError extends CustomError {
+  public readonly code: string;
+
+  public constructor(total: BigNumber, expected: BigNumber, numInputs: number) {
+    super(
+      `Found ${total.toString()} funds, required: ${expected.toString()}; You have ${numInputs} input(s) on the current block, try transfer again on the next`,
+    );
+    this.code = 'FUNDS_IN_USE';
+  }
+}
+
 export class NothingToClaimError extends CustomError {
   public readonly code: string;
 

--- a/packages/neo-one-client/src/provider/neoone/NEOONEProvider.ts
+++ b/packages/neo-one-client/src/provider/neoone/NEOONEProvider.ts
@@ -137,6 +137,10 @@ export class NEOONEProvider {
     return this.getProvider(network).getNetworkSettings(monitor);
   }
 
+  public async getBlockCount(network: NetworkType, monitor?: Monitor): Promise<number> {
+    return this.getProvider(network).getBlockCount(monitor);
+  }
+
   public read(network: NetworkType): NEOONEDataProvider {
     return this.getProvider(network);
   }


### PR DESCRIPTION
Added a mutable Set to localUserAccountProvider that stores user-inputs/block-index so that a user cannot attempt to use the same inputs across 2 (or more) unique transfers. See the bottom of LocalUserAccountProvider.test.ts for some insight on to what this is catching exactly.

Resolves #211 
