### PR TITLE
fix(rpcServer): Update configuration for rateLimit and tooBusy

### DIFF
--- a/packages/neo-one-node-http-rpc/src/middleware/tooBusyCheck.ts
+++ b/packages/neo-one-node-http-rpc/src/middleware/tooBusyCheck.ts
@@ -8,15 +8,19 @@ export interface Options {
   readonly smoothingFactor?: number;
 }
 
-export const tooBusyCheck = (options: Options) => {
-  if (options.interval !== undefined) {
-    tooBusy.interval(options.interval);
-  }
-  if (options.maxLag !== undefined) {
-    tooBusy.maxLag(options.maxLag);
-  }
-  if (options.smoothingFactor !== undefined) {
-    tooBusy.smoothingFactor(options.smoothingFactor);
+tooBusy.maxLag(5000);
+
+export const tooBusyCheck = (options?: Options) => {
+  if (options !== undefined) {
+    if (options.interval !== undefined) {
+      tooBusy.interval(options.interval);
+    }
+    if (options.maxLag !== undefined) {
+      tooBusy.maxLag(options.maxLag);
+    }
+    if (options.smoothingFactor !== undefined) {
+      tooBusy.smoothingFactor(options.smoothingFactor);
+    }
   }
 
   return async (ctx: Context, next: () => Promise<void>) => {

--- a/packages/neo-one-node-http-rpc/src/rpcServer$.ts
+++ b/packages/neo-one-node-http-rpc/src/rpcServer$.ts
@@ -105,12 +105,12 @@ export const rpcServer$ = ({
         router.get(readyMiddleware.name, readyMiddleware.path, readyMiddleware.middleware);
       }
 
-      if (rateLimitOptions !== undefined && rateLimitOptions.enabled) {
-        router.use(rateLimit(rateLimitOptions));
+      if (rateLimitOptions === undefined || rateLimitOptions.enabled) {
+        router.use(rateLimit({ rate: 6000 }));
       }
 
-      if (tooBusyCheckOptions !== undefined && tooBusyCheckOptions.enabled) {
-        router.use(tooBusyCheck(tooBusyCheckOptions));
+      if (tooBusyCheckOptions === undefined || tooBusyCheckOptions.enabled) {
+        router.use(tooBusyCheck());
       }
 
       router.use(cors).post(rpcMiddleware.name, rpcMiddleware.path, rpcMiddleware.middleware);


### PR DESCRIPTION
### Requirements

   Fix rateLimit and tooBusy calls so as to allow for reasonable limits when running unit tests

### Description of the Change
Increased rateLimit
Added a static maxLag for tooBusy

### Test Plan
    yarn jest

### Possible Drawbacks
May introduce a delay in rpcServer calls 

### Applicable Issues
fix: #750, fix: #751
