### PR TITLE
docs(Reference): Give object parameters a name if they will be includ…

### DIFF
--- a/packages/neo-one-client-common/src/helpers.ts
+++ b/packages/neo-one-client-common/src/helpers.ts
@@ -123,13 +123,12 @@ export function isNEP2(encryptedKey: string): boolean {
  * @param privateKey hex-encoded private key
  * @returns NEP-2 format encrypted key
  */
-export async function encryptNEP2({
-  password,
-  privateKey,
-}: {
+export async function encryptNEP2(options: {
   readonly password: string;
   readonly privateKey: PrivateKeyString;
 }): Promise<string> {
+  const { password, privateKey } = options;
+
   return crypto.encryptNEP2({
     addressVersion: common.NEO_ADDRESS_VERSION,
     privateKey: common.stringToPrivateKey(privateKey),
@@ -144,13 +143,11 @@ export async function encryptNEP2({
  * @param encryptedKey NEP-2 format encrypted key
  * @returns hex-encoded private key
  */
-export async function decryptNEP2({
-  password,
-  encryptedKey,
-}: {
+export async function decryptNEP2(options: {
   readonly password: string;
   readonly encryptedKey: string;
 }): Promise<PrivateKeyString> {
+  const { password, encryptedKey } = options;
   const privateKey = await crypto.decryptNEP2({
     addressVersion: common.NEO_ADDRESS_VERSION,
     encryptedKey,

--- a/packages/neo-one-client-core/src/provider/NEOONEOneDataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEOneDataProvider.ts
@@ -50,13 +50,8 @@ export class NEOONEOneDataProvider implements DeveloperProvider {
   private readonly iterBlocksFetchTimeoutMS: number | undefined;
   private readonly iterBlocksBatchSize: number | undefined;
 
-  public constructor({
-    network,
-    projectID,
-    port,
-    iterBlocksFetchTimeoutMS,
-    iterBlocksBatchSize,
-  }: NEOONEOneDataProviderOptions) {
+  public constructor(options: NEOONEOneDataProviderOptions) {
+    const { network, projectID, port, iterBlocksFetchTimeoutMS, iterBlocksBatchSize } = options;
     this.network = network;
     this.projectID = projectID;
     this.port = port;

--- a/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
@@ -58,7 +58,8 @@ export class NEOONEProvider implements Provider {
     return this.networksInternal$.getValue();
   }
 
-  public addNetwork({ network, rpcURL }: { readonly network: NetworkType; readonly rpcURL: string }): void {
+  public addNetwork(options: { readonly network: NetworkType; readonly rpcURL: string }): void {
+    const { network, rpcURL } = options;
     this.mutableProviders[network] = new NEOONEDataProvider({ network, rpcURL });
     const networks = this.networksInternal$.value.filter((net) => network !== net).concat([network]);
     this.networksInternal$.next(networks);

--- a/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
@@ -222,7 +222,8 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
   protected readonly mutableUsedOutputs: Set<string>;
   protected mutableBlockCount: number;
 
-  public constructor({ keystore, provider }: { readonly keystore: TKeyStore; readonly provider: TProvider }) {
+  public constructor(constructorOptions: { readonly keystore: TKeyStore; readonly provider: TProvider }) {
+    const { keystore, provider } = constructorOptions;
     this.keystore = keystore;
     this.provider = provider;
 


### PR DESCRIPTION
With dgeni typescript parsing, function parameters display awkwardly if they are unnamed objects.
Giving them a name like "options" fixes the issue and displays them properly.

#702