### PR TITLE
Adds Unspent Output Consolidation #221

### DIFF
--- a/packages/neo-one-client-core/src/transaction/ClaimTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/ClaimTransaction.ts
@@ -7,6 +7,7 @@ import { Witness } from '../Witness';
 import { Attribute } from './attribute';
 import { hasDuplicateInputs, hasIntersectingInputs } from './common';
 import { Input, InputJSON } from './Input';
+import { Output } from './Output';
 import {
   FeeContext,
   TransactionBase,
@@ -101,15 +102,19 @@ export class ClaimTransaction extends TransactionBase<TransactionType.Claim, Cla
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): ClaimTransaction {
     return new ClaimTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       claims: this.claims,
     });

--- a/packages/neo-one-client-core/src/transaction/ContractTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/ContractTransaction.ts
@@ -3,6 +3,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { IOHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import { TransactionBase, TransactionBaseAdd, TransactionBaseJSON } from './TransactionBase';
 import { TransactionType } from './TransactionType';
 
@@ -52,15 +54,19 @@ export class ContractTransaction extends TransactionBase<TransactionType.Contrac
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): ContractTransaction {
     return new ContractTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
     });
   }

--- a/packages/neo-one-client-core/src/transaction/EnrollmentTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/EnrollmentTransaction.ts
@@ -5,6 +5,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, JSONHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import {
   TransactionBase,
   TransactionBaseAdd,
@@ -84,15 +86,19 @@ export class EnrollmentTransaction extends TransactionBase<TransactionType.Enrol
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): EnrollmentTransaction {
     return new EnrollmentTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       publicKey: this.publicKey,
     });

--- a/packages/neo-one-client-core/src/transaction/Input.ts
+++ b/packages/neo-one-client-core/src/transaction/Input.ts
@@ -21,7 +21,9 @@ export interface InputJSON {
   readonly vout: number;
 }
 
+const SIZE = IOHelper.sizeOfUInt256 + IOHelper.sizeOfUInt16LE;
 export class Input implements SerializableWire<Input>, Equatable, SerializableJSON<InputJSON> {
+  public static readonly size: number = SIZE;
   public static deserializeWireBase({ reader }: DeserializeWireBaseOptions): Input {
     const hash = reader.readUInt256();
     const index = reader.readUInt16LE();
@@ -38,7 +40,7 @@ export class Input implements SerializableWire<Input>, Equatable, SerializableJS
 
   public readonly hash: UInt256;
   public readonly index: number;
-  public readonly size: number = IOHelper.sizeOfUInt256 + IOHelper.sizeOfUInt16LE;
+  public readonly size: number = SIZE;
   public readonly equals: Equals = utils.equals(
     Input,
     (other) => common.uInt256Equal(this.hash, other.hash) && other.index === this.index,

--- a/packages/neo-one-client-core/src/transaction/InvocationTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/InvocationTransaction.ts
@@ -10,6 +10,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, JSONHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import {
   FeeContext,
   TransactionBase,
@@ -114,15 +116,19 @@ export class InvocationTransaction extends TransactionBase<TransactionType.Invoc
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): InvocationTransaction {
     return new InvocationTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       gas: this.gas,
       script: this.script,

--- a/packages/neo-one-client-core/src/transaction/IssueTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/IssueTransaction.ts
@@ -5,6 +5,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { IOHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import {
   FeeContext,
   TransactionBase,
@@ -90,15 +92,19 @@ export class IssueTransaction extends TransactionBase<typeof TransactionType.Iss
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): IssueTransaction {
     return new IssueTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
     });
   }

--- a/packages/neo-one-client-core/src/transaction/MinerTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/MinerTransaction.ts
@@ -5,6 +5,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import {
   FeeContext,
   TransactionBase,
@@ -70,15 +72,19 @@ export class MinerTransaction extends TransactionBase<TransactionType.Miner, Min
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): MinerTransaction {
     return new MinerTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       nonce: this.nonce,
     });

--- a/packages/neo-one-client-core/src/transaction/Output.ts
+++ b/packages/neo-one-client-core/src/transaction/Output.ts
@@ -30,7 +30,9 @@ export interface OutputJSON {
   readonly address: string;
 }
 
+const SIZE = IOHelper.sizeOfUInt256 + IOHelper.sizeOfFixed8 + IOHelper.sizeOfUInt160;
 export class Output implements SerializableWire<Output>, Equatable {
+  public static readonly size: number = SIZE;
   public static deserializeWireBase({ reader }: DeserializeWireBaseOptions): Output {
     const asset = reader.readUInt256();
     const value = reader.readFixed8();
@@ -49,7 +51,7 @@ export class Output implements SerializableWire<Output>, Equatable {
   public readonly asset: UInt256;
   public readonly value: BN;
   public readonly address: UInt160;
-  public readonly size: number = IOHelper.sizeOfUInt256 + IOHelper.sizeOfUInt16LE + IOHelper.sizeOfUInt160;
+  public readonly size: number = SIZE;
   public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
   public readonly equals: Equals = utils.equals(
     Output,
@@ -63,6 +65,14 @@ export class Output implements SerializableWire<Output>, Equatable {
     this.asset = asset;
     this.value = value;
     this.address = address;
+  }
+
+  public clone({ value = this.value }: { readonly value?: BN }): Output {
+    return new Output({
+      asset: this.asset,
+      value,
+      address: this.address,
+    });
   }
 
   public serializeWireBase(writer: BinaryWriter): void {

--- a/packages/neo-one-client-core/src/transaction/PublishTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/PublishTransaction.ts
@@ -10,6 +10,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import { TransactionBase, TransactionBaseAdd, TransactionBaseJSON, TransactionVerifyOptions } from './TransactionBase';
 import { TransactionType } from './TransactionType';
 
@@ -84,15 +86,19 @@ export class PublishTransaction extends TransactionBase<TransactionType.Publish,
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): PublishTransaction {
     return new PublishTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       contract: this.contract,
     });

--- a/packages/neo-one-client-core/src/transaction/RegisterTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/RegisterTransaction.ts
@@ -8,6 +8,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, JSONHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import {
   FeeContext,
   TransactionBase,
@@ -132,15 +134,19 @@ export class RegisterTransaction extends TransactionBase<typeof TransactionType.
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): RegisterTransaction {
     return new RegisterTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       hash: this.hash,
       asset: this.asset,

--- a/packages/neo-one-client-core/src/transaction/StateTransaction.ts
+++ b/packages/neo-one-client-core/src/transaction/StateTransaction.ts
@@ -5,6 +5,8 @@ import { DeserializeWireBaseOptions, SerializeJSONContext } from '../Serializabl
 import { BinaryWriter, IOHelper, utils } from '../utils';
 import { Witness } from '../Witness';
 import { Attribute } from './attribute';
+import { Input } from './Input';
+import { Output } from './Output';
 import { StateDescriptor, StateDescriptorJSON } from './state';
 import {
   FeeContext,
@@ -100,15 +102,19 @@ export class StateTransaction extends TransactionBase<TransactionType.State, Sta
   public clone({
     scripts = this.scripts,
     attributes = this.attributes,
+    inputs = this.inputs,
+    outputs = this.outputs,
   }: {
     readonly scripts?: ReadonlyArray<Witness>;
     readonly attributes?: ReadonlyArray<Attribute>;
+    readonly inputs?: ReadonlyArray<Input>;
+    readonly outputs?: ReadonlyArray<Output>;
   }): StateTransaction {
     return new StateTransaction({
       version: this.version,
       attributes,
-      inputs: this.inputs,
-      outputs: this.outputs,
+      inputs,
+      outputs,
       scripts,
       descriptors: this.descriptors,
     });

--- a/packages/neo-one-client/src/DeveloperClient.ts
+++ b/packages/neo-one-client/src/DeveloperClient.ts
@@ -1,12 +1,12 @@
 import { RawSourceMap } from '../node_modules/source-map/source-map';
 import { ClientBase } from './ClientBase';
 import {
+  BufferString,
   ContractParameter,
   DeveloperProvider,
   Options,
   TransactionOptions,
   UserAccountProvider,
-  BufferString,
 } from './types';
 
 export class DeveloperClient<

--- a/packages/neo-one-client/src/__tests__/user/__snapshots__/LocalUserAccountProvider.test.ts.snap
+++ b/packages/neo-one-client/src/__tests__/user/__snapshots__/LocalUserAccountProvider.test.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LocalUserAccountProvider blank transaction consolidates: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f05005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider blank transaction consolidates: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider blank transaction consolidates: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider blank transaction consolidates: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider blank transaction consolidates: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f05005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
 exports[`LocalUserAccountProvider call with no options: keystore.getCurrentAccount 1`] = `
 Array [
   Array [],
@@ -48,6 +94,62 @@ Array [
   Array [
     "net1",
     "d1012906706172616d3151c10a746573744d6574686f6467f91d6b7085db7c5aaf09f19eeec1ca3c0db2c6ec0010a5d4e800000002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce00",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim consolidates: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim consolidates: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim consolidates: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider claim consolidates: provider.getUnclaimed 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim consolidates: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider claim consolidates: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060001e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -196,6 +298,107 @@ Array [
   Array [
     "net1",
     "0200015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11368c02487f020002f000ff076e656f2d6f6e65015e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f060002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000a3e111000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidate prioritizes any asset with a return output: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65025c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f09005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0700025c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f00c2eb0b000000009847e26135152874355e324afd5cc99f002acb335c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f00c2eb0b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidate prioritizes any asset with a return output: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidate prioritizes any asset with a return output: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider consolidate prioritizes any asset with a return output: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidate prioritizes any asset with a return output: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65025c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f09005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0700025c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f00c2eb0b000000009847e26135152874355e324afd5cc99f002acb335c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f00c2eb0b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidation prioritizes NEO/GAS for new outputs: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f05005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidation prioritizes NEO/GAS for new outputs: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidation prioritizes NEO/GAS for new outputs: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider consolidation prioritizes NEO/GAS for new outputs: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider consolidation prioritizes NEO/GAS for new outputs: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f05005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60004e7253000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -712,7 +915,7 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65025d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65025a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
   ],
@@ -753,7 +956,7 @@ exports[`LocalUserAccountProvider multi-input-fix networkFee-throws: provider.re
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65025d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65025a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50046c323000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -767,7 +970,7 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65015a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
   ],
@@ -777,7 +980,7 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65015a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
   ],
@@ -814,12 +1017,12 @@ exports[`LocalUserAccountProvider multi-input-fix updates-on-new-block: provider
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65015a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65015c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65015a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -1456,6 +1659,116 @@ exports[`LocalUserAccountProvider selectAccount: provider.getBlockCount 1`] = `A
 
 exports[`LocalUserAccountProvider selectAccount: provider.relayTransaction 1`] = `Array []`;
 
+exports[`LocalUserAccountProvider transaction consolidates GAS when network fee present: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65035a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f06005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0400029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates GAS when network fee present: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates GAS when network fee present: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider transaction consolidates GAS when network fee present: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates GAS when network fee present: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65035a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f06005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0400029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e1f505000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates: keystore.sign 1`] = `
+Array [
+  Array [
+    Object {
+      "account": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "net1",
+      },
+      "message": "800002f000ff076e656f2d6f6e65055a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500a3e111000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50027b929000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60008c8647000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "monitor": undefined,
+    },
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates: provider.getBlockCount 1`] = `
+Array [
+  Array [
+    "net1",
+    undefined,
+  ],
+  Array [
+    "net1",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates: provider.getTransactionReceipt 1`] = `Array []`;
+
+exports[`LocalUserAccountProvider transaction consolidates: provider.getUnspentOutputs 1`] = `
+Array [
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+  Array [
+    "net1",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    undefined,
+  ],
+]
+`;
+
+exports[`LocalUserAccountProvider transaction consolidates: provider.relayTransaction 1`] = `
+Array [
+  Array [
+    "net1",
+    "800002f000ff076e656f2d6f6e65055a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f03005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f02005d044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f04005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600039b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500a3e111000000009847e26135152874355e324afd5cc99f002acb339b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50027b929000000003775292229eccdf904f16fff8e83e7cffdc0f0cee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60008c8647000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    undefined,
+  ],
+]
+`;
+
 exports[`LocalUserAccountProvider transfer 0: keystore.sign 1`] = `
 Array [
   Array [
@@ -1561,7 +1874,7 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65055c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33",
+      "message": "800002f000ff076e656f2d6f6e65055a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33",
       "monitor": undefined,
     },
   ],
@@ -1603,7 +1916,7 @@ exports[`LocalUserAccountProvider transfer without network fee: provider.relayTr
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65055c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65055a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0100019b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33010602028a99826e0602028a99826e",
     undefined,
   ],
 ]
@@ -1617,7 +1930,7 @@ Array [
         "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
         "network": "net1",
       },
-      "message": "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
+      "message": "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce",
       "monitor": undefined,
     },
   ],
@@ -1659,7 +1972,7 @@ exports[`LocalUserAccountProvider transfer: provider.relayTransaction 1`] = `
 Array [
   Array [
     "net1",
-    "800002f000ff076e656f2d6f6e65065c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005c044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
+    "800002f000ff076e656f2d6f6e65065a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005a044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f01005e044e69819d0cc3bda0f1ea04b9db7c02ae066f1f8e2ce4c97a11388c02487f0600029b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc50065cd1d000000009847e26135152874355e324afd5cc99f002acb33e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c6000ca9a3b000000003775292229eccdf904f16fff8e83e7cffdc0f0ce010602028a99826e0602028a99826e",
     undefined,
   ],
 ]

--- a/packages/neo-one-client/src/types.ts
+++ b/packages/neo-one-client/src/types.ts
@@ -271,13 +271,7 @@ export interface Output {
   readonly address: AddressString;
 }
 
-export interface UnspentOutput {
-  readonly asset: Hash256String;
-  readonly value: BigNumber;
-  readonly address: AddressString;
-  readonly txid: Hash256String;
-  readonly vout: number;
-}
+export interface UnspentOutput extends Input, Output {}
 
 export interface Witness {
   readonly invocation: BufferString;

--- a/packages/neo-one-client/src/user/LocalUserAccountProvider.ts
+++ b/packages/neo-one-client/src/user/LocalUserAccountProvider.ts
@@ -44,6 +44,7 @@ import {
   AssetRegister,
   Attribute,
   AttributeArg,
+  BufferString,
   ContractRegister,
   DataProvider,
   GetOptions,
@@ -76,13 +77,13 @@ import {
   UserAccountID,
   UserAccountProvider,
   Witness,
-  BufferString,
 } from '../types';
 import * as clientUtils from '../utils';
 import { converters } from './converters';
 
 export interface KeyStore {
   readonly type: string;
+  readonly byteLimit?: number;
   readonly currentAccount$: Observable<UserAccount | undefined>;
   readonly getCurrentAccount: () => UserAccount | undefined;
   readonly accounts$: Observable<ReadonlyArray<UserAccount>>;
@@ -218,7 +219,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
           monitor: span,
         });
 
-        if (inputs.length === 0) {
+        if (inputs.length === 0 && this.keystore.byteLimit === undefined) {
           throw new NothingToTransferError();
         }
 
@@ -231,6 +232,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
         return this.sendTransaction({
           from,
           transaction,
+          inputs,
           onConfirm: async ({ receipt }) => receipt,
           monitor: span,
         });
@@ -283,6 +285,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
         });
 
         return this.sendTransaction({
+          inputs,
           from,
           transaction,
           onConfirm: async ({ receipt }) => receipt,
@@ -451,6 +454,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
         });
 
         return this.sendTransaction({
+          inputs,
           from,
           transaction,
           onConfirm: async ({ receipt }) => receipt,
@@ -734,6 +738,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
 
         return this.sendTransaction({
           from,
+          inputs,
           transaction: invokeTransaction,
           onConfirm: async ({ transaction, receipt }) => {
             const data = await this.provider.getInvocationData(from.network, transaction.txid);
@@ -761,11 +766,13 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
   }
 
   private async sendTransaction<T>({
+    inputs,
     transaction: transactionUnsignedIn,
     from,
     onConfirm,
     monitor,
   }: {
+    readonly inputs: ReadonlyArray<UnspentOutput>;
     readonly transaction: TransactionModel;
     readonly from: UserAccountID;
     readonly onConfirm: (
@@ -779,6 +786,15 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
     return this.capture(
       async (span) => {
         let transactionUnsigned = transactionUnsignedIn;
+        if (this.keystore.byteLimit !== undefined) {
+          transactionUnsigned = await this.consolidate({
+            inputs,
+            from,
+            transactionUnsignedIn,
+            monitor,
+            byteLimit: this.keystore.byteLimit,
+          });
+        }
         const scriptHash = addressToScriptHash(from.address);
         if (
           transactionUnsigned.inputs.length === 0 &&
@@ -818,7 +834,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
           span,
         );
 
-        transactionUnsignedIn.inputs.forEach((transfer) =>
+        transactionUnsigned.inputs.forEach((transfer) =>
           this.mutableUsedOutputs.add(`${common.uInt256ToString(transfer.hash)}:${transfer.index}`),
         );
 
@@ -842,6 +858,169 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
 
       monitor,
     );
+  }
+
+  private async consolidate({
+    inputs,
+    transactionUnsignedIn,
+    from,
+    monitor,
+    byteLimit,
+  }: {
+    readonly transactionUnsignedIn: TransactionModel;
+    readonly inputs: ReadonlyArray<UnspentOutput>;
+    readonly from: UserAccountID;
+    readonly monitor?: Monitor;
+    readonly byteLimit: number;
+  }): Promise<TransactionModel> {
+    const messageSize = transactionUnsignedIn.serializeUnsigned().length;
+
+    const getMessageSize = ({
+      numNewInputs,
+      numNewOutputs = 0,
+    }: {
+      readonly numNewInputs: number;
+      readonly numNewOutputs?: number;
+    }): number => messageSize + numNewInputs * InputModel.size + numNewOutputs * OutputModel.size;
+
+    const { unspentOutputs: consolidatableUnspents } = await this.getUnspentOutputs({ from, monitor });
+    const assetToUnspentOutputsUnsorted = consolidatableUnspents
+      .filter((unspent) => !inputs.some((input) => unspent.txid === input.txid && unspent.vout === input.vout))
+      .reduce<{ [key: string]: ReadonlyArray<UnspentOutput> }>((acc, unspent) => {
+        if ((acc[unspent.asset] as ReadonlyArray<UnspentOutput> | undefined) !== undefined) {
+          return {
+            ...acc,
+            [unspent.asset]: acc[unspent.asset].concat([unspent]),
+          };
+        }
+
+        return {
+          ...acc,
+          [unspent.asset]: [unspent],
+        };
+      }, {});
+
+    const assetToUnspentOutputs = Object.entries(assetToUnspentOutputsUnsorted).reduce(
+      (acc: typeof assetToUnspentOutputsUnsorted, [_asset, outputs]) => ({
+        ...acc,
+        [_asset]: outputs.sort((coinA, coinB) => coinA.value.comparedTo(coinB.value)),
+      }),
+      assetToUnspentOutputsUnsorted,
+    );
+
+    const { newInputs, updatedOutputs, remainingAssetToUnspentOutputs } = transactionUnsignedIn.outputs.reduce(
+      (
+        acc: {
+          readonly newInputs: ReadonlyArray<InputModel>;
+          readonly updatedOutputs: ReadonlyArray<OutputModel>;
+          readonly remainingAssetToUnspentOutputs: typeof assetToUnspentOutputs;
+        },
+        output,
+      ) => {
+        const asset = common.uInt256ToString(output.asset);
+
+        const unspentOutputsIn = acc.remainingAssetToUnspentOutputs[asset] as ReadonlyArray<UnspentOutput> | undefined;
+
+        const unspentOutputs =
+          unspentOutputsIn === undefined || common.uInt160ToString(output.address) !== addressToScriptHash(from.address)
+            ? []
+            : acc.remainingAssetToUnspentOutputs[asset];
+
+        const tempIns = unspentOutputs.slice(
+          0,
+          Math.max(
+            Math.floor((byteLimit - getMessageSize({ numNewInputs: acc.newInputs.length })) / InputModel.size),
+            0,
+          ),
+        );
+
+        return {
+          newInputs: acc.newInputs.concat(this.convertInputs(tempIns)),
+          updatedOutputs: acc.updatedOutputs.concat([
+            output.clone({
+              value: output.value.add(
+                clientUtils.bigNumberToBN(
+                  tempIns.reduce((left, right) => left.plus(right.value), new BigNumber('0')),
+                  8,
+                ),
+              ),
+            }),
+          ]),
+
+          remainingAssetToUnspentOutputs:
+            unspentOutputsIn === undefined
+              ? acc.remainingAssetToUnspentOutputs
+              : {
+                  ...acc.remainingAssetToUnspentOutputs,
+                  [asset]: unspentOutputsIn.slice(tempIns.length),
+                },
+        };
+      },
+      {
+        newInputs: [],
+        updatedOutputs: [],
+        remainingAssetToUnspentOutputs: assetToUnspentOutputs,
+      },
+    );
+
+    const { finalInputs, newOutputs } = _.sortBy(
+      // tslint:disable-next-line no-unused
+      Object.entries(remainingAssetToUnspentOutputs).filter(([_asset, outputs]) => outputs.length >= 2),
+      ([asset]) => {
+        if (asset === common.NEO_ASSET_HASH) {
+          return 0;
+        }
+
+        if (asset === common.GAS_ASSET_HASH) {
+          return 1;
+        }
+
+        return 2;
+      },
+    ).reduce(
+      (
+        acc: {
+          readonly finalInputs: ReadonlyArray<InputModel>;
+          readonly newOutputs: ReadonlyArray<OutputModel>;
+        },
+        [asset, outputs],
+      ) => {
+        const newUnspents = outputs.slice(
+          0,
+          Math.max(
+            0,
+            Math.floor(
+              (byteLimit -
+                getMessageSize({ numNewInputs: acc.finalInputs.length, numNewOutputs: acc.newOutputs.length }) -
+                OutputModel.size) /
+                InputModel.size,
+            ),
+          ),
+        );
+
+        return {
+          finalInputs: acc.finalInputs.concat(this.convertInputs(newUnspents)),
+          newOutputs:
+            newUnspents.length === 0
+              ? acc.newOutputs
+              : acc.newOutputs.concat(
+                  this.convertOutputs([
+                    {
+                      asset,
+                      value: newUnspents.reduce((left, right) => left.plus(right.value), new BigNumber('0')),
+                      address: from.address,
+                    },
+                  ]),
+                ),
+        };
+      },
+      { finalInputs: newInputs, newOutputs: [] },
+    );
+
+    return transactionUnsignedIn.clone({
+      inputs: transactionUnsignedIn.inputs.concat(finalInputs),
+      outputs: updatedOutputs.concat(newOutputs),
+    });
   }
 
   /*
@@ -908,6 +1087,29 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
     throw new InvalidTransactionError('Something went wrong!');
   }
 
+  private async getUnspentOutputs({
+    from,
+    monitor,
+  }: {
+    readonly from: UserAccountID;
+    readonly monitor?: Monitor;
+  }): Promise<{ readonly unspentOutputs: ReadonlyArray<UnspentOutput>; readonly wasFiltered: boolean }> {
+    const [newBlockCount, allUnspentsIn] = await Promise.all([
+      this.provider.getBlockCount(from.network, monitor),
+      this.provider.getUnspentOutputs(from.network, from.address, monitor),
+    ]);
+    if (newBlockCount !== this.mutableBlockCount) {
+      this.mutableUsedOutputs.clear();
+      this.mutableBlockCount = newBlockCount;
+    }
+    const unspentOutputs = allUnspentsIn.filter(
+      (unspent) => !this.mutableUsedOutputs.has(`${unspent.txid}:${unspent.vout}`),
+    );
+    const wasFiltered = allUnspentsIn.length !== unspentOutputs.length;
+
+    return { unspentOutputs, wasFiltered };
+  }
+
   private async getTransfersInputOutputs({
     from,
     transfers,
@@ -918,21 +1120,11 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
     readonly transfers: ReadonlyArray<Transfer>;
     readonly gas: BigNumber;
     readonly monitor?: Monitor;
-  }): Promise<{ readonly outputs: ReadonlyArray<Output>; readonly inputs: ReadonlyArray<Input> }> {
+  }): Promise<{ readonly outputs: ReadonlyArray<Output>; readonly inputs: ReadonlyArray<UnspentOutput> }> {
     if (transfers.length === 0 && gas.lte(utils.ZERO_BIG_NUMBER)) {
       return { inputs: [], outputs: [] };
     }
-    const [newBlockCount, allOutputsIn] = await Promise.all([
-      this.provider.getBlockCount(from.network, monitor),
-      this.provider.getUnspentOutputs(from.network, from.address, monitor),
-    ]);
-
-    if (newBlockCount !== this.mutableBlockCount) {
-      this.mutableUsedOutputs.clear();
-      this.mutableBlockCount = newBlockCount;
-    }
-    const allOutputs = allOutputsIn.filter((output) => !this.mutableUsedOutputs.has(`${output.txid}:${output.vout}`));
-    const wasFiltered = allOutputsIn.length !== allOutputs.length;
+    const { unspentOutputs: allOutputs, wasFiltered } = await this.getUnspentOutputs({ from, monitor });
 
     return Object.values(
       _.groupBy(
@@ -953,7 +1145,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
         const assetResults = toByAsset.reduce<{
           remaining: BigNumber;
           remainingOutputs: ReadonlyArray<UnspentOutput>;
-          inputs: ReadonlyArray<Input>;
+          inputs: ReadonlyArray<UnspentOutput>;
           outputs: ReadonlyArray<Output>;
         }>(
           ({ remaining, remainingOutputs, inputs, outputs: innerOutputs }, { amount, to }) => {
@@ -998,7 +1190,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
           outputs,
         };
       },
-      { inputs: [] as Input[], outputs: [] as Output[] },
+      { inputs: [] as UnspentOutput[], outputs: [] as Output[] },
     );
   }
 
@@ -1018,7 +1210,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
     readonly remaining: BigNumber;
     readonly wasFiltered: boolean;
   }): {
-    readonly inputs: ReadonlyArray<Input>;
+    readonly inputs: ReadonlyArray<UnspentOutput>;
     readonly outputs: ReadonlyArray<Output>;
     readonly remainingOutputs: ReadonlyArray<UnspentOutput>;
     readonly remaining: BigNumber;
@@ -1069,14 +1261,11 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
     }
 
     let coinAmount = utils.ZERO_BIG_NUMBER;
-    const mutableInputs: Input[] = [];
+    const mutableInputs: UnspentOutput[] = [];
     // tslint:disable-next-line no-loop-statement
     for (let i = 0; i < k + 1; i += 1) {
       coinAmount = coinAmount.plus(outputsOrdered[i].value);
-      mutableInputs.push({
-        txid: outputsOrdered[i].txid,
-        vout: outputsOrdered[i].vout,
-      });
+      mutableInputs.push(outputsOrdered[i]);
     }
 
     return {


### PR DESCRIPTION
Working currently in tests. Consolidates unspent outputs when a byte-limit is specified on the keystore to avoid running into the problem of not being able to make a large transaction with multiple small inputs because of ledger/wallet restrictions.

I'm pretty confident in the process and have a test for contractTransaction and claimTransaction that both pass with / without network fees and variable byteLimits.

edit: fixed red squiggles.