### PR TITLE
adds `reactivex/ix-esnext-esm` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@babel/plugin-syntax-numeric-separator": "7.0.0-rc.1",
     "@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1",
     "@babel/plugin-syntax-typescript": "7.0.0-rc.1",
+    "@reactivex/ix-esnext-esm": "2.3.5",
     "@types/babel__code-frame": "7.0.0",
     "@types/bs58": "3.0.30",
     "@types/chokidar": "1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,12 @@
   dependencies:
     tslib "^1.8.0"
 
+"@reactivex/ix-esnext-esm@2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@reactivex/ix-esnext-esm/-/ix-esnext-esm-2.3.5.tgz#c62389c6212385ecff152ae2bb0b86dfb47e1988"
+  dependencies:
+    tslib "^1.8.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
Node 8 and Node 9 might still be broken, but Node 10 won't build either without this one dependency.

adds `@reactivex/ix-esnext-esm` to our dependencies in `package.json`.
