### PR TITLE
fixes build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /packages/*/dist
 /packages/*/dist-ts
 .rpt2_cache
+/reports
 
 # Logs
 logs

--- a/packages/neo-one-client-core/src/crypto/crypto.ts
+++ b/packages/neo-one-client-core/src/crypto/crypto.ts
@@ -3,7 +3,7 @@ import ECKey from '@neo-one/ec-key';
 import { CustomError, utils } from '@neo-one/utils';
 import base58 from 'bs58';
 import xor from 'buffer-xor';
-import * as cryptoLib from 'crypto';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
 import { ec as EC, KeyPair } from 'elliptic';
 import scrypt from 'scrypt-js';
 import WIF from 'wif';
@@ -43,20 +43,17 @@ export class InvalidAddressError extends CustomError {
 }
 
 const sha1 = (value: Buffer): Buffer =>
-  cryptoLib
-    .createHash('sha1')
+  createHash('sha1')
     .update(value)
     .digest();
 
 const sha256 = (value: Buffer): Buffer =>
-  cryptoLib
-    .createHash('sha256')
+  createHash('sha256')
     .update(value)
     .digest();
 
 const rmd160 = (value: Buffer): Buffer =>
-  cryptoLib
-    .createHash('rmd160')
+  createHash('rmd160')
     .update(value)
     .digest();
 
@@ -206,7 +203,7 @@ const createKeyPair = (): { readonly privateKey: PrivateKey; readonly publicKey:
   };
 };
 
-const createPrivateKey = (): PrivateKey => common.bufferToPrivateKey(cryptoLib.randomBytes(32));
+const createPrivateKey = (): PrivateKey => common.bufferToPrivateKey(randomBytes(32));
 
 const toScriptHash = hash160;
 
@@ -468,7 +465,7 @@ const encryptNEP2 = async ({
   const derived1 = derived.slice(0, 32);
   const derived2 = derived.slice(32, 64);
 
-  const cipher = cryptoLib.createCipheriv(NEP2_CIPHER, derived2, Buffer.alloc(0, 0));
+  const cipher = createCipheriv(NEP2_CIPHER, derived2, Buffer.alloc(0, 0));
 
   cipher.setAutoPadding(false);
   cipher.end(xor(privateKey, derived1));
@@ -524,7 +521,7 @@ const decryptNEP2 = async ({
   const derived1 = derived.slice(0, 32);
   const derived2 = derived.slice(32, 64);
 
-  const decipher = cryptoLib.createDecipheriv(NEP2_CIPHER, derived2, Buffer.alloc(0, 0));
+  const decipher = createDecipheriv(NEP2_CIPHER, derived2, Buffer.alloc(0, 0));
 
   decipher.setAutoPadding(false);
   decipher.end(decoded.slice(7, 7 + 32));

--- a/packages/neo-one-client-core/src/utils/utils.ts
+++ b/packages/neo-one-client-core/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { BN } from 'bn.js';
-import * as crypto from 'crypto';
+import { randomBytes } from 'crypto';
 import _ from 'lodash';
 import { equals } from './equals';
 import { lazy } from './lazy';
@@ -118,7 +118,7 @@ const calculateClaimAmount = async ({
 
 const randomUInt = (): number => Math.floor(Math.random() * UINT_MAX_NUMBER);
 
-const randomUInt64 = (): BN => new BN(crypto.randomBytes(8).toString('hex'), 16);
+const randomUInt64 = (): BN => new BN(randomBytes(8).toString('hex'), 16);
 
 export const utils = {
   FD: new BN(0xfd),

--- a/scripts/e2e/One.js
+++ b/scripts/e2e/One.js
@@ -55,7 +55,7 @@ class One {
     this.dirName = this.dir.name;
     this.serverPort = _.random(10000, 50000);
     this.minPort = this.serverPort + 1;
-    const [cmd, args] = this._createCommand('start server --debug --static-neo-one');
+    const [cmd, args] = this._createCommand('start server --static-neo-one');
     this.server = execa(cmd, args, this._getEnv());
 
     let stdout = '';

--- a/scripts/e2e/jestSetup.js
+++ b/scripts/e2e/jestSetup.js
@@ -1,4 +1,4 @@
-jest.setTimeout(5 * 60 * 1000);
+jest.setTimeout(360 * 1000);
 
 afterEach(async () => {
   await one.cleanupTest();


### PR DESCRIPTION
removes `import * as crypto from 'crypto'` from some places of client-core which caused a deprecation warning to trigger even though we never used the deprecated modules.