### PR TITLE
feat(node): add $PORT as a default for the rpc server

### DIFF
--- a/packages/neo-one-node-bin/src/utils/getConfiguration.ts
+++ b/packages/neo-one-node-bin/src/utils/getConfiguration.ts
@@ -33,7 +33,7 @@ const DEFAULT_CONFIG = {
     dataPath: envPaths('neo_one_node', { suffix: false }).data,
     rpc: {
       http: {
-        port: 8080,
+        port: process.env.PORT !== undefined ? process.env.PORT : 8080,
         host: 'localhost',
       },
     },


### PR DESCRIPTION
### Description of the Change

Lets the node default the PORT environment variable to its `rpc.http.port` value. Necessary for Heroku deploys.

### Benefits

Heroku deploys
