### PR TITLE
fix(types): adjust 'scrypt-js' callback usage

### DIFF
--- a/packages/neo-one-client-common/src/crypto.ts
+++ b/packages/neo-one-client-common/src/crypto.ts
@@ -413,7 +413,7 @@ const getNEP2Derived = async ({
         if (error != undefined) {
           reject(error);
         } else if (key) {
-          resolve(Buffer.from(key));
+          resolve(Buffer.from([...key]));
         }
       },
     ),


### PR DESCRIPTION
### Description of the Change

I incorrectly reverted my own types to "fix" a lint issue, but I actually just made a mistake and the issue was our usage not the type definition. When that definition change is pushed this will fix it.

### Applicable Issues

The type PR is here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32447#pullrequestreview-196229199

Essentially typing it as `string` worked because the underlying js used the correct overload for `Buffer.from(...)` even though typescript said we were using the string overload.

I thought this was going to fail until the DT PR came in but that isn't the case so we could merge now and then the DT change won't affect anything.