### PR TITLE
fix(tslint-export-name): revert to "tslint-microsoft-contrib": "5.2.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     "tslint-config-prettier": "1.17.0",
     "tslint-consistent-codestyle": "1.14.1",
     "tslint-immutable": "4.9.1",
-    "tslint-microsoft-contrib": "6.0.0",
+    "tslint-microsoft-contrib": "5.2.1",
     "tslint-sonarts": "1.8.0",
     "typescript": "3.2.2",
     "typescript-styled-plugin": "0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20569,10 +20569,10 @@ tslint-immutable@4.9.1:
   resolved "https://registry.yarnpkg.com/tslint-immutable/-/tslint-immutable-4.9.1.tgz#ca4555d04c3995c92c912b9e57502d423151002c"
   integrity sha512-iIFCq08H4YyNIX0bV5N6fGQtAmjc4OQZKQCgBP5WHgQaITyGAHPVmAw+Yf7qe0zbRCvCDZdrdEC/191fLGFiww==
 
-tslint-microsoft-contrib@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz#7bff73c9ad7a0b7eb5cdb04906de58f42a2bf7a2"
-  integrity sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==
+tslint-microsoft-contrib@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
+  integrity sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 


### PR DESCRIPTION
### Requirements

Revert tslint-microsoft-contrib dependency to 5.2.1 before 6.0 where a bug was introduced that incorrectly flags our ` index.ts ` files with single export-defaults entries as failing the export-name test. 

### Description of the Change

reverting tslint-microsoft-contrib until next release.
