### PR TITLE
Markdown links open new page

### DIFF
--- a/packages/neo-one-website/src/components/course/lesson/LessonView.tsx
+++ b/packages/neo-one-website/src/components/course/lesson/LessonView.tsx
@@ -62,7 +62,7 @@ export const LessonView = ({ selected }: Props) => (
     </Helmet>
     <BoxWrapper>
       <InnerWrapper>
-        <Markdown source={selectLesson(selected).documentation} />
+        <Markdown source={selectLesson(selected).documentation} openAllLinksInNewTab />
         <ButtonWrapper>
           <Text>
             Lesson {selected.lesson + 1}: {selectLesson(selected).title}

--- a/packages/neo-one-website/src/elements/Markdown.tsx
+++ b/packages/neo-one-website/src/elements/Markdown.tsx
@@ -187,6 +187,7 @@ const Wrapper = styled.div<{ readonly linkColor: 'primary' | 'gray' | 'accent' }
 interface Props {
   readonly source: string;
   readonly linkColor?: 'primary' | 'gray' | 'accent';
+  readonly openAllLinksInNewTab?: boolean;
 }
 export class Markdown extends React.Component<Props> {
   private readonly ref = React.createRef<HTMLElement>();
@@ -194,6 +195,19 @@ export class Markdown extends React.Component<Props> {
   public componentDidMount(): void {
     if (this.ref.current) {
       Prism.highlightAllUnder(this.ref.current);
+
+      const anchors = this.ref.current.getElementsByTagName('a');
+      // tslint:disable-next-line no-loop-statement prefer-for-of
+      for (let i = 0; i < anchors.length; i += 1) {
+        const a = anchors[i];
+        if (this.props.openAllLinksInNewTab) {
+          // tslint:disable-next-line no-object-mutation
+          a.target = '_blank';
+        } else if (a.host !== window.location.host) {
+          // tslint:disable-next-line no-object-mutation
+          a.target = '_blank';
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Change
Links on markdown pages now open in new page.  The exception are same-page links which will still just scroll you to the section (e.g. #section3).
