### PR TITLE
feat(neo-one-cli): print last N lines of server log when server fails to start

### DIFF
--- a/packages/neo-one-cli/src/utils/reportError.ts
+++ b/packages/neo-one-cli/src/utils/reportError.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+export const reportError = async (logFilePath: string) => {
+  const serverLogFile = path.resolve(logFilePath, 'server/server.log');
+
+  try {
+    const contents = await fs.readFile(serverLogFile, 'utf8');
+    const maxLines = 10;
+
+    const lines = contents.split('\n').filter((line) => line.length > 1);
+    const output = lines.slice(-maxLines);
+
+    /* tslint:disable-next-line:no-console */
+    console.log(`\n\nLast ${maxLines} entries of server log:\n${serverLogFile}\n`, output.join('\n'));
+  } catch {
+    /* tslint:disable-next-line:no-console */
+    console.error(`\nError reading server log: ${serverLogFile}\n`);
+  }
+};


### PR DESCRIPTION
### Requirements

report server log path and last N lines when server fails to start

### Description of the Change

Update start-server error-handling to also report last N lines of server log & path of log.

### Test Plan

run tests

### Benefits

Provide additional hints when debugging in the local development environment.

Sample Output: 
![image](https://user-images.githubusercontent.com/39564353/51871738-14f9b680-230c-11e9-9963-925a237bb9b5.png)

