### PR TITLE
chore(deps): revert dependency @reactivex/ix-esnext-esm to v2.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@babel/preset-env": "7.2.0",
     "@babel/preset-react": "7.0.0",
     "@cypress/webpack-preprocessor": "4.0.2",
-    "@reactivex/ix-esnext-esm": "2.5.0",
+    "@reactivex/ix-esnext-esm": "2.3.5",
     "@types/autoprefixer": "9.1.1",
     "@types/jest": "23.3.12",
     "@types/react": "16.7.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,13 +2216,11 @@
   dependencies:
     tslib "^1.8.0"
 
-"@reactivex/ix-esnext-esm@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@reactivex/ix-esnext-esm/-/ix-esnext-esm-2.5.0.tgz#9716a26fc223b2a18e7e0216901d846be78affd6"
+"@reactivex/ix-esnext-esm@2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@reactivex/ix-esnext-esm/-/ix-esnext-esm-2.3.5.tgz#c62389c6212385ecff152ae2bb0b86dfb47e1988"
   dependencies:
-    "@types/node" "^10.12.18"
-    is-stream "1.1.0"
-    tslib "^1.9.3"
+    tslib "^1.8.0"
 
 "@render-props/events@^0.1.2":
   version "0.1.9"
@@ -2810,10 +2808,6 @@
 "@types/node@*", "@types/node@^10.1.0":
   version "10.12.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
-
-"@types/node@^10.12.18":
-  version "10.12.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
 
 "@types/node@^9.4.6":
   version "9.6.39"
@@ -10415,7 +10409,7 @@ is-stream-ended@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
 
-is-stream@1.1.0, is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -16505,12 +16499,6 @@ rxjs-tslint-rules@4.14.3:
     resolve "^1.4.0"
     tslib "^1.8.0"
     tsutils "^3.0.0"
-
-rxjs@5.5.11:
-  version "5.5.11"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
-  dependencies:
-    symbol-observable "1.0.1"
 
 rxjs@6.3.3, rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"


### PR DESCRIPTION
### Description of the Change

Revert latest commit f4af6ee81ea8ca3904b4b46cd7086c98e6c6e794 the 2.5 update of `ix-esnext-esm` contains an issue that matches an open issue ReactiveX/IxJS has accepted onto their backlog. (1) This issue has been observed in releases after 2.3.5.

(1) https://github.com/ReactiveX/IxJS/issues/236

@ v = 2.3.5 our source does not produce these errors.
@ v > 2.3.5 we perform:

    # given
    const iterable = AsyncIterableX.from(this.enumerator as AsyncIterableIterator<Value>).pipe(map(({ value }) => ({ value })),
    );
      # result
      # error TS2339: Property 'pipe' does not exist on type 'AsyncIterableX<Value>'
      # error TS2339: Property 'type' does not exist on type '{}'.

### Test Plan
    yarn install
    yarn build

### Benefits
 build is no longer broken.

### Applicable Issues

* https://github.com/neo-one-suite/neo-one/pull/936
* https://github.com/neo-one-suite/neo-one/pull/904