### PR TITLE
fix(build): adjust several packages to allow emitting .d.ts files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,12 +258,11 @@
     "yargs": "12.0.5"
   },
   "resolutions": {
-    "@types/react": "16.7.22",
+    "@reactivex/ix-es2015-cjs": "2.3.5",
     "ajv": "6.5.5",
     "babel-core": "7.0.0-bridge.0",
     "bn.js": "4.11.8",
     "regenerator-runtime": "0.13.1",
-    "styled-components": "4.1.3",
     "webpack": "4.29.0"
   },
   "config": {

--- a/packages/neo-one-client-common/package.json
+++ b/packages/neo-one-client-common/package.json
@@ -8,7 +8,6 @@
     "@neo-one/monitor": "^1.0.1",
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
-    "@types/bn.js": "^4.11.4",
     "@types/bs58": "^4.0.0",
     "@types/buffer-xor": "^2.0.0",
     "@types/elliptic": "^6.4.0",

--- a/packages/neo-one-client-core/package.json
+++ b/packages/neo-one-client-core/package.json
@@ -11,7 +11,6 @@
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
     "@reactivex/ix-es2015-cjs": "2.3.5",
-    "@types/bn.js": "^4.11.4",
     "@types/lodash": "^4.14.118",
     "@types/tapable": "^1.0.4",
     "bignumber.js": "^8.0.2",

--- a/packages/neo-one-client-full-core/package.json
+++ b/packages/neo-one-client-full-core/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@neo-one/node-core": "^1.0.1",
     "@reactivex/ix-es2015-cjs": "2.3.5",
-    "@types/bn.js": "4.11.4",
     "bn.js": "4.11.8",
     "rxjs": "6.3.3"
   },

--- a/packages/neo-one-editor-server/src/entry.ts
+++ b/packages/neo-one-editor-server/src/entry.ts
@@ -103,7 +103,6 @@ process.on('uncaughtException', (error) => {
 
 const app = new Application();
 app.proxy = true;
-// $FlowFixMe
 app.silent = true;
 
 app.on('error', appOnError({ monitor }));

--- a/packages/neo-one-editor-server/src/lambda.ts
+++ b/packages/neo-one-editor-server/src/lambda.ts
@@ -35,7 +35,6 @@ export const lambda = (name: string, middleware: Middleware, type: 'get' | 'post
 
   const app = new Application();
   app.proxy = true;
-  // $FlowFixMe
   app.silent = true;
 
   app.on('error', appOnError({ monitor }));

--- a/packages/neo-one-local-browser/src/utils.ts
+++ b/packages/neo-one-local-browser/src/utils.ts
@@ -1,5 +1,5 @@
 export const getSmartContractBasePath = (value: string) => `/node_modules/@neo-one/smart-contract/${value}`;
 export const getSmartContractLibBasePath = (value: string) => `/node_modules/@neo-one/smart-contract-lib/${value}`;
-export const getSmartContractPath = (value: string) => getSmartContractBasePath(`src/${value}`);
-export const getSmartContractLibPath = (value: string) => getSmartContractLibBasePath(`src/${value}`);
+export const getSmartContractPath = (value: string) => getSmartContractBasePath(`${value}`);
+export const getSmartContractLibPath = (value: string) => getSmartContractLibBasePath(`${value}`);
 export const CONTRACTS_PATH = '/one/contracts';

--- a/packages/neo-one-local/src/setupWallets.ts
+++ b/packages/neo-one-local/src/setupWallets.ts
@@ -11,7 +11,7 @@ import BigNumber from 'bignumber.js';
 import { constants } from './constants';
 import { getClients } from './getClients';
 
-interface BootstrapWallet {
+export interface BootstrapWallet {
   readonly name: string;
   readonly privateKey: string;
   readonly publicKey: string;

--- a/packages/neo-one-monitor/src/NodeMonitor.ts
+++ b/packages/neo-one-monitor/src/NodeMonitor.ts
@@ -74,7 +74,7 @@ export class NodeMonitor extends MonitorBase {
     app.silent = true;
 
     const monitor = this.at('telemetry');
-    app.on('error', (error) => {
+    app.on('error', (error: Error) => {
       monitor.logError({
         name: 'http_server_request_uncaught_error',
         message: 'Unexpected uncaught request error.',

--- a/packages/neo-one-node-blockchain/package.json
+++ b/packages/neo-one-node-blockchain/package.json
@@ -9,7 +9,6 @@
     "@neo-one/node-core": "^1.0.1",
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
-    "@types/bn.js": "^4.11.4",
     "@types/js-priority-queue": "^0.0.5",
     "@types/lodash": "^4.14.118",
     "bn.js": "^4.11.8",

--- a/packages/neo-one-node-core/package.json
+++ b/packages/neo-one-node-core/package.json
@@ -9,7 +9,6 @@
     "@neo-one/monitor": "^1.0.1",
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
-    "@types/bn.js": "^4.11.4",
     "@types/lodash": "^4.14.118",
     "@types/through": "^0.0.29",
     "bignumber.js": "^8.0.2",

--- a/packages/neo-one-node-core/src/transaction/TransactionBase.ts
+++ b/packages/neo-one-node-core/src/transaction/TransactionBase.ts
@@ -94,6 +94,7 @@ export interface TransactionVerifyOptions {
   readonly memPool?: ReadonlyArray<Transaction>;
 }
 
+/** @internal */
 export function TransactionBase<
   Type extends TransactionType,
   TransactionJSON,

--- a/packages/neo-one-node-neo-settings/package.json
+++ b/packages/neo-one-node-neo-settings/package.json
@@ -8,7 +8,6 @@
     "@neo-one/node-core": "^1.0.1",
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
-    "@types/bn.js": "^4.11.4",
     "bn.js": "^4.11.8",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-node-protocol/package.json
+++ b/packages/neo-one-node-protocol/package.json
@@ -12,7 +12,6 @@
     "@neo-one/utils": "^1.0.1",
     "@types/bloem": "^0.2.0",
     "@types/bloom-filter": "^0.2.0",
-    "@types/bn.js": "^4.11.4",
     "@types/ip-address": "^5.8.2",
     "@types/lodash": "^4.14.118",
     "@types/lru-cache": "^4.1.1",

--- a/packages/neo-one-node-storage-common/package.json
+++ b/packages/neo-one-node-storage-common/package.json
@@ -7,7 +7,6 @@
     "@neo-one/client-common": "^1.0.1",
     "@neo-one/node-core": "^1.0.1",
     "@neo-one/types": "^1.0.1",
-    "@types/bn.js": "^4.11.4",
     "@types/bytewise": "^1.1.0",
     "bn.js": "^4.11.8",
     "bytewise": "^1.1.0",

--- a/packages/neo-one-node-vm/package.json
+++ b/packages/neo-one-node-vm/package.json
@@ -11,7 +11,6 @@
     "@neo-one/types": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
     "@reactivex/ix-es2015-cjs": "2.3.5",
-    "@types/bn.js": "^4.11.4",
     "@types/lodash": "^4.14.118",
     "bitwise": "^2.0.0",
     "bn.js": "^4.11.8",

--- a/packages/neo-one-node-vm/src/constants.ts
+++ b/packages/neo-one-node-vm/src/constants.ts
@@ -45,7 +45,7 @@ export interface ExecutionInit {
   readonly vmFeatures: VMFeatureSwitches;
 }
 
-interface CreatedContracts {
+export interface CreatedContracts {
   readonly [hash: string]: UInt160;
 }
 export interface Options {

--- a/packages/neo-one-react-common/src/Popover.tsx
+++ b/packages/neo-one-react-common/src/Popover.tsx
@@ -9,7 +9,7 @@ import { PopoverArrow } from './PopoverArrow';
 
 const { forwardRef, useCallback, useEffect, useRef, useState } = React;
 
-interface PopoverProps extends HiddenProps {
+export interface PopoverProps extends HiddenProps {
   readonly role?: string;
   readonly hideOnEsc?: boolean;
   readonly placement?: Popper.Placement;

--- a/packages/neo-one-server-grpc/src/index.ts
+++ b/packages/neo-one-server-grpc/src/index.ts
@@ -1,4 +1,4 @@
 /// <reference types="@neo-one/types" />
 import * as path from 'path';
 // tslint:disable-next-line export-name
-export const proto = path.resolve(__dirname, '../proto/server.proto');
+export const proto = path.resolve(__dirname, 'proto', 'server.proto');

--- a/packages/neo-one-server-plugin-wallet/src/bootstrap.ts
+++ b/packages/neo-one-server-plugin-wallet/src/bootstrap.ts
@@ -768,7 +768,7 @@ async function addWalletsToKeystore({
 const findContracts = async (current: string): Promise<string> => {
   const exists = await fs.pathExists(path.resolve(current, 'package.json'));
   if (exists) {
-    return path.resolve(current, 'src', 'contracts');
+    return path.resolve(current, current.split(path.sep).some((dir) => dir === 'dist') ? '' : 'src', 'contracts');
   }
 
   return findContracts(path.dirname(current));

--- a/packages/neo-one-server-plugin/src/version.ts
+++ b/packages/neo-one-server-plugin/src/version.ts
@@ -2,4 +2,4 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 // tslint:disable-next-line export-name
-export const VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
+export const VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;

--- a/packages/neo-one-smart-contract-compiler/package.json
+++ b/packages/neo-one-smart-contract-compiler/package.json
@@ -14,7 +14,6 @@
     "@neo-one/typescript-concatenator": "^1.0.1",
     "@neo-one/utils": "^1.0.1",
     "@types/babel__code-frame": "^7.0.0",
-    "@types/bn.js": "^4.11.4",
     "@types/lodash": "^4.14.118",
     "bn.js": "^4.11.8",
     "lodash": "^4.17.11",

--- a/packages/neo-one-ts-utils/src/print.ts
+++ b/packages/neo-one-ts-utils/src/print.ts
@@ -2,7 +2,7 @@ import { RawSourceMap } from 'source-map';
 import ts from 'typescript';
 import * as file_ from './file';
 
-interface Result {
+export interface Result {
   readonly text: string;
   readonly sourceMap: RawSourceMap;
 }

--- a/packages/neo-one-types/bn.js/index.d.ts
+++ b/packages/neo-one-types/bn.js/index.d.ts
@@ -1,0 +1,512 @@
+declare module 'bn.js' {
+  // Type definitions for bn.js 4.11
+  // Project: https://github.com/indutny/bn.js
+  // Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
+  //                 Henry Nguyen <https://github.com/HenryNguyen5>
+  // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+  /// <reference types="node"/>
+
+  type Endianness = 'le' | 'be';
+  type IPrimeName = 'k256' | 'p224' | 'p192' | 'p25519';
+
+  declare class RedBN {
+    redAdd(b: RedBN): RedBN;
+    redIAdd(b: RedBN): RedBN;
+    redSub(b: RedBN): RedBN;
+    redISub(b: RedBN): RedBN;
+    redShl(num: number): RedBN;
+    redMul(b: RedBN): RedBN;
+    redIMul(b: RedBN): RedBN;
+    redSqr(): RedBN;
+    redISqr(): RedBN;
+    /**
+     * @description square root modulo reduction context's prime
+     */
+    redSqrt(): RedBN;
+    /**
+     * @description  modular inverse of the number
+     */
+    redInvm(): RedBN;
+    redNeg(): RedBN;
+    /**
+     * @description modular exponentiation
+     */
+    redPow(b: RedBN): RedBN;
+    fromRed(): BN;
+  }
+
+  // FIXME: not sure how to specify the reduction context here
+  interface ReductionContext {
+    m: number;
+    prime: any;
+    [key: string]: any;
+  }
+
+  export default class BN {
+    constructor(number: number | string | number[] | Buffer | BN, base?: number | 'hex', endian?: Endianness);
+    constructor(number: number | string | number[] | Buffer | BN, endian?: Endianness);
+
+    /**
+     * @description  create a reduction context
+     */
+    static red(reductionContext: BN | IPrimeName): ReductionContext;
+
+    /**
+     * @description  create a reduction context  with the Montgomery trick.
+     */
+    static mont(num: BN): ReductionContext;
+
+    /**
+     * @description returns true if the supplied object is a BN.js instance
+     */
+    static isBN(b: any): b is BN;
+
+    /**
+     * @description returns the maximum of 2 BN instances.
+     */
+    static max(left: BN, right: BN): BN;
+
+    /**
+     * @description returns the minimum of 2 BN instances.
+     */
+    static min(left: BN, right: BN): BN;
+
+    /**
+     * @description  Convert number to red
+     */
+    toRed(reductionContext: ReductionContext): RedBN;
+
+    /**
+     * @description  clone number
+     */
+    clone(): BN;
+
+    /**
+     * @description  convert to base-string and pad with zeroes
+     */
+    toString(base?: number | 'hex', length?: number): string;
+
+    /**
+     * @description convert to Javascript Number (limited to 53 bits)
+     */
+    toNumber(): number;
+
+    /**
+     * @description convert to JSON compatible hex string (alias of toString(16))
+     */
+    toJSON(): string;
+
+    /**
+     * @description  convert to byte Array, and optionally zero pad to length, throwing if already exceeding
+     */
+    toArray(endian?: Endianness, length?: number): number[];
+
+    /**
+     * @description convert to an instance of `type`, which must behave like an Array
+     */
+    toArrayLike(ArrayType: typeof Buffer, endian?: Endianness, length?: number): Buffer;
+
+    toArrayLike(ArrayType: any[], endian?: Endianness, length?: number): any[];
+
+    /**
+     * @description  convert to Node.js Buffer (if available). For compatibility with browserify and similar tools, use this instead: a.toArrayLike(Buffer, endian, length)
+     */
+    toBuffer(endian?: Endianness, length?: number): Buffer;
+
+    /**
+     * @description get number of bits occupied
+     */
+    bitLength(): number;
+
+    /**
+     * @description return number of less-significant consequent zero bits (example: 1010000 has 4 zero bits)
+     */
+    zeroBits(): number;
+
+    /**
+     * @description return number of bytes occupied
+     */
+    byteLength(): number;
+
+    /**
+     * @description  true if the number is negative
+     */
+    isNeg(): boolean;
+
+    /**
+     * @description  check if value is even
+     */
+    isEven(): boolean;
+
+    /**
+     * @description   check if value is odd
+     */
+    isOdd(): boolean;
+
+    /**
+     * @description  check if value is zero
+     */
+    isZero(): boolean;
+
+    /**
+     * @description compare numbers and return `-1 (a < b)`, `0 (a == b)`, or `1 (a > b)` depending on the comparison result
+     */
+    cmp(b: BN): -1 | 0 | 1;
+
+    /**
+     * @description compare numbers and return `-1 (a < b)`, `0 (a == b)`, or `1 (a > b)` depending on the comparison result
+     */
+    ucmp(b: BN): -1 | 0 | 1;
+
+    /**
+     * @description compare numbers and return `-1 (a < b)`, `0 (a == b)`, or `1 (a > b)` depending on the comparison result
+     */
+    cmpn(b: number): -1 | 0 | 1;
+
+    /**
+     * @description a less than b
+     */
+    lt(b: BN): boolean;
+
+    /**
+     * @description a less than b
+     */
+    ltn(b: number): boolean;
+
+    /**
+     * @description a less than or equals b
+     */
+    lte(b: BN): boolean;
+
+    /**
+     * @description a less than or equals b
+     */
+    lten(b: number): boolean;
+
+    /**
+     * @description a greater than b
+     */
+    gt(b: BN): boolean;
+
+    /**
+     * @description a greater than b
+     */
+    gtn(b: number): boolean;
+
+    /**
+     * @description a greater than or equals b
+     */
+    gte(b: BN): boolean;
+
+    /**
+     * @description a greater than or equals b
+     */
+    gten(b: number): boolean;
+
+    /**
+     * @description a equals b
+     */
+    eq(b: BN): boolean;
+
+    /**
+     * @description a equals b
+     */
+    eqn(b: number): boolean;
+
+    /**
+     * @description convert to two's complement representation, where width is bit width
+     */
+    toTwos(width: number): BN;
+
+    /**
+     * @description  convert from two's complement representation, where width is the bit width
+     */
+    fromTwos(width: number): BN;
+
+    /**
+     * @description negate sign
+     */
+    neg(): BN;
+
+    /**
+     * @description negate sign
+     */
+    ineg(): BN;
+
+    /**
+     * @description absolute value
+     */
+    abs(): BN;
+
+    /**
+     * @description absolute value
+     */
+    iabs(): BN;
+
+    /**
+     * @description addition
+     */
+    add(b: BN): BN;
+
+    /**
+     * @description  addition
+     */
+    iadd(b: BN): BN;
+
+    /**
+     * @description addition
+     */
+    addn(b: number): BN;
+
+    /**
+     * @description addition
+     */
+    iaddn(b: number): BN;
+
+    /**
+     * @description subtraction
+     */
+    sub(b: BN): BN;
+
+    /**
+     * @description subtraction
+     */
+    isub(b: BN): BN;
+
+    /**
+     * @description subtraction
+     */
+    subn(b: number): BN;
+
+    /**
+     * @description subtraction
+     */
+    isubn(b: number): BN;
+
+    /**
+     * @description multiply
+     */
+    mul(b: BN): BN;
+
+    /**
+     * @description multiply
+     */
+    imul(b: BN): BN;
+
+    /**
+     * @description multiply
+     */
+    muln(b: number): BN;
+
+    /**
+     * @description multiply
+     */
+    imuln(b: number): BN;
+
+    /**
+     * @description square
+     */
+    sqr(): BN;
+
+    /**
+     * @description square
+     */
+    isqr(): BN;
+
+    /**
+     * @description raise `a` to the power of `b`
+     */
+    pow(b: BN): BN;
+
+    /**
+     * @description divide
+     */
+    div(b: BN): BN;
+
+    /**
+     * @description divide
+     */
+    divn(b: number): BN;
+
+    /**
+     * @description divide
+     */
+    idivn(b: number): BN;
+
+    /**
+     * @description reduct
+     */
+    mod(b: BN): BN;
+
+    /**
+     * @description reduct
+     */
+    umod(b: BN): BN;
+
+    /**
+     * @see API consistency https://github.com/indutny/bn.js/pull/130
+     * @description reduct
+     */
+    modn(b: number): number;
+
+    /**
+     * @description  rounded division
+     */
+    divRound(b: BN): BN;
+
+    /**
+     * @description or
+     */
+    or(b: BN): BN;
+
+    /**
+     * @description or
+     */
+    ior(b: BN): BN;
+
+    /**
+     * @description or
+     */
+    uor(b: BN): BN;
+
+    /**
+     * @description or
+     */
+    iuor(b: BN): BN;
+
+    /**
+     * @description and
+     */
+    and(b: BN): BN;
+
+    /**
+     * @description and
+     */
+    iand(b: BN): BN;
+
+    /**
+     * @description and
+     */
+    uand(b: BN): BN;
+
+    /**
+     * @description and
+     */
+    iuand(b: BN): BN;
+
+    /**
+     * @description and (NOTE: `andln` is going to be replaced with `andn` in future)
+     */
+    andln(b: number): BN;
+
+    /**
+     * @description xor
+     */
+    xor(b: BN): BN;
+
+    /**
+     * @description xor
+     */
+    ixor(b: BN): BN;
+
+    /**
+     * @description xor
+     */
+    uxor(b: BN): BN;
+
+    /**
+     * @description xor
+     */
+    iuxor(b: BN): BN;
+
+    /**
+     * @description set specified bit to 1
+     */
+    setn(b: number): BN;
+
+    /**
+     * @description shift left
+     */
+    shln(b: number): BN;
+
+    /**
+     * @description shift left
+     */
+    ishln(b: number): BN;
+
+    /**
+     * @description shift left
+     */
+    ushln(b: number): BN;
+
+    /**
+     * @description shift left
+     */
+    iushln(b: number): BN;
+
+    /**
+     * @description shift right
+     */
+    shrn(b: number): BN;
+
+    /**
+     * @description shift right (unimplemented https://github.com/indutny/bn.js/blob/master/lib/bn.js#L2086)
+     */
+    ishrn(b: number): BN;
+
+    /**
+     * @description shift right
+     */
+    ushrn(b: number): BN;
+    /**
+     * @description shift right
+     */
+
+    iushrn(b: number): BN;
+    /**
+     * @description  test if specified bit is set
+     */
+
+    testn(b: number): boolean;
+    /**
+     * @description clear bits with indexes higher or equal to `b`
+     */
+
+    maskn(b: number): BN;
+    /**
+     * @description clear bits with indexes higher or equal to `b`
+     */
+
+    imaskn(b: number): BN;
+    /**
+     * @description add `1 << b` to the number
+     */
+    bincn(b: number): BN;
+
+    /**
+     * @description not (for the width specified by `w`)
+     */
+    notn(w: number): BN;
+
+    /**
+     * @description not (for the width specified by `w`)
+     */
+    inotn(w: number): BN;
+
+    /**
+     * @description GCD
+     */
+    gcd(b: BN): BN;
+
+    /**
+     * @description Extended GCD results `({ a: ..., b: ..., gcd: ... })`
+     */
+    egcd(b: BN): { a: BN; b: BN; gcd: BN };
+
+    /**
+     * @description inverse `a` modulo `b`
+     */
+    invm(b: BN): BN;
+  }
+}

--- a/packages/neo-one-types/index.d.ts
+++ b/packages/neo-one-types/index.d.ts
@@ -1,5 +1,6 @@
 /// <reference lib="esnext" />
 /// <reference path="./@neo-one/ec-key/index.d.ts" />
+/// <reference path="./bn.js/index.d.ts" />
 /// <reference path="./json-file-plus/index.d.ts" />
 /// <reference path="./koa-bodyparser/index.d.ts" />
 /// <reference path="./level-js/index.d.ts" />

--- a/tsconfig/tsconfig.build.json
+++ b/tsconfig/tsconfig.build.json
@@ -6,6 +6,8 @@
     "noEmit": false,
     "sourceMap": false,
     "inlineSources": true,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "declaration": true,
+    "stripInternal": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,6 +2214,7 @@
 "@reactivex/ix-es2015-cjs@2.3.5":
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/@reactivex/ix-es2015-cjs/-/ix-es2015-cjs-2.3.5.tgz#f50adc537e0c1fa91d68f5870bbc7e3d1ec9d327"
+  integrity sha512-eZRfTc+xlp5Y1saw2/UxP/pVfmx4v6IS4nn/z6IbCFCukMzhkkFYUVhEuPOAy2QRkxUmbWDWequvD8e3RA7mFA==
   dependencies:
     tslib "^1.8.0"
 
@@ -2364,12 +2365,6 @@
 "@types/bn.js@*":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.3.tgz#0f09e53e98659b007d7019261ddab9178135df38"
-  dependencies:
-    "@types/node" "*"
-
-"@types/bn.js@4.11.4", "@types/bn.js@^4.11.4":
-  version "4.11.4"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.4.tgz#a7bed5bdef9f16b25c92ba27745ab261374787d7"
   dependencies:
     "@types/node" "*"
 
@@ -3166,12 +3161,6 @@
 "@types/sizzle@*":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
-
-"@types/stream-throttle@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/stream-throttle/-/stream-throttle-0.1.0.tgz#8807746990431b68ec897e86cf14832f3025950e"
-  dependencies:
-    "@types/node" "*"
 
 "@types/styled-components@4.1.7":
   version "4.1.7"
@@ -5879,7 +5868,7 @@ commander@2.17.x, commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.16.0, commander@^2.18.0, commander@^2.2.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.16.0, commander@^2.18.0, commander@^2.8.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
@@ -12000,10 +11989,6 @@ liftoff@2.5.0, liftoff@^2.5.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
-limiter@^1.0.5:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.3.tgz#32e2eb55b2324076943e5d04c1185ffb387968ef"
-
 linkify-it@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
@@ -14935,7 +14920,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
 
-"postcss@5 - 7":
+"postcss@5 - 7", postcss@^7.0.14:
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
@@ -14963,14 +14948,6 @@ postcss@^6.0.14:
 postcss@^7.0.13:
   version "7.0.13"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.13.tgz#42bf716413e8f1c786ab71dc6e722b3671b16708"
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.14:
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -17494,13 +17471,6 @@ stream-shift@^1.0.0:
 stream-skip@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/stream-skip/-/stream-skip-1.0.3.tgz#fb1a7c932a7e9956233cf3196653da86f3546695"
-
-stream-throttle@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/stream-throttle/-/stream-throttle-0.1.3.tgz#add57c8d7cc73a81630d31cd55d3961cfafba9c3"
-  dependencies:
-    commander "^2.2.0"
-    limiter "^1.0.5"
 
 stream-to-observable@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Description of the Change

- temporarily use custom `bn.js` type definition which uses `export default`
- `export` a few local interfaces/functions that need to be exposed for declaration gen.
- `** @internal *` mark `TransactionBase` to hide the mixin function from declaration.

While we use the temporary `bn.js/index.d.ts` I have opened in issue in definitelyTyped:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32178

### Test Plan

```
yarn install
yarn build
```
`/dist` should now *only* have `.d.ts` and `.js` files.

### Alternate Designs

I think the only alternative is to handwrite the declaration files.

### Benefits

Should fix compiling a project which uses our packages but utilizes a different `tsconfig`.

### Possible Drawbacks

Need eyes on the `gulpfile.js` changes, not *wholly* confident in what I've done but essentially I just removed copying the typescript files to dist and compiling in place, in favor of compiling from src to dist. Do my changes implicate missing transforms? 🤷‍♂️

### Issues

#951 
