### PR TITLE
chore(node): nit dockerfile adjustments.

### DIFF
--- a/scripts/DockerfileNode
+++ b/scripts/DockerfileNode
@@ -57,7 +57,7 @@ COPY packages/neo-one-node/package.json packages/neo-one-node/
 RUN sudo yarn install --non-interactive
 RUN yarn build:node
 
-FROM node:10-stretch-slim
-COPY --from=builder tmp/neo-one/dist/ /tmp/
-WORKDIR /tmp/neo-one
-ENTRYPOINT ["node", "packages/neo-one-node-bin/bin/neo-one-node"]
+FROM node:10-stretch-slim AS production
+RUN mkdir -p neo-one
+COPY --from=builder tmp/neo-one/dist/neo-one/ neo-one/
+ENTRYPOINT ["node", "neo-one/packages/neo-one-node-bin/bin/neo-one-node"]


### PR DESCRIPTION
### Description of the Change

cleanup some things in the node Dockerfile. Also copy less to the final stage, making the final image smaller.

Also, I mark the second stage of the multi-stage build. Apparently some processes can use that 🤷‍♂️ 

### Benefits
using:
```
COPY --from=builder tmp/neo-one/dist/neo-one/ neo-one/
```
instead of just copying all of `dist` should save some space which is fun :)