### PR TITLE
chore(node): remove 'writeBytesPerSecond' backup field.

### DIFF
--- a/packages/neo-one-node-data-backup/src/provider/GCloudProvider.ts
+++ b/packages/neo-one-node-data-backup/src/provider/GCloudProvider.ts
@@ -12,7 +12,6 @@ export interface Options {
   readonly projectID: string;
   readonly bucket: string;
   readonly prefix: string;
-  readonly writeBytesPerSecond: number;
   readonly keepBackupCount?: number;
   readonly maxSizeBytes?: number;
 }
@@ -41,7 +40,7 @@ export class GCloudProvider extends Provider {
 
   public async restore(monitorIn: Monitor): Promise<void> {
     const monitor = monitorIn.at('gcloud_provider');
-    const { prefix, writeBytesPerSecond } = this.options;
+    const { prefix } = this.options;
     const { dataPath, tmpPath } = this.environment;
 
     const { time, files } = await this.getLatestTime();
@@ -65,7 +64,6 @@ export class GCloudProvider extends Provider {
           name: 'neo_restore_download',
         });
     }
-
     await Promise.all(
       fileAndPaths.map(async ({ filePath }) =>
         monitor.withData({ filePath }).captureSpanLog(
@@ -73,7 +71,6 @@ export class GCloudProvider extends Provider {
             extract({
               downloadPath: filePath,
               dataPath,
-              writeBytesPerSecond,
             }),
           { name: 'neo_restore_extract' },
         ),

--- a/packages/neo-one-node-data-backup/src/provider/MegaProvider.ts
+++ b/packages/neo-one-node-data-backup/src/provider/MegaProvider.ts
@@ -10,7 +10,6 @@ export interface Options {
   readonly download?: {
     readonly id: string;
     readonly key: string;
-    readonly writeBytesPerSecond: number;
   };
 
   readonly upload?: {
@@ -58,7 +57,7 @@ export class MegaProvider extends Provider {
       return;
     }
 
-    const { id, key, writeBytesPerSecond } = download;
+    const { id, key } = download;
     const { dataPath, tmpPath } = this.environment;
     const downloadPath = path.resolve(tmpPath, 'storage.db.tar.gz');
 
@@ -109,7 +108,6 @@ export class MegaProvider extends Provider {
         extract({
           downloadPath,
           dataPath,
-          writeBytesPerSecond,
         }),
       {
         name: 'neo_restore_extract',

--- a/packages/neo-one-node-data-backup/src/provider/extract.ts
+++ b/packages/neo-one-node-data-backup/src/provider/extract.ts
@@ -6,7 +6,6 @@ export const extract = async ({
 }: {
   readonly downloadPath: string;
   readonly dataPath: string;
-  readonly writeBytesPerSecond: number;
 }) => {
   await tar.extract({
     file: downloadPath,

--- a/packages/neo-one-server-plugin-network/src/commonBackupNode.ts
+++ b/packages/neo-one-server-plugin-network/src/commonBackupNode.ts
@@ -60,7 +60,6 @@ export const processArgs = async (
       projectID,
       bucket,
       prefix,
-      writeBytesPerSecond: 50000000,
     };
   } else {
     vorpal.activeCommand.log(`Unknown provider: ${provider}. Valid choices: "mega", "gcloud"`);


### PR DESCRIPTION
### Description of the Change

`writeBytesPerSecond` isn't required anymore, and if I'm going to be entering configs via arg inputs, I don't want this extra one hanging around.

### Benefits

It should have been gone already.
