### PR TITLE
feat(neo-one-server): version detection & graceful upgrades of neo-one server

### DIFF
--- a/packages/neo-one-server-client/package.json
+++ b/packages/neo-one-server-client/package.json
@@ -14,12 +14,14 @@
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^5.0.4",
     "@types/is-running": "^2.1.0",
+    "@types/semver":"^5.5.0",
     "env-paths": "^2.0.0",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.1",
     "grpc": "^1.16.1",
     "is-running": "^2.1.0",
     "rxjs": "^6.3.3",
+    "semver": "^5.6.0",
     "tslib": "^1.9.3"
   },
   "sideEffects": false

--- a/packages/neo-one-server-plugin-project/package.json
+++ b/packages/neo-one-server-plugin-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo-one/server-plugin-project",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "NEO•ONE server plugin for project functionality.",
   "main": "./src/index.ts",
   "dependencies": {

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/client.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/client.ts
@@ -1,4 +1,4 @@
-/* @hash de68655f3da88f17f466a738b34a4915 */
+/* @hash 6bcbc4842b7d2c13f85d2a573d5240f1 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -39,7 +39,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 > => {
   const providers: Array<NEOONEOneDataProvider | NEOONEDataProviderOptions> = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 39111 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40101 }));
   }
   const provider = new NEOONEProvider(providers);
 
@@ -119,11 +119,11 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (): { [network: string]: DeveloperClient } => ({
-  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 39111 })),
+  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40101 })),
 });
 
 export const createLocalClients = (): { [network: string]: LocalClient } => {
-  const client = new OneClient(39111);
+  const client = new OneClient(40101);
   return {
     local: {
       getNEOTrackerURL: async () => {

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/projectID.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/projectID.ts
@@ -1,8 +1,8 @@
-/* @hash 1dcd23904b3cb3ac7449371a14fc32b4 */
+/* @hash 2590a4095deb2832d115deed85dc6a73 */
 // tslint:disable
 /* eslint-disable */
 /**
- * @projectID f4901b44e5464373b93075b5b73bc0db
+ * @projectID fqC2IaDjOFneM1zGDEYqZ
  */
 
-export const projectID = 'f4901b44e5464373b93075b5b73bc0db';
+export const projectID = 'fqC2IaDjOFneM1zGDEYqZ';

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/sourceMaps.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/sourceMaps.ts
@@ -1,4 +1,4 @@
-/* @hash 3a2cdb4770eb0cd1e8884c21545c8d7d */
+/* @hash 4813b54bd756626cc11d532e8ba9e559 */
 // tslint:disable
 /* eslint-disable */
 /* @source-map-hash ce0712dd5ed0e0059fefadc69473ac47 */
@@ -8,7 +8,7 @@ import { projectID } from './projectID';
 let sourceMapsIn: Promise<SourceMaps> = Promise.resolve({});
 if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
   sourceMapsIn = Promise.resolve().then(async () => {
-    const client = new OneClient(39111);
+    const client = new OneClient(40101);
     const result = await client.request({
       plugin: '@neo-one/server-plugin-project',
       options: { type: 'sourceMaps', projectID },

--- a/packages/neo-one-server-plugin-project/src/build/generateCode.ts
+++ b/packages/neo-one-server-plugin-project/src/build/generateCode.ts
@@ -32,7 +32,7 @@ export const generateCode = async (
   });
 
   await fs.ensureDir(base);
-  if (project.codegen.javascript) {
+  if (project.codegen.language === 'javascript') {
     await Promise.all([writeFile(abiPath, abi.js), writeFile(createContractPath, contract.js)]);
   } else {
     await Promise.all([

--- a/packages/neo-one-server-plugin-project/src/build/generateCommonCode.ts
+++ b/packages/neo-one-server-plugin-project/src/build/generateCommonCode.ts
@@ -54,24 +54,44 @@ export const generateCommonCode = async (
   });
 
   await fs.ensureDir(project.paths.generated);
-  if (project.codegen.javascript) {
-    await Promise.all([
-      writeFile(sourceMapsPath, sourceMaps.js),
-      writeFile(testPath, test.js),
-      writeFile(reactPath, react.js),
-      writeFile(clientPath, client.js),
-      writeFile(generatedPath, generated.js),
-      writeFile(projectIDPath, projectIDFile.js),
-    ]);
-  } else {
-    await Promise.all([
-      writeFile(getTSPath(sourceMapsPath), sourceMaps.ts),
-      writeFile(getTSPath(testPath), test.ts),
-      writeFile(getTSPath(reactPath), react.ts),
-      writeFile(getTSPath(clientPath), client.ts),
-      writeFile(getTSPath(generatedPath), generated.ts),
-      writeFile(getTSPath(projectIDPath), projectIDFile.ts),
-      writeFile(getTSPath(commonTypesPath), commonTypes.ts),
-    ]);
-  }
+  await Promise.all(
+    [
+      {
+        path: sourceMapsPath,
+        data: sourceMaps,
+      },
+      {
+        path: testPath,
+        data: test,
+      },
+      {
+        path: reactPath,
+        data: project.codegen.framework === 'react' ? react : undefined,
+      },
+      {
+        path: clientPath,
+        data: client,
+      },
+      {
+        path: generatedPath,
+        data: generated,
+      },
+      {
+        path: projectIDPath,
+        data: projectIDFile,
+      },
+      {
+        path: commonTypesPath,
+        data: project.codegen.language === 'typescript' ? commonTypes : undefined,
+      },
+    ].map(async ({ path, data }) => {
+      if (data !== undefined) {
+        if (project.codegen.language === 'javascript') {
+          await writeFile(path, data.js);
+        } else {
+          await writeFile(getTSPath(path), data.ts);
+        }
+      }
+    }),
+  );
 };

--- a/packages/neo-one-server-plugin-project/src/types.ts
+++ b/packages/neo-one-server-plugin-project/src/types.ts
@@ -1,3 +1,4 @@
+import convict from 'convict';
 import * as path from 'path';
 
 export interface BuildTaskListOptions {
@@ -30,17 +31,20 @@ export interface NEOTrackerRequestOptions {
 
 export type RequestOptions = NetworkRequestOptions | SourceMapsRequestOptions | NEOTrackerRequestOptions;
 
+export type CodegenLanguage = 'typescript' | 'javascript';
+export type CodegenFramework = 'none' | 'react';
 export interface ProjectConfig {
   readonly paths: {
     readonly contracts: string;
     readonly generated: string;
   };
   readonly codegen: {
-    readonly javascript: boolean;
+    readonly language: CodegenLanguage;
+    readonly framework: CodegenFramework;
   };
 }
 
-export const projectConfigSchema = {
+export const projectConfigSchema: convict.Schema<ProjectConfig> = {
   paths: {
     contracts: {
       format: String,
@@ -52,9 +56,13 @@ export const projectConfigSchema = {
     },
   },
   codegen: {
-    javascript: {
-      format: Boolean,
-      default: false,
+    language: {
+      format: ['typescript', 'javascript'],
+      default: 'typescript',
+    },
+    framework: {
+      format: ['none', 'react'],
+      default: 'none',
     },
   },
 };

--- a/packages/neo-one-server-plugin-project/src/utils/loadProjectID.ts
+++ b/packages/neo-one-server-plugin-project/src/utils/loadProjectID.ts
@@ -11,7 +11,7 @@ const projectIDRegex = /@projectID ([0-9a-z-]+)/;
 const loadProjectIDFromFile = async (projectConfig: ProjectConfig): Promise<string | undefined> => {
   const { projectIDPath: projectIDPathIn } = getCommonPaths(projectConfig);
 
-  const projectIDPath = projectConfig.codegen.javascript ? projectIDPathIn : getTSPath(projectIDPathIn);
+  const projectIDPath = projectConfig.codegen.language === 'javascript' ? projectIDPathIn : getTSPath(projectIDPathIn);
 
   const exists = await fs.pathExists(projectIDPath);
   if (exists) {

--- a/packages/neo-one-server-plugin/src/version.ts
+++ b/packages/neo-one-server-plugin/src/version.ts
@@ -1,2 +1,5 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
 // tslint:disable-next-line export-name
-export const VERSION = '1.0.0-preview.1';
+export const VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
@@ -3,7 +3,7 @@
     "@neo-one/react": "1.0.0-preview.3",
     "@neo-one/react-core": "1.0.0-preview.5",
     "@types/react": "16.7.3",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "16.0.10",
     "@types/styled-components": "4.1.0",
     "bignumber.js": "8.0.1",
     "react": "16.7.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6367,6 +6367,15 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
+cosmiconfig@5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  integrity sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
 cosmiconfig@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
@@ -12619,15 +12628,15 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-lint-staged@8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.0.5.tgz#8eeca1a213eaded09c4e217da455b6f432046034"
-  integrity sha512-QI2D6lw2teArlr2fmrrCIqHxef7mK2lKjz9e+aZSzFlk5rsy10rg97p3wA9H/vIFR3Fvn34fAgUktD/k896S2A==
+lint-staged@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.1.0.tgz#dbc3ae2565366d8f20efb9f9799d076da64863f2"
+  integrity sha512-yfSkyJy7EuVsaoxtUSEhrD81spdJOe/gMTGea3XaV7HyoRhTb9Gdlp6/JppRZERvKSEYXP9bjcmq6CA5oL2lYQ==
   dependencies:
     "@iamstarkov/listr-update-renderer" "0.4.1"
     chalk "^2.3.1"
     commander "^2.14.1"
-    cosmiconfig "^5.0.2"
+    cosmiconfig "5.0.6"
     debug "^3.1.0"
     dedent "^0.7.0"
     del "^3.0.0"
@@ -17794,10 +17803,10 @@ rx-lite@^3.1.2:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
   integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
 
-rxjs-tslint-rules@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-4.12.0.tgz#92cf4c26d53163afdc32d4d8a23c7c13faa9e988"
-  integrity sha512-JaCcoy7m4r/uktKjAdh70e+ijcTqozwKEU82N66tJ1dhSfzBgUX7bxopv/yQiHZ2BOeqRN61VfRMagqXTuzgdg==
+rxjs-tslint-rules@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-4.13.0.tgz#9c8dce5bc22c5fa8b9a60a7ac7f8cf9a875461bb"
+  integrity sha512-DMq33D4KdPZQemaApMtbqQTWMr8w0iGNzirnZQVY4LBdsyHxhPZz/sRvqs6e5Va+rGI3sMrhRJHWHIAakRTYAg==
   dependencies:
     "@phenomnomnominal/tsquery" "^3.0.0"
     decamelize "^2.0.0"


### PR DESCRIPTION

### Requirements

Make client requests aware of server version, when there's a conflict, take appropriate action, see below.

### Description of the Change

 These outcomes are expected both when the server is running or not running:
 * client/server have same version, newer version online
 * client is upgraded, server is not - restart server
 * server is upgraded, client is not - throw version conflict error

### Test Plan
manual testing of the above listed scenarios.

### Benefits
Server will restart with correct version, otherwise user will be made aware of version conflicts. 

### Applicable Issues
RE: #716
