### PR TITLE
feat(node): add @neo-one/node-bin

### DIFF
--- a/packages/neo-one-node-bin/package.json
+++ b/packages/neo-one-node-bin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@neo-one/node-bin",
+  "version": "1.0.1",
+  "description": "NEO•ONE NEO executable full node.",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@neo-one/monitor": "^1.0.1",
+    "@neo-one/node": "^1.0.1",
+    "@neo-one/node-neo-settings": "^1.0.1",
+    "@neo-one/types": "^1.0.1",
+    "@neo-one/utils":"^1.0.1",
+    "env-paths":"^2.0.0",
+    "winston":"^3.1.0",
+    "rxjs": "^6.3.3",
+    "tslib": "^1.9.3"
+  },
+  "sideEffects": false
+}

--- a/packages/neo-one-node-bin/src/bin/neo-one-node.ts
+++ b/packages/neo-one-node-bin/src/bin/neo-one-node.ts
@@ -1,0 +1,6 @@
+// tslint:disable-next-line:no-implicit-dependencies
+import { startNode } from '@neo-one/node-bin';
+
+startNode().catch(() => {
+  // do nothing
+});

--- a/packages/neo-one-node-bin/src/createMonitor.ts
+++ b/packages/neo-one-node-bin/src/createMonitor.ts
@@ -1,0 +1,65 @@
+import { DefaultMonitor, Monitor } from '@neo-one/monitor';
+import { createLogger, format, transports } from 'winston';
+
+export const createMonitor = (): Monitor => {
+  const formats = format.combine(format.timestamp(), format.json());
+  const logger = createLogger({
+    transports: [
+      new transports.Console({
+        level: 'verbose',
+        format: formats,
+      }),
+    ],
+  });
+
+  logger.on('error', (error) => {
+    // tslint:disable-next-line:no-console
+    console.error(error);
+  });
+
+  return DefaultMonitor.create({
+    service: 'node',
+    logger: {
+      log: (logMessage) => {
+        const { error, ...rest } = logMessage;
+
+        let message: typeof rest & { stack?: string | undefined } = { ...rest };
+        if (error !== undefined) {
+          message = {
+            ...message,
+            stack: error.stack,
+          };
+        }
+
+        if (logger.transports.length > 0) {
+          // tslint:disable-next-line no-any
+          logger.log(message as any);
+        }
+      },
+      close: (callback) => {
+        let exited = false;
+        const doExit = () => {
+          if (!exited) {
+            exited = true;
+            callback();
+          }
+        };
+        const numFlushes = logger.transports.length;
+        let numFlushed = 0;
+        logger.transports.forEach((transport) => {
+          transport.once('finish', () => {
+            numFlushed += 1;
+            if (numFlushes === numFlushed) {
+              setTimeout(doExit, 30);
+            }
+          });
+
+          transport.end();
+        });
+
+        // Force an exit
+        setTimeout(doExit, 250);
+      },
+    },
+  });
+};

--- a/packages/neo-one-node-bin/src/index.ts
+++ b/packages/neo-one-node-bin/src/index.ts
@@ -1,0 +1,1 @@
+export * from './startNode';

--- a/packages/neo-one-node-bin/src/startNode.ts
+++ b/packages/neo-one-node-bin/src/startNode.ts
@@ -1,0 +1,107 @@
+// tslint:disable no-object-mutation no-any
+import { FullNode, FullNodeEnvironment } from '@neo-one/node';
+import { createTest } from '@neo-one/node-neo-settings';
+import { finalize } from '@neo-one/utils';
+import { of as _of } from 'rxjs';
+import { createMonitor } from './createMonitor';
+
+const createRPCEnvironment = () => ({
+  http: {
+    port: 8080,
+    host: 'localhost',
+  },
+});
+
+const createDataPath = () => './neo-one-node';
+
+const createEnvironment = (options: Partial<FullNodeEnvironment> = {}): FullNodeEnvironment => ({
+  dataPath: createDataPath(),
+  rpc: createRPCEnvironment(),
+  ...options,
+});
+
+export const startNode = async (): Promise<void> => {
+  const monitor = createMonitor();
+  let mutableShutdownFuncs: ReadonlyArray<() => Promise<void>> = [];
+
+  const initiateShutdown = async () => {
+    await Promise.all(mutableShutdownFuncs.map(async (func) => func()));
+    await finalize.wait();
+  };
+
+  let shutdownInitiated = false;
+  const shutdown = ({ exitCode: exitCodeIn, error }: { exitCode: number; error?: Error | undefined }) => {
+    const exitCode =
+      error !== undefined && (error as any).exitCode != undefined && typeof (error as any).exitCode === 'number'
+        ? (error as any).exitCode
+        : exitCodeIn;
+    if (!shutdownInitiated) {
+      shutdownInitiated = true;
+      monitor
+        .captureLog(initiateShutdown, {
+          name: 'node_shutdown',
+          message: 'Shutdown cleanly.',
+          error: 'Failed to shutdown cleanly',
+        })
+        .then(() => {
+          monitor.close(() => {
+            process.exit(exitCode);
+          });
+        })
+        .catch(() => {
+          monitor.close(() => {
+            process.exit(exitCode > 0 ? exitCode : 1);
+          });
+        });
+    }
+  };
+
+  process.on('unhandledRejection', (error) => {
+    monitor.logError({
+      name: 'unhandled_rejection',
+      message: 'Unhandled rejection. Shutting down.',
+      error,
+    });
+
+    shutdown({ exitCode: 1, error });
+  });
+
+  process.on('uncaughtException', (error) => {
+    monitor.logError({
+      name: 'uncaught_exception',
+      message: 'Uncaught exception. Shutting down.',
+      error,
+    });
+
+    shutdown({ exitCode: 1, error });
+  });
+
+  process.on('SIGINT', () => {
+    monitor.log({
+      name: 'node_sigint',
+      message: 'Exiting...',
+    });
+
+    shutdown({ exitCode: 0 });
+  });
+
+  process.on('SIGTERM', () => {
+    monitor.log({
+      name: 'node_sigterm',
+      message: 'Exiting...',
+    });
+
+    shutdown({ exitCode: 0 });
+  });
+
+  const fullNode = new FullNode({
+    monitor,
+    environment: createEnvironment(),
+    settings: createTest(),
+    options$: _of({}),
+  });
+
+  mutableShutdownFuncs = mutableShutdownFuncs.concat(fullNode.stop);
+
+  await fullNode.start();
+};


### PR DESCRIPTION
### Description of the Change

Adds `@neo-one/node-bin`, which acts as the entry point for `@neo-one/node`. Creates some helper setup functions to prepared for more detailed configuration options.

### Test Plan

```bash
yarn build:e2e
node ./dist/neo-one/packages/neo-one-node-bin/bin/neo-one-node
```

### Alternate Designs

Rip this thing apart if it doesn't look how you think it should. I want it to be the best it can be.

### Benefits

Woah node entrypoint

### Possible Drawbacks

I had the create a folder for it to put its data, right now that is `neo-one-node/data`, there is almost certainly a better place/ way for me to handle this folder, should that come in the next commit? I temp added the data folder to `.gitignore`.

### Applicable Issues

#708 
