### PR TITLE
chore(dep): update neo-one packages with bignumber.js 8.0.2

### DIFF
--- a/packages/neo-one-client-common/package.json
+++ b/packages/neo-one-client-common/package.json
@@ -15,7 +15,7 @@
     "@types/lodash": "^4.14.118",
     "@types/scrypt-js": "^2.0.1",
     "@types/wif": "^2.0.1",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "bn.js": "^4.11.8",
     "bs58": "^4.0.1",
     "buffer-xor": "^2.0.2",

--- a/packages/neo-one-client-core/package.json
+++ b/packages/neo-one-client-core/package.json
@@ -14,7 +14,7 @@
     "@types/bn.js": "^4.11.3",
     "@types/lodash": "^4.14.118",
     "@types/tapable": "^1.0.4",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "bn.js": "^4.11.8",
     "cross-fetch": "^3.0.0",
     "dataloader": "^1.4.0",

--- a/packages/neo-one-client-full-core/package.json
+++ b/packages/neo-one-client-full-core/package.json
@@ -12,7 +12,7 @@
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
     "@types/lodash": "^4.14.118",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "lodash": "^4.17.11",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-developer-tools-frame/package.json
+++ b/packages/neo-one-developer-tools-frame/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^16.0.9",
     "@types/react-select": "^2.0.7",
     "@types/styled-components": "^4.1.0",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "date-fns": "^2.0.0-alpha.25",
     "localforage": "^1.7.3",
     "lodash": "^4.17.11",

--- a/packages/neo-one-local/package.json
+++ b/packages/neo-one-local/package.json
@@ -9,7 +9,7 @@
     "@neo-one/client-full-core": "^1.0.2",
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "tslib": "^1.9.3"
   },
   "sideEffects": false

--- a/packages/neo-one-node-consensus/package.json
+++ b/packages/neo-one-node-consensus/package.json
@@ -11,7 +11,7 @@
     "@neo-one/utils": "^1.0.1",
     "@reactivex/ix-es2015-cjs": "^2.3.5",
     "@types/lodash": "^4.14.118",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "bn.js": "^4.11.8",
     "lodash": "^4.17.11",
     "rxjs": "^6.3.3",

--- a/packages/neo-one-node-core/package.json
+++ b/packages/neo-one-node-core/package.json
@@ -12,7 +12,7 @@
     "@types/bn.js": "^4.11.3",
     "@types/lodash": "^4.14.118",
     "@types/through": "^0.0.29",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "bn.js": "^4.11.8",
     "lodash": "^4.17.11",
     "rxjs": "^6.3.3",

--- a/packages/neo-one-server-plugin-project/package.json
+++ b/packages/neo-one-server-plugin-project/package.json
@@ -37,7 +37,7 @@
     "@neo-one/smart-contract": "^1.0.1",
     "@neo-one/smart-contract-test": "1.0.0-alpha.44",
     "@types/react": "16.7.18",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0"
   },
   "sideEffects": false

--- a/packages/neo-one-server-plugin-wallet/package.json
+++ b/packages/neo-one-server-plugin-wallet/package.json
@@ -18,7 +18,7 @@
     "@types/fs-extra": "^5.0.4",
     "@types/lodash": "^4.14.118",
     "@types/ora": "^3.0.0",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.11",
     "ora": "^3.0.0",

--- a/packages/neo-one-smart-contract-compiler/package.json
+++ b/packages/neo-one-smart-contract-compiler/package.json
@@ -34,7 +34,7 @@
     "@types/levelup": "3.1.0",
     "@types/memdown": "3.0.0",
     "app-root-dir": "1.0.2",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "levelup": "4.0.0",
     "memdown": "3.0.0"
   },

--- a/packages/neo-one-smart-contract-lib/package.json
+++ b/packages/neo-one-smart-contract-lib/package.json
@@ -13,7 +13,7 @@
     "@neo-one/smart-contract-test": "^1.0.2",
     "@types/app-root-dir": "0.1.0",
     "app-root-dir": "1.0.2",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "tslib": "1.9.3"
   },
   "sideEffects": false

--- a/packages/neo-one-smart-contract-test-common/package.json
+++ b/packages/neo-one-smart-contract-test-common/package.json
@@ -10,7 +10,7 @@
     "@neo-one/local": "^1.0.2",
     "@neo-one/smart-contract-compiler": "^1.0.2",
     "@neo-one/types": "^1.0.1",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "^8.0.2",
     "change-case": "^3.0.2",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/0-contracts/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/0-contracts/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/1-properties/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/1-properties/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/2-storage/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/2-storage/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/3-structured-storage/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/3-structured-storage/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/4-constructors/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/4-constructors/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/5-methods/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/5-methods/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/6-events/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/6-events/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/7-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/7-transfer/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/0-receiving/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/0-receiving/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/1-processing/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/1-processing/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/2-mint/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/2-mint/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/3-duration/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/3-duration/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/4-withdraw/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/4-withdraw/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",
     "@types/styled-components": "4.1.0",
-    "bignumber.js": "8.0.1",
+    "bignumber.js": "8.0.2",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "rxjs": "6.3.3",

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/0-approvals/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/0-approvals/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/1-deposit/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/1-deposit/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/2-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/2-transfer/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/3-claim/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/3-claim/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/4-refund/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/4-refund/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/5-generalize/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/5-generalize/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/6-cneo/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/6-cneo/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/7-forward/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/7-forward/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.1"
+    "bignumber.js": "8.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,7 +2060,7 @@
     apollo-client "^2.4.5"
     apollo-link "^1.2.3"
     app-root-dir "^1.0.2"
-    bignumber.js "^8.0.1"
+    bignumber.js "^8.0.2"
     bn.js "^4.11.8"
     change-case "^3.0.2"
     chokidar "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,6 +2809,10 @@
   version "10.12.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
 
+"@types/node@^10.12.18":
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+
 "@types/node@^9.4.6":
   version "9.6.39"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.39.tgz#111cb4f5591cb6945aad34733b4e40bfd59b58fc"
@@ -4745,7 +4749,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
 
-bignumber.js@8.0.1, bignumber.js@^8.0.1:
+bignumber.js@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.2.tgz#d8c4e1874359573b1ef03011a2d861214aeef137"
+
+bignumber.js@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.1.tgz#5d419191370fb558c64e3e5f70d68e5947138832"
 
@@ -10401,7 +10409,7 @@ is-stream-ended@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@1.1.0, is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -16487,6 +16495,12 @@ rxjs-tslint-rules@4.14.3:
     resolve "^1.4.0"
     tslib "^1.8.0"
     tsutils "^3.0.0"
+
+rxjs@5.5.11:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@6.3.3, rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"


### PR DESCRIPTION
### Requirements

Renovate bot did not update all neo-one packages to latest version of bignumber.

### Description of the Change

updated package.json and yarn.lock to include 8.0.2 version of BigNumber. 

### Test Plan

    yarn install
    yarn build

### Applicable Issues

https://github.com/neo-one-suite/neo-one/pull/933

# Depends on 
React Update