### PR TITLE
chore(dep): revert ix-esnext-esm from 2.4.3 to 2.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@babel/preset-env": "7.2.0",
     "@babel/preset-react": "7.0.0",
     "@cypress/webpack-preprocessor": "4.0.2",
-    "@reactivex/ix-esnext-esm": "2.4.3",
+    "@reactivex/ix-esnext-esm": "2.3.5",
     "@types/autoprefixer": "9.1.1",
     "@types/jest": "23.3.12",
     "@types/react": "16.7.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,14 +2263,11 @@
   dependencies:
     tslib "^1.8.0"
 
-"@reactivex/ix-esnext-esm@2.4.3":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@reactivex/ix-esnext-esm/-/ix-esnext-esm-2.4.3.tgz#8053ec77af42fba3f97729078d1f70ff343036d8"
+"@reactivex/ix-esnext-esm@2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@reactivex/ix-esnext-esm/-/ix-esnext-esm-2.3.5.tgz#c62389c6212385ecff152ae2bb0b86dfb47e1988"
   dependencies:
-    "@types/node" "^10.12.18"
-    is-stream "1.1.0"
-    rxjs "5.5.11"
-    tslib "^1.9.3"
+    tslib "^1.8.0"
 
 "@render-props/events@^0.1.2":
   version "0.1.9"
@@ -2858,10 +2855,6 @@
 "@types/node@*", "@types/node@^10.1.0":
   version "10.12.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
-
-"@types/node@^10.12.18":
-  version "10.12.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
 
 "@types/node@^9.4.6":
   version "9.6.39"
@@ -10533,7 +10526,7 @@ is-stream-ended@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
 
-is-stream@1.1.0, is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -16636,12 +16629,6 @@ rxjs-tslint-rules@4.14.3:
     resolve "^1.4.0"
     tslib "^1.8.0"
     tsutils "^3.0.0"
-
-rxjs@5.5.11:
-  version "5.5.11"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
-  dependencies:
-    symbol-observable "1.0.1"
 
 rxjs@6.3.3, rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"


### PR DESCRIPTION
Revert "chore(deps): update dependency @reactivex/ix-esnext-esm to v2.4.3"


### Description of the Change
Pull request https://github.com/neo-one-suite/neo-one/pull/904 containing commit `d6cc1b1ce80b3b7e81c8fec85586857773f194bc` breaks the `compileTypescript:es2017:cjs:task`

![image](https://user-images.githubusercontent.com/39564353/50986546-f26a3f80-14bb-11e9-8bb8-fa5175070a80.png)

Reverting this change results in a successful build:
![image](https://user-images.githubusercontent.com/39564353/50986632-2e9da000-14bc-11e9-958a-ab2678376e5c.png)

### Test Plan
    yarn && yarn build 

### Benefits

Build is no longer broken
