### PR TITLE
Add tests: Expression Compilers

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/AsExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/AsExpressionCompiler.test.ts
@@ -1,0 +1,17 @@
+import { helpers } from '../../../__data__';
+
+// as borrowed from: InterfaceDeclarationCompiler.test
+describe('AsExpressionCompiler', () => {
+  test('Create object given interface, using "as {type}"', async () => {
+    await helpers.executeString(`
+    interface Foo {
+      bar: number;
+    }
+    var foo = {} as Foo;
+
+    if (foo.bar!== undefined) {
+      throw 'Failure';
+    }
+      `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/IdentifierCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/IdentifierCompiler.test.ts
@@ -1,0 +1,27 @@
+import { helpers } from '../../../__data__';
+
+describe('IdentifierCompiler', () => {
+  test('valid identifiers', async () => {
+    await helpers.executeString(`
+    let $variable = 'valid';
+    let _var_i_able_ = 'valid';
+    let $holy$dollar$batman$ = 'valid';
+    `);
+  });
+  test('this is not CSS, identifiers cannot have hyphens', async () => {
+    await helpers.compileString(
+      `
+      let hyphenated-variable = 'invalid';
+      `,
+      { type: 'error' },
+    );
+  });
+  test('identifiers may contain but not start with numbers', async () => {
+    await helpers.compileString(
+      `
+      let 1BigVariable = 'invalid';
+      `,
+      { type: 'error' },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/NewExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/NewExpressionCompiler.test.ts
@@ -1,0 +1,12 @@
+import { helpers } from '../../../__data__';
+
+describe('NewExpressionCompiler', () => {
+  test('use New make an object', async () => {
+    await helpers.executeString(`
+      const d = new Array('one', 'two', 'three');
+      if(! (d instanceof Array)) {
+        throw 'Failure';
+      }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/NumericLiteralCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/NumericLiteralCompiler.test.ts
@@ -1,0 +1,49 @@
+import { helpers } from '../../../__data__';
+
+describe('NumericLiteralCompiler', () => {
+  test('Number Groupings & types', async () => {
+    await helpers.executeString(`
+const sevenPointSixBillion = 7_600_000_000;
+
+if (sevenPointSixBillion !== 7600000000) {
+  throw 'Failure';
+}
+    `);
+  });
+
+  test('Assigning decimal, binary, hex & octal', async () => {
+    await helpers.executeString(`
+const sevenPointSixBillion = 7_600_000_000;
+const binaryByteMasking = 0b1111_1111;
+const grouping_hex = 0xFF_EF_D5;
+const anOctal: number = 0o744;
+
+if (sevenPointSixBillion !== 7600000000) {
+  throw 'Failure';
+}
+if (grouping_hex !== 16773077) {
+  throw 'Failure';
+}
+if (binaryByteMasking !== 255) {
+  throw 'Failure';
+}
+if (anOctal !== 484) {
+  throw 'Failure';
+}
+    `);
+  });
+
+  test('To the E', async () => {
+    await helpers.executeString(`
+const toTheE = 123e5;
+const toTheNegativeE = 0.00123;
+
+if(toTheE !== 12300000 ) {
+  throw 'Failure';
+}
+if(toTheNegativeE !== 0.00123 ) {
+  throw 'Failure';
+}
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ParenthesizedExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ParenthesizedExpressionCompiler.test.ts
@@ -1,0 +1,12 @@
+import { helpers } from '../../../__data__';
+
+describe('ParenthesizedExpressionCompiler', () => {
+  test('simple', async () => {
+    await helpers.executeString(`
+      const d = ((1 + 2) * (3-1)) / 2;
+      if(d !==3){
+        throw 'Failure';
+      }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PostfixUnaryExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PostfixUnaryExpressionCompiler.test.ts
@@ -1,0 +1,22 @@
+import { helpers } from '../../../__data__';
+
+describe('PostfixUnaryExpressionCompiler', () => {
+  test('Increment', async () => {
+    await helpers.executeString(`
+    let i = 1;
+    i++;
+    if(i++ !== 2){
+        throw 'Failure';
+    }
+    `);
+  });
+  test('decrement', async () => {
+    await helpers.executeString(`
+    let i = 2;
+    i++;
+    if(i !== 3){
+      throw 'Failure';
+    }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PrefixUnaryExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PrefixUnaryExpressionCompiler.test.ts
@@ -1,0 +1,34 @@
+import { helpers } from '../../../__data__';
+
+describe('PrefixUnaryExpressionCompiler', () => {
+  test('Double Negative', async () => {
+    await helpers.executeString(`
+      if(-(-2) !== 2){
+        throw 'Failure';
+      }
+    `);
+  });
+  test('Not False', async () => {
+    await helpers.executeString(`
+      if(!false !== true){
+        throw 'Failure';
+      }
+    `);
+  });
+  test('increment', async () => {
+    await helpers.executeString(`
+    let i = 2;
+      if(++i !== 3){
+        throw 'Failure';
+      }
+    `);
+  });
+  test('decrement', async () => {
+    await helpers.executeString(`
+    let i = 3;
+      if(--i !== 2){
+        throw 'Failure';
+      }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PropertyAccessExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PropertyAccessExpressionCompiler.test.ts
@@ -1,0 +1,12 @@
+import { helpers } from '../../../__data__';
+
+describe('PropertyAccessExpressionCompiler', () => {
+  test('access object property', async () => {
+    await helpers.executeString(`
+    const bar = {x:'1', y:'2'};
+    if(bar.x + bar.y !== '12' ){
+      throw 'failure'
+    }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/StringLiteralCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/StringLiteralCompiler.test.ts
@@ -1,0 +1,12 @@
+import { helpers } from '../../../__data__';
+
+describe('StringLiteralCompiler', () => {
+  test('basic', async () => {
+    await helpers.executeString(`
+    const x = "aString";
+    if ('aString' !== x){
+      throw 'Failure';
+    }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/SuperExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/SuperExpressionCompiler.test.ts
@@ -1,0 +1,26 @@
+import { helpers } from '../../../__data__';
+
+describe('SuperExpressionCompiler', () => {
+  test('basic', async () => {
+    await helpers.executeString(`
+    class Animal{
+      animal : string;
+      constructor(animal: string){
+        this.animal = animal;
+      }
+    }
+    class Dog extends Animal{
+      constructor(){
+        super('dog');
+      }
+    }
+
+    const d =  new Dog();
+
+    if(d.animal!=="dog"){
+      throw 'Failure';
+    }
+
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ThisExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ThisExpressionCompiler.test.ts
@@ -1,0 +1,27 @@
+import { helpers } from '../../../__data__';
+
+describe('ThisExpressionCompiler', () => {
+  test.skip('basic this usage on object literal', async () => {
+    await helpers.executeString(`
+    const x = {
+      otherThing: (x: string)=> 'A ' + x;
+      thing: (x: string)=> this.otherThing(x);
+    }
+    if(x.thing('foo') !=='A foo'){
+      throw 'Failure';
+    }
+    `);
+  });
+  test('basic this usage from a class', async () => {
+    await helpers.executeString(`
+    class Dohicky{
+      thing = (x: string)=> this.otherThing(x);
+      otherThing = (x: string)=> 'A ' + x;
+    }
+    const x = new Dohicky();
+    if(x.thing('foo') !=='A foo'){
+      throw 'Failure';
+    }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/VoidExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/VoidExpressionCompiler.test.ts
@@ -1,0 +1,15 @@
+import { helpers } from '../../../__data__';
+
+describe('VoidExpressionCompiler', () => {
+  test('void must be compared against undefined', async () => {
+    await helpers.executeString(`
+    let outer;
+    let z = 1;
+    const fnct = (x: number):void=>{ outer = x};
+    var y = fnct(z);
+    if( y!==undefined || outer !==z){
+      throw 'Failure';
+    }
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/IdentifierCompiler.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/IdentifierCompiler.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IdentifierCompiler identifiers may contain but not start with numbers 1`] = `"code.ts (2,12): Unknown reference: BigVariable"`;
+
+exports[`IdentifierCompiler this is not CSS, identifiers cannot have hyphens 1`] = `"code.ts (2,22): Unknown reference: variable"`;


### PR DESCRIPTION
    Adding tests for Expression Compilers:
    - Number Literals
    - As
    - identifier (variable naming)
    - new thing();
    - parenthesis.
    - postfix
    - prefix
    - property access
    - string literal
    - super();
    - this
    - void

    & snapshots

# Ready for merge
If there are no obvious tests that should be added, this pull request is a good start and ready for merge.