### PR TITLE
docs(commands): update docs to show NPM commands where there are Yarn commands

### DIFF
--- a/packages/neo-one-website/docs/0-installation/1-environment-setup.md
+++ b/packages/neo-one-website/docs/0-installation/1-environment-setup.md
@@ -63,7 +63,7 @@ In addition to the above, if you're developing TypeScript smart contracts using 
 Configure your IDE to use your local TypeScript installation and the `@neo-one/smart-contract-typescript-plugin` in order to take advantage of inline compiler diagnostics. These instructions are for [VSCode](https://code.visualstudio.com/), but they should be similar for any editor that supports TypeScript IntelliSense.
 
   1. Ensure `@neo-one/cli` and `@neo-one/smart-contract-typescript-plugin` are installed.
-  2. Run `yarn neo-one init`. This will create a `tsconfig.json` file in the configured smart contract directory (by default, `one/contracts`).
+  2. Run `yarn neo-one init` or `npm run neo-one init`. This will create a `tsconfig.json` file in the configured smart contract directory (by default, `one/contracts`).
   3. Open a TypeScript file, then click the TypeScript version number in the lower right hand side of your editor and choose "Use Workspace Version"
 
 That's it! Enjoy inline smart contract compiler diagnostics.

--- a/packages/neo-one-website/docs/0-installation/2-playground.md
+++ b/packages/neo-one-website/docs/0-installation/2-playground.md
@@ -15,7 +15,7 @@ This guide will walk you through getting started with the [NEO•ONE Playground]
 ## Requirements
 
   - [Node](https://nodejs.org) >= 8.9.0 (We recommend the latest version)
-  - [yarn](https://yarnpkg.com/)
+  - a package manager: [yarn](https://yarnpkg.com/)   **OR**   npm (distributed with Node)
 
 ---
 
@@ -24,6 +24,7 @@ This guide will walk you through getting started with the [NEO•ONE Playground]
 ```bash
 git clone https://github.com/neo-one-suite/neo-one-playground.git
 cd neo-one-playground
+# npm install
 yarn install
 ```
 
@@ -32,6 +33,7 @@ yarn install
 ## Compile
 
 ```bash
+# npm run neo-one build
 yarn neo-one build
 ```
 
@@ -42,6 +44,7 @@ This will start up a local network, compile the smart contracts located in the `
 ## Start the Playground
 
 ```bash
+# npm run start
 yarn start
 ```
 
@@ -52,6 +55,7 @@ This will open a browser window with the playground. Modify the files in the `sr
 ## Run the tests
 
 ```bash
+# npm test
 yarn test
 ```
 

--- a/packages/neo-one-website/tutorial/tutorial.md
+++ b/packages/neo-one-website/tutorial/tutorial.md
@@ -55,13 +55,16 @@ Here's how to setup your local development environment:
   - Windows: We recommend using [Chocolatey](https://chocolatey.org/).
 2. Follow the [installation instructions for Create React App](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) to make a new project.
   - Be sure to invoke Create React App with the `--typescript` flag in order to enable TypeScript support: `npx create-react-app token --typescript`
-3. Install NEO•ONE using either [yarn](https://yarnpkg.com/) (`yarn add <package name>`) or [npm](https://www.npmjs.com/) `npm install <package name>`.
+3. Install NEO•ONE using either [yarn](https://yarnpkg.com/) (`yarn add <package name>`) or [npm](https://www.npmjs.com/) (`npm install <package name>`).
 
 ```bash
 yarn add @neo-one/cli @neo-one/client @neo-one/smart-contract @neo-one/smart-contract-test @neo-one/smart-contract-typescript-plugin
 ```
+```bash
+npm install @neo-one/cli @neo-one/client @neo-one/smart-contract @neo-one/smart-contract-test @neo-one/smart-contract-typescript-plugin
+```
 
-4. Run `yarn neo-one init`.
+4. Run `yarn neo-one init` or `npm run neo-one init`
 
 We recommend taking a moment to [setup your editor](/docs/environment-setup#Editor-Setup) to take advantage of inline NEO•ONE compiler diagnostics.
 
@@ -101,11 +104,11 @@ This smart contract doesn't do a whole lot, in fact it does nothing, but this is
   4. Deploy the smart contracts to the private NEO network.
   5. Generate code for use in your decentralized app.
 
-Additionally, you may run `yarn build` with the `--reset` flag to reset the network. Running with `--watch` will execute the above process whenever you make a change to your smart contracts.
+Additionally, you may run `yarn neo-one build` OR `npm run neo-one build` with the `--reset` flag to reset the network. Running with `--watch` will execute the above process whenever you make a change to your smart contracts.
 
 ### Testing
 
-Throughout the tutorial we'll write tests for each piece of smart contract functionality. Run the tests using `yarn test`. It's convention to put smart contract tests under `one/tests`, e.g. `one/tests/Token.test.ts`, however for this tutorial we'll put the tests under `src/__tests__/contracts` so that Jest will automatically pick them up without additional configuration. Create a new file `src/__tests__/contracts/Token.test.ts` and add the following:
+Throughout the tutorial we'll write tests for each piece of smart contract functionality. Run the tests using `yarn test` OR `npm test`. It's convention to put smart contract tests under `one/tests`, e.g. `one/tests/Token.test.ts`, however for this tutorial we'll put the tests under `src/__tests__/contracts` so that Jest will automatically pick them up without additional configuration. Create a new file `src/__tests__/contracts/Token.test.ts` and add the following:
 
 ```typescript
 /**


### PR DESCRIPTION
Updating docs to include npm commands for every yarn command.

### Requirements

provide appropriate npm commands for every yarn command. 


### Test Plan
manually tested:
```    npm install @neo-one/client @neo-one/cli @neo-one/smart-contract @neo-one/smart-contract-test @neo-one/smart-contract-typescript-plugin
npm run neo-one init
npm install
npm run neo-one build
npm run start
npm test
```

### Applicable Issues

re #781
