### PR TITLE
fixes a .only that shouldn't be and formats a filename in base.js

### DIFF
--- a/jest/base.js
+++ b/jest/base.js
@@ -6,7 +6,7 @@ if (process.platform === 'win32') {
   testPathIgnorePatterns = testPathIgnorePatterns.concat([
     '/packages/neo-one-editor/src/__tests__/.*',
     '/packages/neo-one-editor-server/src/__tests__/.*',
-    'packages/neo-one-smart-contract-compiler/src/__tests__/getSemanticDiagnostics.test.ts',
+    '/packages/neo-one-smart-contract-compiler/src/__tests__/getSemanticDiagnostics.test.ts',
   ]);
 }
 

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/InvokeSmartContractHelper6.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/InvokeSmartContractHelper6.test.ts
@@ -13,7 +13,7 @@ public readonly properties = {
 `;
 
 describe('InvokeSmartContractHelper', () => {
-  test.only('class that used processedTransactions, send, receive and claim', async () => {
+  test('class that used processedTransactions, send, receive and claim', async () => {
     const node = await helpers.startNode();
     const accountID = node.masterWallet.account.id;
     const contract = await node.addContract(`


### PR DESCRIPTION
### Description of the Change

somehow I snuck in a `test.only` to InvokeSmartContractHelper6. Also I brought the diagnostic fileName in line with the other ones, don't know why it wasn't originally.

Sorry for missing these initially.

### Benefits

My wallaby was straight broken with that `test.only`. It was only running that one test. weird :thinking:

