### PR TITLE
fix(node): adjust logging levels of several node commands.

### DIFF
--- a/packages/neo-one-node-network/src/Network.ts
+++ b/packages/neo-one-node-network/src/Network.ts
@@ -489,12 +489,12 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
           {
             name: 'neo_network_peer_connect',
             message: `Connecting to peer at ${endpoint}`,
-            level: 'verbose',
+            level: 'debug',
             metric: NEO_NETWORK_PEER_CONNECT_TOTAL,
             error: {
               message: `Failed to connect to peer at ${endpoint}.`,
               metric: NEO_NETWORK_PEER_CONNECT_FAILURES_TOTAL,
-              level: 'verbose',
+              level: 'debug',
             },
           },
         );
@@ -571,8 +571,9 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
       .withData({
         [this.monitor.labels.PEER_ADDRESS]: peer.endpoint,
       })
-      .logError({
+      .log({
         name: 'neo_network_peer_error',
+        level: 'debug',
         message: `Encountered error with peer at ${peer.endpoint}.`,
         error,
       });

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -899,7 +899,7 @@ export class Node implements INode {
             },
             {
               name: 'neo_relay_block',
-              level: { log: 'verbose', span: 'info' },
+              level: { log: 'info', span: 'info' },
               trace: true,
             },
           );


### PR DESCRIPTION
### Description of the Change

Adjust log-levels of some commands in the node to make `info`, `verbose`, and `debug` more distinct in what they log for easier use.

### Alternate Designs

Could be better ways to organize them maybe?

### Benefits

readability of node-monitor output.