### PR TITLE
move typescript to worker only

### DIFF
--- a/packages/neo-one-editor/src/monaco/AsyncLanguageService.ts
+++ b/packages/neo-one-editor/src/monaco/AsyncLanguageService.ts
@@ -127,6 +127,24 @@ const clearFiles = (diagnostics: ReadonlyArray<ts.Diagnostic>) => {
   });
 };
 
+const convertFormattingOptions = (options: monaco.languages.FormattingOptions): ts.FormatCodeOptions => ({
+  ConvertTabsToSpaces: options.insertSpaces,
+  TabSize: options.tabSize,
+  IndentSize: options.tabSize,
+  IndentStyle: ts.IndentStyle.Smart,
+  NewLineCharacter: '\n',
+  InsertSpaceAfterCommaDelimiter: true,
+  InsertSpaceAfterSemicolonInForStatements: true,
+  InsertSpaceBeforeAndAfterBinaryOperators: true,
+  InsertSpaceAfterKeywordsInControlFlowStatements: true,
+  InsertSpaceAfterFunctionKeywordForAnonymousFunctions: true,
+  InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
+  InsertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
+  InsertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
+  PlaceOpenBraceOnNewLineForControlBlocks: false,
+  PlaceOpenBraceOnNewLineForFunctions: false,
+});
+
 const preferences = { includeCompletionsForModuleExports: true, includeCompletionsWithInsertText: true };
 const defaultFormatOptions: ts.FormatCodeSettings = {
   convertTabsToSpaces: true,
@@ -284,21 +302,27 @@ export class AsyncLanguageService {
     fileName: string,
     start: number,
     end: number,
-    options: ts.FormatCodeOptions,
-  ): Promise<ReadonlyArray<ts.TextChange>> =>
-    this.languageService.then((languageService) =>
+    optionsIn: monaco.languages.FormattingOptions,
+  ): Promise<ReadonlyArray<ts.TextChange>> => {
+    const options = convertFormattingOptions(optionsIn);
+
+    return this.languageService.then((languageService) =>
       languageService.getFormattingEditsForRange(fileName, start, end, options),
     );
+  };
 
   public readonly getFormattingEditsAfterKeystroke = (
     fileName: string,
     postion: number,
     ch: string,
-    options: ts.FormatCodeOptions,
-  ): Promise<ReadonlyArray<ts.TextChange>> =>
-    this.languageService.then((languageService) =>
+    optionsIn: monaco.languages.FormattingOptions,
+  ): Promise<ReadonlyArray<ts.TextChange>> => {
+    const options = convertFormattingOptions(optionsIn);
+
+    return this.languageService.then((languageService) =>
       languageService.getFormattingEditsAfterKeystroke(fileName, postion, ch, options),
     );
+  };
 
   public readonly getEmitOutput = (fileName: string): Promise<ts.EmitOutput> =>
     this.languageService.then((languageService) => languageService.getEmitOutput(fileName));

--- a/packages/neo-one-editor/src/monaco/features/FormatAdapter.ts
+++ b/packages/neo-one-editor/src/monaco/features/FormatAdapter.ts
@@ -2,7 +2,7 @@
 import { map, switchMap } from 'rxjs/operators';
 import ts from 'typescript';
 import { Adapter } from './Adapter';
-import { convertFormattingOptions, convertTextChange, positionToOffset } from './utils';
+import { convertTextChange, positionToOffset } from './utils';
 
 export class FormatAdapter extends Adapter implements monaco.languages.DocumentRangeFormattingEditProvider {
   public provideDocumentRangeFormattingEdits(
@@ -25,7 +25,7 @@ export class FormatAdapter extends Adapter implements monaco.languages.DocumentR
                   resource.path,
                   positionToOffset(model, { lineNumber: range.startLineNumber, column: range.startColumn }),
                   positionToOffset(model, { lineNumber: range.endLineNumber, column: range.endColumn }),
-                  convertFormattingOptions(options),
+                  options,
                 ),
         ),
         map((edits) => (model.isDisposed() ? [] : edits.map((edit) => convertTextChange(model, edit)))),

--- a/packages/neo-one-editor/src/monaco/features/FormatOnTypeAdapter.ts
+++ b/packages/neo-one-editor/src/monaco/features/FormatOnTypeAdapter.ts
@@ -2,7 +2,7 @@
 import { map, switchMap } from 'rxjs/operators';
 import ts from 'typescript';
 import { Adapter } from './Adapter';
-import { convertFormattingOptions, convertTextChange, positionToOffset } from './utils';
+import { convertTextChange, positionToOffset } from './utils';
 
 export class FormatOnTypeAdapter extends Adapter implements monaco.languages.OnTypeFormattingEditProvider {
   public get autoFormatTriggerCharacters() {
@@ -26,12 +26,7 @@ export class FormatOnTypeAdapter extends Adapter implements monaco.languages.OnT
           async (worker): Promise<ReadonlyArray<ts.TextChange>> =>
             model.isDisposed()
               ? []
-              : worker.getFormattingEditsAfterKeystroke(
-                  resource.path,
-                  positionToOffset(model, position),
-                  ch,
-                  convertFormattingOptions(options),
-                ),
+              : worker.getFormattingEditsAfterKeystroke(resource.path, positionToOffset(model, position), ch, options),
         ),
         map((edits) => (model.isDisposed() ? [] : edits.map((edit) => convertTextChange(model, edit)))),
       ),

--- a/packages/neo-one-editor/src/monaco/features/utils.ts
+++ b/packages/neo-one-editor/src/monaco/features/utils.ts
@@ -30,24 +30,6 @@ export const getModel = (resource: monaco.Uri | string): monaco.editor.ITextMode
   return model == undefined || model.isDisposed() ? undefined : model;
 };
 
-export const convertFormattingOptions = (options: monaco.languages.FormattingOptions): ts.FormatCodeOptions => ({
-  ConvertTabsToSpaces: options.insertSpaces,
-  TabSize: options.tabSize,
-  IndentSize: options.tabSize,
-  IndentStyle: ts.IndentStyle.Smart,
-  NewLineCharacter: '\n',
-  InsertSpaceAfterCommaDelimiter: true,
-  InsertSpaceAfterSemicolonInForStatements: true,
-  InsertSpaceBeforeAndAfterBinaryOperators: true,
-  InsertSpaceAfterKeywordsInControlFlowStatements: true,
-  InsertSpaceAfterFunctionKeywordForAnonymousFunctions: true,
-  InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
-  InsertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
-  InsertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
-  PlaceOpenBraceOnNewLineForControlBlocks: false,
-  PlaceOpenBraceOnNewLineForFunctions: false,
-});
-
 export const convertTags = (tags: ReadonlyArray<ts.JSDocTagInfo> | undefined) =>
   tags
     ? '\n\n' +


### PR DESCRIPTION
### Description of the Change
Moved `convertFormattingOptions` method from utils to the ts worker.  Updated 2 locations where the method was used.