### PR TITLE
Ledger Support for Node and Browser

### DIFF
--- a/jest/ledger.js
+++ b/jest/ledger.js
@@ -1,0 +1,7 @@
+const unit = require('./unit');
+
+module.exports = {
+  ...unit,
+  displayName: 'ledger',
+  testRegex: '^.*/__ledger_tests__/.*\\.test\\.tsx?$',
+};

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test": "yarn run jest --config jest/unit.js",
     "test-ci": "yarn run jest --config jest/unit-ci.js --ci -w 1",
     "test:playground": "yarn run ts-node ./packages/neo-one-playground/scripts/runCypress.ts",
+    "test:ledger": "yarn run jest --config jest/ledger.js --w 1",
     "e2e": "yarn run jest --config jest/e2e.js",
     "e2e-ci": "yarn run jest --config jest/e2e-ci.js --ci -w 1",
     "tsc": "cross-env NODE_OPTIONS=\"--max-old-space-size=3072\" tsc && tsc -p packages/neo-one-smart-contract && tsc -p packages/neo-one-smart-contract-lib && tsc -p packages/neo-one-smart-contract-lib/src/__data__/contracts && tsc -p packages/neo-one-smart-contract-compiler/src/__data__/contracts && tsc -p packages/neo-one-server-plugin-project/src/__data__/ico/one/contracts",

--- a/packages/neo-one-client-core/src/__ledger_tests__/LedgerHandler.test.ts
+++ b/packages/neo-one-client-core/src/__ledger_tests__/LedgerHandler.test.ts
@@ -1,0 +1,37 @@
+import { publicKeyToAddress } from '@neo-one/client-common';
+import { LedgerHandler } from '../user/keystore/LedgerHandler';
+
+describe(`Ledger Handler`, () => {
+  let handler: LedgerHandler;
+
+  beforeAll(async () => {
+    handler = await LedgerHandler.init();
+  });
+
+  test(`gets pubKey`, async () => {
+    const pubKey = await handler.getPublicKey(0);
+
+    expect(pubKey).toBeDefined();
+    expect(pubKey.length).toEqual(66);
+    expect(publicKeyToAddress(pubKey)).toBeDefined();
+  });
+
+  test(`gets multiple distinct pubKeys`, async () => {
+    const values = [1, 2, 3];
+
+    const keys = await Promise.all(values.map(async (val) => handler.getPublicKey(val)));
+
+    expect(keys[0]).not.toEqual(keys[1]);
+    expect(keys[1]).not.toEqual(keys[2]);
+  });
+
+  test('signs', async () => {
+    const message = Buffer.from(
+      '8000000185e7e907cc5c5683e7fc926ba4be613d1810aebe14686b3675ee27d2476e5201000002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60a08601000000000013354f4f5d3f989a221c794271e0bb2471c2735ee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60e23f01000000000013354f4f5d3f989a221c794271e0bb2471c2735e',
+      'hex',
+    );
+
+    const test = await handler.sign({ message, account: 0 });
+    expect(test.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/neo-one-client-core/src/__tests__/user/keystore/LedgerKeyStore.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/user/keystore/LedgerKeyStore.test.ts
@@ -1,0 +1,213 @@
+import { common, crypto } from '@neo-one/client-common';
+import { utils } from '@neo-one/utils';
+import BigNumber from 'bignumber.js';
+import _ from 'lodash';
+import { of } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+import {
+  ConnectedHandler,
+  Handler,
+  Ledger,
+  LedgerKeyStore,
+  LedgerProvider,
+  Ledgers,
+} from '../../../user/keystore/LedgerKeyStore';
+
+const testMessage =
+  '8000000185e7e907cc5c5683e7fc926ba4be613d1810aebe14686b3675ee27d2476e5201000002e72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60a08601000000000013354f4f5d3f989a221c794271e0bb2471c2735ee72d286979ee6cb1b7e65dfddfb2e384100b8d148e7758de42e4168b71792c60e23f01000000000013354f4f5d3f989a221c794271e0bb2471c2735e';
+
+const flattenLedgers = (ledgers: Ledgers) =>
+  _.flatten(
+    Object.values(ledgers)
+      .filter(utils.notNull)
+      .map((networkLedgers) => Object.values(networkLedgers)),
+  ).filter(utils.notNull);
+
+describe('LedgerKeyStore', () => {
+  const emptyAccount = {
+    balances: {
+      ['dicarloin']: new BigNumber(0),
+    },
+  };
+
+  const activeAccount = {
+    balances: {
+      ['dicarloin']: new BigNumber(1),
+    },
+  };
+
+  const networks = ['test'];
+  const networks$ = of(networks);
+  const getAccount = jest.fn();
+
+  const ledgerProvider: LedgerProvider = {
+    networks$,
+    getAccount,
+    getNetworks: () => networks,
+  };
+
+  const indexAccount = {
+    type: 'ledger',
+    id: {
+      network: 'test',
+      address: 'ARL4VYQWxSwigpRsCsucLxovujKDmwYeTd',
+    },
+    name: '0',
+    publicKey: '03d81d462f80d55ff234b1b221e46d52e4da3f93c465edbbaeebd742bc1947fe6d',
+    configurableName: false,
+    deletable: false,
+  };
+
+  const secondaryAccount = {
+    type: 'ledger',
+    id: {
+      network: 'test',
+      address: 'AJGCVgoLp3bU57zd4k6mcpedWr45Em8dFD',
+    },
+    name: '1',
+    publicKey: '031546889cf12577237536380e86b2587d55743f9d4dac8879f332b79ce1a84cd6',
+    configurableName: false,
+    deletable: false,
+  };
+
+  const indexLedger: Ledger = {
+    accountKey: 0,
+    account: indexAccount,
+  };
+
+  const secondaryLedger: Ledger = {
+    accountKey: 1,
+    account: secondaryAccount,
+  };
+
+  const mockConnectedHandler: ConnectedHandler = {
+    getPublicKey: async (account?: number) => {
+      switch (account === undefined || account > 1 ? 2 : account) {
+        case 0: {
+          return Promise.resolve('03d81d462f80d55ff234b1b221e46d52e4da3f93c465edbbaeebd742bc1947fe6d');
+        }
+        case 1: {
+          return Promise.resolve('031546889cf12577237536380e86b2587d55743f9d4dac8879f332b79ce1a84cd6');
+        }
+        case 2: {
+          return Promise.resolve(common.ecPointToString(crypto.privateKeyToPublicKey(crypto.createPrivateKey())));
+        }
+        default:
+          throw new Error('how did this happen?');
+      }
+    },
+    sign: async () =>
+      Promise.resolve(
+        Buffer.from(
+          '30440220587176332925a4bb30990ea66426a826221b2f925cdb087b8d20fd5561bacc5102207c58ebef1b7e8337ee175680203bc6a5ba6269149641a0c3fe9899fb4b6414b6ffffe78096130342169ee4998f941f48dee0e07c535084da66696bd7edea52403ff1',
+          'hex',
+        ),
+      ),
+    close: async () => Promise.resolve(),
+  };
+
+  const mockHandler: Handler = {
+    byteLimit: 2048,
+    type: 'ledger',
+    init: async () => Promise.resolve(mockConnectedHandler),
+  };
+
+  let keystore: LedgerKeyStore;
+
+  beforeAll(() => {
+    getAccount.mockReset();
+    getAccount.mockImplementation(() => emptyAccount);
+    keystore = new LedgerKeyStore(ledgerProvider, mockHandler);
+  });
+
+  afterAll(async () => {
+    await keystore.close();
+  });
+
+  test('accounts$', async () => {
+    const [currentAccount, accounts] = await Promise.all([
+      keystore.currentAccount$
+        .pipe(
+          filter((value) => value !== undefined),
+          take(1),
+        )
+        .toPromise(),
+      keystore.accounts$
+        .pipe(
+          filter((value) => value.length > 0),
+          take(1),
+        )
+        .toPromise(),
+    ]);
+    expect(currentAccount).toEqual(indexAccount);
+    expect(accounts).toEqual([indexAccount, secondaryAccount]);
+  });
+
+  test('type', () => {
+    const result = keystore.type;
+
+    expect(result).toEqual('ledger');
+  });
+
+  test('byteLimit', () => {
+    const result = keystore.byteLimit;
+
+    expect(result).toEqual(2048);
+  });
+
+  test('getAccounts', async () => {
+    const result = keystore.getAccounts();
+
+    expect(result).toEqual([indexAccount, secondaryAccount]);
+  });
+
+  test('ledgers', async () => {
+    const result = keystore.ledgers;
+
+    expect(flattenLedgers(result)).toEqual([indexLedger, secondaryLedger]);
+  });
+
+  test('mixed scan', async () => {
+    await keystore.close();
+
+    let count = 0;
+    getAccount.mockReset();
+    getAccount.mockImplementation(() => {
+      if (count === 19) {
+        count = count + 1;
+
+        return activeAccount;
+      }
+      count = count + 1;
+
+      return emptyAccount;
+    });
+
+    keystore = new LedgerKeyStore(ledgerProvider, mockHandler);
+    await keystore.currentAccount$
+      .pipe(
+        filter((value) => value !== undefined),
+        take(1),
+      )
+      .toPromise();
+
+    const accounts = keystore.getAccounts();
+    const account = keystore.getCurrentAccount();
+
+    expect(accounts.length).toEqual(21);
+    expect(account).toBeDefined();
+  });
+
+  test('sign', async () => {
+    await keystore.accounts$
+      .pipe(
+        filter((value) => value.length !== 0),
+        take(1),
+      )
+      .toPromise();
+
+    const result = await keystore.sign({ account: indexLedger.account.id, message: testMessage });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/neo-one-client-core/src/__tests__/user/keystore/__snapshots__/LedgerKeyStore.test.ts.snap
+++ b/packages/neo-one-client-core/src/__tests__/user/keystore/__snapshots__/LedgerKeyStore.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LedgerKeyStore sign 1`] = `
+Object {
+  "invocation": "4c6830440220587176332925a4bb30990ea66426a826221b2f925cdb087b8d20fd5561bacc5102207c58ebef1b7e8337ee175680203bc6a5ba6269149641a0c3fe9899fb4b6414b6ffffe78096130342169ee4998f941f48dee0e07c535084da66696bd7edea52403ff1",
+  "verification": "2103d81d462f80d55ff234b1b221e46d52e4da3f93c465edbbaeebd742bc1947fe6dac",
+}
+`;

--- a/packages/neo-one-client-core/src/errors.ts
+++ b/packages/neo-one-client-core/src/errors.ts
@@ -81,3 +81,15 @@ export const PasswordRequiredError = makeErrorWithCode(
   () => 'A password is required when creating accounts on the MainNet.',
 );
 export const NothingToTransferError = makeErrorWithCode('NOTHING_TO_TRANSFER', () => 'Nothing to transfer.');
+export const LedgerNotSupportedError = makeErrorWithCode(
+  'LEDGER_NOT_SUPPORTED',
+  () => `Ledger not supported by your machine.`,
+);
+export const LedgerNotDetectedError = makeErrorWithCode(
+  'LEDGER_NOT_DETECTED',
+  () => `Ledger not detected by your machine.`,
+);
+export const LedgerStatusCodeError = makeErrorWithCode(
+  'BAD_LEDGER_STATUS_CODE',
+  (code: string) => `Received status code ${code} from ledger.`,
+);

--- a/packages/neo-one-client-core/src/user/keystore/LedgerHandler.ts
+++ b/packages/neo-one-client-core/src/user/keystore/LedgerHandler.ts
@@ -1,0 +1,134 @@
+import { crypto, PublicKeyString } from '@neo-one/client-common';
+import { HWLedger, LedgerTransport } from '@neo-one/client-switch';
+import { LedgerNotDetectedError, LedgerNotSupportedError, LedgerStatusCodeError } from '../../errors';
+
+export interface LedgerQueueRequest {
+  readonly msg: Buffer;
+  readonly resolve: (value: Buffer) => void;
+  readonly reject: (error: Error) => void;
+}
+
+const keyRequestParams = Buffer.from('80040000', 'hex');
+const initMessageParams = Buffer.from('80020000', 'hex');
+const finalMessageParams = Buffer.from('80028000', 'hex');
+
+const BIP44 = (accountIn = 0): Buffer => {
+  const account = accountIn.toString(16);
+
+  return Buffer.from(`8000002C800003788000000000000000${'0'.repeat(8 - account.length)}${account}`, 'hex');
+};
+
+const chunkBuffer = (buffer: Buffer, chunkLength: number): ReadonlyArray<Buffer> => {
+  if (buffer.length > chunkLength) {
+    return [buffer.slice(0, chunkLength)].concat(chunkBuffer(buffer.slice(chunkLength), chunkLength));
+  }
+
+  return [buffer];
+};
+
+export class LedgerHandler {
+  public static readonly byteLimit = LedgerTransport.byteLimit;
+  public static readonly type = LedgerTransport.type;
+
+  public static readonly init = async () => {
+    const isSupported = await LedgerTransport.isSupported();
+    if (!isSupported) {
+      throw new LedgerNotSupportedError();
+    }
+    const paths = await LedgerTransport.list();
+    if (paths.length === 0) {
+      throw new LedgerNotDetectedError();
+    }
+    const ledger = await LedgerTransport.open(paths[0]);
+    ledger.setScrambleKey('NEO');
+
+    return new LedgerHandler(ledger);
+  };
+
+  private readonly ledger: HWLedger;
+  private readonly mutableQueue: LedgerQueueRequest[];
+  private mutableRunning: boolean;
+
+  private constructor(ledger: HWLedger) {
+    this.ledger = ledger;
+    this.mutableRunning = false;
+    this.mutableQueue = [];
+  }
+
+  public async getPublicKey(account = 0): Promise<PublicKeyString> {
+    const response = await this.send(Buffer.concat([keyRequestParams, Buffer.from('14', 'hex'), BIP44(account)]));
+
+    return crypto.toECPoint(response).toString('hex');
+  }
+
+  public async sign({ message, account }: { readonly message: Buffer; readonly account: number }): Promise<Buffer> {
+    const data = Buffer.concat([message, BIP44(account)]);
+    const chunks = chunkBuffer(data, 250);
+    const initChunks = chunks.slice(0, chunks.length - 1);
+    const finalChunk = chunks[chunks.length - 1];
+
+    await Promise.all(
+      initChunks.map(async (chunk) => {
+        await this.send(Buffer.concat([initMessageParams, Buffer.from([chunk.length]), chunk]));
+      }),
+    );
+
+    return this.send(
+      Buffer.concat([finalMessageParams, Buffer.from(finalChunk.length.toString(16), 'hex'), finalChunk]),
+    );
+  }
+
+  public async close(): Promise<void> {
+    await this.ledger.close();
+  }
+
+  private async send(msg: Buffer): Promise<Buffer> {
+    // tslint:disable-next-line:promise-must-complete
+    const promise = new Promise<Buffer>((resolve, reject) => {
+      this.mutableQueue.push({
+        msg,
+        resolve,
+        reject,
+      });
+    });
+
+    this.startSendLoop().catch(() => {
+      // do nothing
+    });
+
+    return promise;
+  }
+
+  private async startSendLoop(): Promise<void> {
+    if (this.mutableRunning) {
+      return;
+    }
+
+    this.mutableRunning = true;
+
+    let entry = this.mutableQueue.shift();
+    // tslint:disable-next-line:no-loop-statement
+    while (entry !== undefined) {
+      try {
+        const result = await this.doSend(entry.msg);
+        entry.resolve(result);
+      } catch (error) {
+        entry.reject(error);
+      }
+      entry = this.mutableQueue.shift();
+    }
+
+    this.mutableRunning = false;
+  }
+
+  private async doSend(msg: Buffer): Promise<Buffer> {
+    const response = await this.ledger.exchange(msg);
+
+    const status = response.slice(response.length - 2);
+    if (status.toString('hex') !== '9000') {
+      throw new LedgerStatusCodeError(status.toString('hex'));
+    }
+
+    return response.slice(0, response.length - 2);
+  }
+}

--- a/packages/neo-one-client-core/src/user/keystore/LedgerKeyStore.ts
+++ b/packages/neo-one-client-core/src/user/keystore/LedgerKeyStore.ts
@@ -1,0 +1,338 @@
+import {
+  Account,
+  AddressString,
+  common,
+  crypto,
+  NetworkType,
+  PublicKeyString,
+  publicKeyToAddress,
+  UserAccount,
+  UserAccountID,
+  Witness,
+  WitnessModel,
+} from '@neo-one/client-common';
+import { Monitor } from '@neo-one/monitor';
+import { mergeScanLatest, utils } from '@neo-one/utils';
+import _ from 'lodash';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
+import { UnknownAccountError } from '../../errors';
+import { LedgerHandler } from './LedgerHandler';
+
+export type Ledgers = { readonly [Network in string]?: { readonly [Address in string]?: Ledger } };
+
+export interface Ledger {
+  readonly accountKey: number;
+  readonly account: UserAccount;
+}
+
+export interface LedgerProvider {
+  readonly getNetworks: () => ReadonlyArray<NetworkType>;
+  readonly networks$: Observable<ReadonlyArray<NetworkType>>;
+  readonly getAccount: (network: NetworkType, address: AddressString, monitor?: Monitor) => Promise<Account>;
+}
+
+export interface Handler {
+  readonly byteLimit: number;
+  readonly type: string;
+  readonly init: () => Promise<ConnectedHandler>;
+}
+
+export interface ConnectedHandler {
+  readonly getPublicKey: (account?: number) => Promise<PublicKeyString>;
+  readonly sign: (
+    options: {
+      readonly message: Buffer;
+      readonly account: number;
+    },
+  ) => Promise<Buffer>;
+  readonly close: () => Promise<void>;
+}
+
+interface ScanInterface {
+  readonly ledgers: Ledgers;
+  readonly scannedNetworks: Set<NetworkType>;
+}
+
+const flattenLedgers = (ledgers: Ledgers) =>
+  _.flatten(
+    Object.values(ledgers)
+      .filter(utils.notNull)
+      .map((networkLedgers) => Object.values(networkLedgers)),
+  ).filter(utils.notNull);
+
+const getNewNetworks = (networks: Set<NetworkType> | undefined, networksIn: ReadonlyArray<NetworkType>) => {
+  if (networks === undefined) {
+    return networksIn;
+  }
+
+  return networksIn.filter((network) => !networks.has(network));
+};
+
+export class LedgerKeyStore {
+  public get ledgers(): Ledgers {
+    return this.ledgersInternal$.getValue();
+  }
+
+  public get currentAccount(): UserAccount | undefined {
+    return this.currentAccountInternal$.getValue();
+  }
+  public readonly type: string;
+  public readonly byteLimit: number;
+  public readonly currentAccount$: Observable<UserAccount | undefined>;
+  public readonly accounts$: Observable<ReadonlyArray<UserAccount>>;
+
+  private readonly ledgerHandler: Handler;
+  private readonly initPromise: Promise<ConnectedHandler>;
+  private readonly provider: LedgerProvider;
+  private readonly ledgers$: Observable<ReadonlyArray<Ledger>>;
+  private readonly currentAccountInternal$: BehaviorSubject<UserAccount | undefined>;
+  private readonly accountsInternal$: BehaviorSubject<ReadonlyArray<UserAccount>>;
+  private readonly ledgersInternal$: BehaviorSubject<Ledgers>;
+  private readonly ledgersSubscription: Subscription;
+
+  public constructor(provider: LedgerProvider, handlerIn?: Handler) {
+    this.ledgerHandler = handlerIn === undefined ? LedgerHandler : handlerIn;
+    this.type = this.ledgerHandler.type;
+    this.byteLimit = this.ledgerHandler.byteLimit;
+    this.provider = provider;
+
+    this.initPromise = this.init();
+
+    this.ledgersInternal$ = new BehaviorSubject<Ledgers>({});
+    this.ledgersSubscription = this.provider.networks$
+      .pipe(
+        mergeScanLatest(async (acc: ScanInterface | undefined, networks) => {
+          const networksFiltered = getNewNetworks(acc === undefined ? undefined : acc.scannedNetworks, networks);
+          const handler = await this.initPromise;
+          const next = await Promise.all(
+            networksFiltered.map(async (network) => this.scanLedgerAccounts(handler, network)),
+          );
+          const newLedgers = next.reduce<ReadonlyArray<Ledger>>(
+            (accum, newLedgersIn) => accum.concat(newLedgersIn),
+            [],
+          );
+
+          const nextLedgers = newLedgers.reduce<Ledgers>(
+            (accum, ledger) => ({
+              ...accum,
+              [ledger.account.id.network]: {
+                ...(accum[ledger.account.id.network] === undefined ? {} : accum[ledger.account.id.network]),
+                [ledger.account.id.address]: ledger,
+              },
+            }),
+            acc === undefined ? {} : acc.ledgers,
+          );
+
+          return {
+            ledgers: nextLedgers,
+            scannedNetworks: acc === undefined ? new Set() : new Set([...acc.scannedNetworks].concat(networksFiltered)),
+          };
+        }),
+        map(({ ledgers }) => ledgers),
+      )
+      .subscribe(this.ledgersInternal$);
+
+    this.ledgers$ = this.ledgersInternal$.pipe(
+      distinctUntilChanged((a, b) => _.isEqual(a, b)),
+      map(flattenLedgers),
+    );
+
+    this.accountsInternal$ = new BehaviorSubject<ReadonlyArray<UserAccount>>([]);
+    this.ledgers$.pipe(map((ledgers) => ledgers.map(({ account }) => account))).subscribe(this.accountsInternal$);
+    this.accounts$ = this.accountsInternal$;
+
+    this.currentAccountInternal$ = new BehaviorSubject<UserAccount | undefined>(undefined);
+    this.ledgers$
+      .pipe(
+        map((ledgers) => {
+          if (ledgers.length === 0) {
+            return undefined;
+          }
+
+          return ledgers[Math.max(0, ledgers.length - 2)].account;
+        }),
+      )
+      .subscribe(this.currentAccountInternal$);
+    this.currentAccount$ = this.currentAccountInternal$.pipe(distinctUntilChanged());
+  }
+
+  public getCurrentAccount(): UserAccount | undefined {
+    return this.currentAccountInternal$.getValue();
+  }
+
+  public getAccounts(): ReadonlyArray<UserAccount> {
+    return this.accountsInternal$.getValue();
+  }
+
+  public getNetworks(): ReadonlyArray<NetworkType> {
+    return this.provider.getNetworks();
+  }
+
+  public async deleteAccount(): Promise<void> {
+    throw new Error('not implemented on ledger.');
+  }
+
+  public async updateAccountName(): Promise<void> {
+    throw new Error('not implemented on ledger.');
+  }
+
+  public async selectAccount(id?: UserAccountID, _monitor?: Monitor): Promise<void> {
+    if (id === undefined) {
+      this.currentAccountInternal$.next(undefined);
+    } else {
+      const { account } = this.getLedger(id);
+      this.currentAccountInternal$.next(account);
+    }
+  }
+
+  public async sign({
+    account,
+    message,
+    monitor,
+  }: {
+    readonly account: UserAccountID;
+    readonly message: string;
+    readonly monitor?: Monitor;
+  }): Promise<Witness> {
+    const handler = await this.initPromise;
+
+    return this.capture(
+      async () => {
+        const ledger = this.getLedger(account);
+        const response = await handler.sign({
+          message: Buffer.from(message, 'hex'),
+          account: ledger.accountKey,
+        });
+
+        const witness = crypto.createWitnessForSignature(
+          response,
+          common.stringToECPoint(ledger.account.publicKey),
+          WitnessModel,
+        );
+
+        return {
+          verification: witness.verification.toString('hex'),
+          invocation: witness.invocation.toString('hex'),
+        };
+      },
+      'neo_ledger_sign',
+      monitor,
+    );
+  }
+
+  public getLedger({ address, network }: UserAccountID): Ledger {
+    const ledgers = this.ledgers[network];
+    if (ledgers === undefined) {
+      throw new UnknownAccountError(address);
+    }
+
+    const ledger = ledgers[address];
+    if (ledger === undefined) {
+      throw new UnknownAccountError(address);
+    }
+
+    return ledger;
+  }
+
+  public async init(): Promise<ConnectedHandler> {
+    return this.ledgerHandler.init();
+  }
+
+  public async close(): Promise<void> {
+    const handler = await this.initPromise;
+    this.ledgersSubscription.unsubscribe();
+    await handler.close();
+  }
+
+  private async scanLedgerAccounts(
+    handler: ConnectedHandler,
+    network: NetworkType,
+    maxOffset = 20,
+  ): Promise<ReadonlyArray<Ledger>> {
+    const scanAccountsInternal = async (start: number, currentOffset = 0): Promise<ReadonlyArray<Ledger>> => {
+      const ledgerAccounts = await Promise.all(
+        [...Array(maxOffset).keys()].map(async (num) => {
+          const key = await handler.getPublicKey(start + num);
+
+          return this.publicKeyToLedgerAccount(start + num, key, network);
+        }),
+      );
+
+      const unscannedAccounts = await Promise.all(
+        ledgerAccounts.map(async (ledger) => {
+          const { balances } = await this.provider.getAccount(network, ledger.account.publicKey);
+
+          return {
+            empty: Object.values(balances).every((balance) => balance.isEqualTo(0)),
+            ledger,
+          };
+        }),
+      );
+
+      const { ledgerAccounts: newAccounts, offset: newOffset } = unscannedAccounts.reduce(
+        (
+          acc: {
+            readonly ledgerAccounts: ReadonlyArray<Ledger>;
+            readonly offset: number;
+          },
+          unscanned,
+        ) => {
+          if (unscanned.empty) {
+            return {
+              ledgerAccounts: acc.ledgerAccounts.concat(unscanned.ledger),
+              offset: acc.offset + 1,
+            };
+          }
+
+          return {
+            ledgerAccounts: acc.ledgerAccounts.concat(unscanned.ledger),
+            offset: 1,
+          };
+        },
+        { ledgerAccounts: [], offset: currentOffset },
+      );
+
+      if (newOffset < maxOffset) {
+        const nextAccounts = await scanAccountsInternal(start + maxOffset, newOffset);
+
+        return newAccounts.concat(nextAccounts);
+      }
+
+      return newAccounts.slice(newOffset - maxOffset, maxOffset);
+    };
+
+    const accounts = await scanAccountsInternal(0);
+
+    return accounts.slice(0, accounts.length - (maxOffset - 2));
+  }
+
+  private publicKeyToLedgerAccount(accountVal: number, publicKey: string, network: NetworkType): Ledger {
+    return {
+      accountKey: accountVal,
+      account: {
+        type: `ledger`,
+        id: {
+          network,
+          address: publicKeyToAddress(publicKey),
+        },
+        name: accountVal.toString(),
+        publicKey,
+        configurableName: false,
+        deletable: false,
+      },
+    };
+  }
+
+  private async capture<T>(func: (monitor?: Monitor) => Promise<T>, name: string, monitor?: Monitor): Promise<T> {
+    if (monitor === undefined) {
+      return func();
+    }
+
+    return monitor.at('ledger_key_store').captureSpanLog(func, {
+      name,
+      level: { log: 'verbose', span: 'info' },
+      trace: true,
+    });
+  }
+}

--- a/packages/neo-one-client-switch/package.json
+++ b/packages/neo-one-client-switch/package.json
@@ -6,12 +6,17 @@
   "browser": "./src/index.browser.ts",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
+    "@ledgerhq/hw-transport-node-hid": "4.22.0",
+    "@ledgerhq/hw-transport-u2f": "4.21.0",
     "@neo-one/client-common": "^1.0.0-preview.0",
     "@neo-one/node-vm": "^1.0.0-preview.0",
     "@neo-one/types": "^1.0.0-preview.0",
     "@neo-one/utils": "^1.0.0-preview.0",
     "@types/babel__code-frame": "^7.0.0",
     "@types/lodash": "^4.14.116",
+    "@types/ledgerhq__hw-transport":"^4.21.0",
+    "@types/ledgerhq__hw-transport-node-hid":"^4.22.0",
+    "@types/ledgerhq__hw-transport-u2f":"^4.21.0",
     "lodash": "^4.17.11",
     "source-map": "^0.7.3",
     "tslib": "^1.9.3"

--- a/packages/neo-one-client-switch/src/browser/LedgerTransport.ts
+++ b/packages/neo-one-client-switch/src/browser/LedgerTransport.ts
@@ -1,0 +1,10 @@
+import TransportU2F from '@ledgerhq/hw-transport-u2f';
+import { Ledger } from '../common';
+
+export const LedgerTransport: Ledger = {
+  type: 'ledger',
+  byteLimit: 256,
+  isSupported: TransportU2F.isSupported,
+  list: TransportU2F.list,
+  open: TransportU2F.open,
+};

--- a/packages/neo-one-client-switch/src/browser/index.ts
+++ b/packages/neo-one-client-switch/src/browser/index.ts
@@ -1,3 +1,4 @@
 export * from './createConsoleLogMessages';
 export * from './processActionsAndMessage';
 export * from './processConsoleLogMessages';
+export * from './LedgerTransport';

--- a/packages/neo-one-client-switch/src/common/Ledger.ts
+++ b/packages/neo-one-client-switch/src/common/Ledger.ts
@@ -1,0 +1,13 @@
+export interface HWLedger {
+  readonly setScrambleKey: (key: string) => void;
+  readonly exchange: (apdu: Buffer) => Promise<Buffer>;
+  readonly close: () => Promise<void>;
+}
+
+export interface Ledger {
+  readonly type: string;
+  readonly byteLimit: number;
+  readonly open: (path: string) => Promise<HWLedger>;
+  readonly list: () => Promise<ReadonlyArray<string>>;
+  readonly isSupported: () => Promise<boolean>;
+}

--- a/packages/neo-one-client-switch/src/common/index.ts
+++ b/packages/neo-one-client-switch/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './createConsoleLogMessages';
 export * from './processConsoleLogMessages';
 export * from './processActionsAndMessage';
+export * from './Ledger';

--- a/packages/neo-one-client-switch/src/index.browser.ts
+++ b/packages/neo-one-client-switch/src/index.browser.ts
@@ -4,5 +4,6 @@ export {
   ProcessActionsAndMessageOptions,
   ProcessConsoleLogOptions,
   disableConsoleLogForTest,
+  HWLedger,
 } from './common';
 export * from './browser';

--- a/packages/neo-one-client-switch/src/index.ts
+++ b/packages/neo-one-client-switch/src/index.ts
@@ -5,5 +5,6 @@ export {
   ProcessConsoleLogOptions,
   disableConsoleLogForTest,
   enableConsoleLogForTest,
+  HWLedger,
 } from './common';
 export * from './node';

--- a/packages/neo-one-client-switch/src/node/LedgerTransport.ts
+++ b/packages/neo-one-client-switch/src/node/LedgerTransport.ts
@@ -1,0 +1,10 @@
+import TransportNodeHid from '@ledgerhq/hw-transport-node-hid';
+import { Ledger } from '../common';
+
+export const LedgerTransport: Ledger = {
+  type: 'ledger',
+  byteLimit: 256,
+  open: TransportNodeHid.open,
+  list: TransportNodeHid.list,
+  isSupported: TransportNodeHid.isSupported,
+};

--- a/packages/neo-one-client-switch/src/node/index.ts
+++ b/packages/neo-one-client-switch/src/node/index.ts
@@ -1,3 +1,4 @@
 export * from './createConsoleLogMessages';
 export * from './processActionsAndMessage';
 export * from './processConsoleLogMessages';
+export * from './LedgerTransport';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,6 +1220,31 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@ledgerhq/hw-transport-node-hid@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.22.0.tgz#1ee00dcccd852cb6fb152cd68c781c9689cf9f24"
+  integrity sha1-HuANzM2FLLb7FSzWjHgclonPnyQ=
+  dependencies:
+    "@ledgerhq/hw-transport" "^4.21.0"
+    lodash "^4.17.10"
+    node-hid "^0.7.2"
+    usb "^1.3.2"
+
+"@ledgerhq/hw-transport-u2f@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.21.0.tgz#85695d7e853a5c21af7e7dcb0ce3919f2b65cdd9"
+  integrity sha1-hWldfoU6XCGvfn3LDOORnytlzdk=
+  dependencies:
+    "@ledgerhq/hw-transport" "^4.21.0"
+    u2f-api "0.2.7"
+
+"@ledgerhq/hw-transport@^4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.21.0.tgz#50f85cfe115ba3f9d5bf94755c701e927175794f"
+  integrity sha1-UPhc/hFbo/nVv5R1XHAeknF1eU8=
+  dependencies:
+    events "^2.0.0"
+
 "@lerna/add@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
@@ -2430,6 +2455,28 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/ledgerhq__hw-transport-node-hid@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport-node-hid/-/ledgerhq__hw-transport-node-hid-4.22.0.tgz#f4e0272c0159c8206f41747d52ccaab14ebf44ed"
+  integrity sha512-QE1gSC0QU7k60Ngc/+LK/Tsm0lu9ttmjCv32uBqjAVOtlj8cb3dMC5KvtGMKUiqdf1N/H5juiHbrLJOJKkplRw==
+  dependencies:
+    "@types/node" "*"
+    "@types/node-hid" "*"
+
+"@types/ledgerhq__hw-transport-u2f@^4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport-u2f/-/ledgerhq__hw-transport-u2f-4.21.0.tgz#b3d7af7c42ac063fe98cf0f82dc9aa581a558b3c"
+  integrity sha512-kE5Re3B7Ga6ICx9HYVt/Q/oSuTsITeijw2LbMm2od0qg61Rr76a+QmGmdNhuLmsK8+QFK0G2wvYj73uJQ+OIIg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ledgerhq__hw-transport@^4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.0.tgz#d6de28dc1c70622096f6404224e3678fab8345f0"
+  integrity sha512-OKck4LAMglquNqJe+yZ1fG/Btyi7dsiypKLgYsB6i1OwHtF5kBjTZL+7Ki/Mf98FtTnLFoGqODknnZl2MZELag==
+  dependencies:
+    "@types/node" "*"
+
 "@types/leveldown@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/leveldown/-/leveldown-4.0.0.tgz#3725cd6593f723435c5d72215369ef969a2fcce5"
@@ -2536,6 +2583,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/node-cron/-/node-cron-1.2.0.tgz#aefb50be6c09f7e6a1e4c074168698b526c0b543"
   integrity sha512-A5ABiPYKir3vjEjrq0+a8KFXD9dgXq9EOP6Mi2OWTltx5YxIZDSrJBkBqvlyuhg9fbwTYi09NruciVYP42vkKA==
+
+"@types/node-hid@*":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@types/node-hid/-/node-hid-0.7.0.tgz#f696f39c528059116236e41df90c8fcba077d711"
+  integrity sha512-P46Ed7R+/3peWShb7hNGD/ajvpMiY1tWKG35aQ3oPOxV2Nls6porDqXPvZT4qnx5T8hb6Ot5juxfQS87Tpjk4w==
 
 "@types/node@*", "@types/node@^10.1.0":
   version "10.11.0"
@@ -4482,7 +4534,7 @@ binaryextensions@2:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
   integrity sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==
 
-bindings@~1.3.0:
+bindings@^1.3.0, bindings@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
   integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
@@ -7437,6 +7489,11 @@ events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
+events@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
+  integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
 
 eventsource@0.1.6:
   version "0.1.6"
@@ -12680,7 +12737,7 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.0.0, nan@^2.10.0, nan@^2.9.2:
+nan@^2.0.0, nan@^2.10.0, nan@^2.8.0, nan@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
   integrity sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==
@@ -12816,6 +12873,15 @@ node-gyp@^3.8.0:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
+
+node-hid@^0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.3.tgz#736e9a4dee5eec96c20fbe301e0311bb185cb2f4"
+  integrity sha512-LOCqWqcOlng+Kn1Qj/54zrPVfCagg1O7RlSgMmugykBcoYvUud6BswTrJM2aXuBac+bCCm3lA2srRG8YfmyXZQ==
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.10.0"
+    prebuild-install "^4.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -17780,6 +17846,11 @@ tz-offset@0.0.1:
   resolved "https://registry.yarnpkg.com/tz-offset/-/tz-offset-0.0.1.tgz#fef920257024d3583ed9072a767721a18bdb8a76"
   integrity sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ==
 
+u2f-api@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
+  integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
+
 ua-parser-js@^0.7.17, ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
@@ -18082,6 +18153,14 @@ urlgrey@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
+
+usb@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-1.3.3.tgz#4e8a4b44ab8833fa1c4fb99778ebae1d2d626970"
+  integrity sha512-WRBxI54yEs2QPj28G6kITI3Wu7VxrtHbqiDvDRUDKdg97lcK1pTP8y9LoDWF22OiCCrEvrdeq0lNcr84QOzjXQ==
+  dependencies:
+    nan "^2.8.0"
+    node-pre-gyp "^0.10.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# 【﻿Ｌｅｄｇｅｒ　Ｓｕｐｐｏｒｔ】
#192 

(resubmission of #403 after refactoring of neo-one)
## Description of the Change

Strap in for this commit boys. L E D G E R support is here!

In this commit I've done a few things:
1) created declaration files for external ledger packages in our `@types` directory.
2) created a browser/node switchable `LedgerTransport` in `@neo-one/client-switch` which handles communicating with our Ledgers in their respective environments.
3) created `LedgerKeyStore` in `@neo-one/client/user/keystores/` which implements the KeyStore interface (modified to fit some functions that aren't necessary for ledger) using our newly defined `LedgerHandler` to handle the passing of messages and connections to ledgers.
4) ??? hopefully this just hooks up super ez-pz?
5) profit.


## Requirements

we add two new dependencies to `@neo-one/client-switch`,
```json
    "@ledgerhq/hw-transport-node-hid":"4.22.0",
    "@ledgerhq/hw-transport-u2f":"4.21.0",
```

additionally I have created declaration files for the Transport classes inside these at `@types/@ledgerhq/`

## Test Plan

### KeyStores
Need to test `LedgerKeyStore` in the same manner that we test `LocalKeyStore`.

*Update* I have added tests for `LedgerKeyStore`, need to get with you @dicarlo2 and review all of this. I think there is still a few more spots for improvement but I'd like to touch base with you again. It is working for our ledger though. :)

### Transports
I think the one thing I want to make certain of now for Transports is that we are handling the opening/closing of them properly. Also I think we could definitely hook up the `listen` observable from Transport now to easily support more adding/removing ledger-path connections in our `LedgerKeyStore`. Something to discuss.

## Alternate Designs

It spent a lot of time figuring out the best way to abstract Keystores / Transports / Stores / AccountProviders and while it seemed like a good idea originally, ultimately we went with just creating a new `LedgerKeyStore` class alongside `LocalKeyStore` that has similar functionality but doesn't use the concept of *wallets*.

## Benefits

Ｌｅｄｇｅｒ　Ｓｕｐｐｏｒｔ

## Possible Drawbacks

To all of our fans out their who were looking for a wallet that **did not** support ledgers, this is going to be a major turn-off.

## Applicable Issues

Getting it working on CI has been a struggle.

TODO: #415 