### PR TITLE
Concatenator work, almost operational.

### DIFF
--- a/packages/neo-one-ts-utils/src/file.ts
+++ b/packages/neo-one-ts-utils/src/file.ts
@@ -48,3 +48,9 @@ export function createSourceMapRange(node: ts.Node): ts.SourceMapRange {
     source: file === undefined ? undefined : ts.createSourceMapSource(getFilePath(file), getText(node)),
   };
 }
+
+export function getExportedSymbols(typeChecker: ts.TypeChecker, node: ts.SourceFile): ReadonlyArray<ts.Symbol> {
+  const symbol = node_.getSymbol(typeChecker, node);
+
+  return symbol === undefined ? [] : typeChecker.getExportsOfModule(symbol);
+}

--- a/packages/neo-one-ts-utils/src/importDeclaration.ts
+++ b/packages/neo-one-ts-utils/src/importDeclaration.ts
@@ -6,18 +6,19 @@ export function getImportClause(node: ts.ImportDeclaration): ts.ImportClause | u
   return utils.getValueOrUndefined(node.importClause);
 }
 
-export function getNamespaceImport(node: ts.ImportDeclaration): ts.Identifier | undefined {
+export function getNamespaceImport(node: ts.ImportDeclaration): ts.NamespaceImport | undefined {
   const clause = getImportClause(node);
   if (clause === undefined) {
     return undefined;
   }
 
-  const namespaceImport = node_.getFirstDescendantByKind(node, ts.SyntaxKind.NamespaceImport);
-  if (namespaceImport === undefined) {
-    return undefined;
-  }
+  return node_.getFirstDescendantByKind(node, ts.SyntaxKind.NamespaceImport);
+}
 
-  return node_.getFirstDescendantByKind(node, ts.SyntaxKind.Identifier);
+export function getNamespaceImportIdentifier(node: ts.ImportDeclaration): ts.Identifier | undefined {
+  return getNamespaceImport(node) === undefined
+    ? undefined
+    : node_.getFirstDescendantByKind(node, ts.SyntaxKind.Identifier);
 }
 
 export function getDefaultImport(node: ts.ImportDeclaration): ts.Identifier | undefined {

--- a/packages/neo-one-ts-utils/src/node.ts
+++ b/packages/neo-one-ts-utils/src/node.ts
@@ -1,5 +1,6 @@
 // tslint:disable no-any
 import ts from 'typescript';
+import * as symbol_ from './symbol';
 import * as utils from './utils';
 
 type NamedNode = ts.Node & { readonly name: ts.Identifier };
@@ -284,3 +285,17 @@ export function isPartOfTypeNode(node: ts.Node): boolean {
   // tslint:disable-next-line no-any
   return (ts as any).isPartOfTypeNode(node);
 }
+
+export const getSymbolOrAlias = (typeChecker: ts.TypeChecker) => (node: ts.Node) => {
+  const symbol = getSymbol(typeChecker, node);
+  if (symbol === undefined) {
+    return undefined;
+  }
+
+  const aliased = symbol_.getAliasedSymbol(typeChecker, symbol);
+  if (aliased !== undefined) {
+    return aliased;
+  }
+
+  return symbol;
+};

--- a/packages/neo-one-ts-utils/src/variable.ts
+++ b/packages/neo-one-ts-utils/src/variable.ts
@@ -11,3 +11,7 @@ export function getDeclarations(node: ts.VariableDeclarationList): ReadonlyArray
 export function getDeclarationList(node: ts.VariableStatement): ts.VariableDeclarationList {
   return node.declarationList;
 }
+
+export function getDeclarationsFromStatement(node: ts.VariableStatement): ReadonlyArray<ts.VariableDeclaration> {
+  return getDeclarations(getDeclarationList(node));
+}

--- a/packages/neo-one-typescript-concatenator/package.json
+++ b/packages/neo-one-typescript-concatenator/package.json
@@ -12,5 +12,8 @@
     "toposort": "^2.0.2",
     "typescript": "3.2.0-dev.20181020"
   },
+  "devDependencies": {
+    "app-root-dir": "^1.0.2"
+  },
   "sideEffects": false
 }

--- a/packages/neo-one-typescript-concatenator/src/__data__/directories/test/childOne.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/directories/test/childOne.ts
@@ -1,0 +1,20 @@
+const bar = 'bar';
+
+function foo() {
+  return bar;
+}
+
+export function barBar() {
+  return bar.concat(bar);
+}
+
+export class ChildClass {
+  public readonly prop: string;
+  public constructor() {
+    this.prop = 'child';
+  }
+
+  public childFunc() {
+    return foo();
+  }
+}

--- a/packages/neo-one-typescript-concatenator/src/__data__/directories/test/childTwo.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/directories/test/childTwo.ts
@@ -1,0 +1,23 @@
+type childTypeInternal = string | number;
+
+interface ChildInterfaceInternal {
+  readonly child: childTypeInternal;
+}
+
+export type childType = childTypeInternal | ReadonlyArray<childTypeInternal>;
+
+export interface ChildInterface {
+  readonly child: ChildInterfaceInternal;
+}
+
+enum childEnumInternal {
+  one,
+  two,
+}
+
+export const getEnumValue = (value: number) => childEnumInternal[value];
+
+export enum childEnum {
+  two,
+  three,
+}

--- a/packages/neo-one-typescript-concatenator/src/__data__/directories/test/index.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/directories/test/index.ts
@@ -1,0 +1,2 @@
+export * from './parentOne';
+export * from './parentTwo';

--- a/packages/neo-one-typescript-concatenator/src/__data__/directories/test/parentOne.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/directories/test/parentOne.ts
@@ -1,0 +1,22 @@
+import { barBar, ChildClass } from './childOne';
+import { childType } from './childTwo';
+
+type parentType = childType | Buffer;
+
+const bar = new ChildClass();
+
+// tslint:disable-next-line:export-name
+export class ParentClass extends ChildClass {
+  public readonly thing: parentType;
+  public readonly child: ChildClass;
+
+  public constructor() {
+    super();
+    this.thing = '2';
+    this.child = bar;
+  }
+
+  public foo() {
+    return barBar();
+  }
+}

--- a/packages/neo-one-typescript-concatenator/src/__data__/directories/test/parentTwo.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/directories/test/parentTwo.ts
@@ -1,0 +1,17 @@
+import { ChildClass } from './childOne';
+import { childEnum, getEnumValue } from './childTwo';
+
+export const parentEnum = childEnum;
+
+export type parentType = Buffer | string;
+
+export class ParentTwoClass extends ChildClass {
+  public static readonly enumValue = getEnumValue;
+  public constructor() {
+    super();
+  }
+
+  public parentFunc() {
+    return this.childFunc();
+  }
+}

--- a/packages/neo-one-typescript-concatenator/src/__data__/expected/test.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/expected/test.ts
@@ -1,0 +1,59 @@
+type childTypeInternal = string | number;
+interface ChildInterfaceInternal {
+    readonly child: childTypeInternal;
+}
+type childType = childTypeInternal | ReadonlyArray<childTypeInternal>;
+interface ChildInterface {
+    readonly child: ChildInterfaceInternal;
+}
+enum childEnumInternal {
+    one,
+    two
+}
+const getEnumValue = (value: number) => childEnumInternal[value];
+enum childEnum {
+    two,
+    three
+}
+const s9 = 'bar';
+function foo() {
+    return s9;
+}
+function barBar() {
+    return s9.concat(s9);
+}
+class ChildClass {
+    public readonly prop: string;
+    public constructor() {
+        this.prop = 'child';
+    }
+    public childFunc() {
+        return foo();
+    }
+}
+export const parentEnum = childEnum;
+export type parentType = Buffer | string;
+export class ParentTwoClass extends ChildClass {
+    public static readonly enumValue = getEnumValue;
+    public constructor() {
+        super();
+    }
+    public parentFunc() {
+        return this.childFunc();
+    }
+}
+type s26 = childType | Buffer;
+const sc1 = new ChildClass();
+// tslint:disable-next-line:export-name
+export class ParentClass extends ChildClass {
+    public readonly thing: s26;
+    public readonly child: ChildClass;
+    public constructor() {
+        super();
+        this.thing = '2';
+        this.child = sc1;
+    }
+    public foo() {
+        return barBar();
+    }
+}

--- a/packages/neo-one-typescript-concatenator/src/__data__/helpers/index.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './testDirectoryPath';

--- a/packages/neo-one-typescript-concatenator/src/__data__/helpers/testDirectoryPath.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/helpers/testDirectoryPath.ts
@@ -1,0 +1,30 @@
+import { normalizePath } from '@neo-one/utils';
+import * as appRootDir from 'app-root-dir';
+import * as path from 'path';
+
+export const testDirectoryPath = (directory: string) =>
+  normalizePath(
+    path.resolve(
+      appRootDir.get(),
+      'packages',
+      'neo-one-typescript-concatenator',
+      'src',
+      '__data__',
+      'directories',
+      directory,
+      'index.ts',
+    ),
+  );
+
+export const outDirectoryPath = (directory: string) =>
+  normalizePath(
+    path.resolve(
+      appRootDir.get(),
+      'packages',
+      'neo-one-typescript-concatenator',
+      'src',
+      '__data__',
+      'expected',
+      `${directory}.ts`,
+    ),
+  );

--- a/packages/neo-one-typescript-concatenator/src/__tests__/concatenate.test.ts
+++ b/packages/neo-one-typescript-concatenator/src/__tests__/concatenate.test.ts
@@ -1,0 +1,18 @@
+import { testDirectoryPath } from '../__data__/helpers';
+import { concatenate } from '../concatenate';
+
+const tests: ReadonlyArray<string> = ['test', 'reImport'];
+
+const runConcatenateTest = (entry: string) => {
+  test(`${entry} concatenation test`, () => {
+    const entryPath = testDirectoryPath(entry);
+
+    const result = concatenate(entryPath);
+    if (result === undefined) {
+      throw Error('unexpected error, result of concatenation undefined');
+    }
+    expect(result).toMatchSnapshot();
+  });
+};
+
+tests.forEach(runConcatenateTest);

--- a/packages/neo-one-typescript-concatenator/src/concatenate.ts
+++ b/packages/neo-one-typescript-concatenator/src/concatenate.ts
@@ -1,0 +1,96 @@
+import { tsUtils } from '@neo-one/ts-utils';
+import * as fs from 'fs-extra';
+import path from 'path';
+import ts from 'typescript';
+import { Concatenator } from './Concatenator';
+
+export type SymbolAndSources = { readonly [Symbol in string]: string };
+export type SourceFileSymbolAndSources = { readonly [SourceFile in string]: SymbolAndSources };
+
+export function concatenate(entry: string) {
+  const servicesHost: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [entry],
+    getScriptVersion: () => '0',
+    getScriptSnapshot: (fileName) => {
+      // tslint:disable-next-line no-non-null-assertion
+      if (!servicesHost.fileExists!(fileName)) {
+        return undefined;
+      }
+
+      // tslint:disable-next-line no-non-null-assertion
+      return ts.ScriptSnapshot.fromString(servicesHost.readFile!(fileName)!);
+    },
+    getCurrentDirectory: () => process.cwd(),
+    getCompilationSettings: () => {
+      const configPath = ts.findConfigFile(entry, ts.sys.fileExists);
+      if (configPath === undefined) {
+        return ts.getDefaultCompilerOptions();
+      }
+      const text = fs.readFileSync(configPath, 'utf8');
+      const parseResult = ts.parseConfigFileTextToJson(configPath, text);
+
+      return ts.parseJsonConfigFileContent(
+        parseResult.config,
+        {
+          useCaseSensitiveFileNames: true,
+          readDirectory: ts.sys.readDirectory,
+          fileExists: ts.sys.fileExists,
+          readFile: ts.sys.readFile,
+        },
+        path.dirname(configPath),
+        undefined,
+        undefined,
+      ).options;
+    },
+    getDefaultLibFileName: (opts) => ts.getDefaultLibFilePath(opts),
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+    getNewLine: () => ts.sys.newLine,
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+  };
+
+  const languageService = ts.createLanguageService(servicesHost);
+  const program = languageService.getProgram();
+  if (program === undefined) {
+    throw new Error('Failed to get program from language service.');
+  }
+
+  const sourceFile = tsUtils.file.getSourceFileOrThrow(program, entry);
+  const typeChecker = program.getTypeChecker();
+
+  const indexExportedSymbols = tsUtils.file.getExportedSymbols(typeChecker, sourceFile).map((symbol) => {
+    const aliased = tsUtils.symbol.getAliasedSymbol(typeChecker, symbol);
+
+    return aliased === undefined ? symbol : aliased;
+  });
+  const globalExportSymbols = new Set(indexExportedSymbols);
+
+  const isGlobalFile = (node: ts.SourceFile) => program.isSourceFileFromExternalLibrary(node);
+  const isIgnoreFile = () => false;
+  const isGlobalIdentifier = () => false;
+  const isGlobalSymbol = (symbol: ts.Symbol) => globalExportSymbols.has(symbol);
+  const skipReferenceCheck = true;
+
+  const concatenator = new Concatenator({
+    context: {
+      typeChecker,
+      program,
+      languageService,
+      getSymbol: tsUtils.node.getSymbolOrAlias(typeChecker),
+      isIgnoreFile,
+      isGlobalIdentifier,
+      isGlobalFile,
+      isGlobalSymbol,
+      skipReferenceCheck,
+    },
+    sourceFile,
+  });
+
+  const sourceFiles = concatenator.sourceFiles;
+  if (sourceFiles.length === 0 || sourceFiles.length === 1) {
+    return undefined;
+  }
+
+  return tsUtils.printBundle(program, sourceFiles, concatenator.substituteNode);
+}


### PR DESCRIPTION
### Description of the Change

Leverages the neo-one-typescript-concatenator to bundle typescript files into a single entry. 

### Test Plan

`neo-one-typescript-concatenator/__data__/` has a test directory already which shows off current capabilities.

Unsupported situations:
`import * as ___` still has issues after 1 level of concatenating. `replaceImport` is my work so far to deal with this case.

Circular imports are still an issue.

### Benefits

This would be huge.

### Possible Drawbacks

Everything *SHOULD* be unaltered for SmartContract concatenating.

### Applicable Issues
#564 
