### PR TITLE
adds 'file-name-casing': false which fixes the stupid linting build error

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -40,6 +40,7 @@
     "no-expression-statement": false,
     "no-parameter-properties": false,
     "prefer-function-over-method": false,
+    "file-name-casing": false,
 
     "trailing-comma": [
       true,


### PR DESCRIPTION
`"file-name-casing": false`
