### PR TITLE
fix(token): rename Token to NEP5Token

### DIFF
--- a/packages/neo-one-server-plugin-wallet/src/contracts/SimpleToken.ts
+++ b/packages/neo-one-server-plugin-wallet/src/contracts/SimpleToken.ts
@@ -1,7 +1,7 @@
 import { Address, Fixed, SmartContract } from '@neo-one/smart-contract';
-import { Token } from '@neo-one/smart-contract-lib';
+import { NEP5Token } from '@neo-one/smart-contract-lib';
 
-export abstract class SimpleToken extends Token(SmartContract) {
+export abstract class SimpleToken extends NEP5Token(SmartContract) {
   public readonly owner: Address;
   public readonly decimals: 8 = 8;
 

--- a/packages/neo-one-smart-contract-lib/src/NEP5Token.ts
+++ b/packages/neo-one-smart-contract-lib/src/NEP5Token.ts
@@ -14,8 +14,8 @@ interface TokenPayableContract {
   readonly onRevokeSendTransfer: (from: Address, amount: Fixed<0>, asset: Address) => void;
 }
 
-export function Token<TBase extends Constructor<SmartContract>>(Base: TBase) {
-  abstract class TokenClass extends Base {
+export function NEP5Token<TBase extends Constructor<SmartContract>>(Base: TBase) {
+  abstract class NEP5TokenClass extends Base {
     public abstract readonly name: string;
     public abstract readonly decimals: 8;
     public abstract readonly symbol: string;
@@ -167,5 +167,5 @@ export function Token<TBase extends Constructor<SmartContract>>(Base: TBase) {
     }
   }
 
-  return TokenClass;
+  return NEP5TokenClass;
 }

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/SimpleToken.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/SimpleToken.ts
@@ -1,8 +1,8 @@
 import { Address, Fixed, SmartContract } from '@neo-one/smart-contract';
 // tslint:disable-next-line no-implicit-dependencies
-import { Token } from '@neo-one/smart-contract-lib';
+import { NEP5Token } from '@neo-one/smart-contract-lib';
 
-export abstract class SimpleToken extends Token(SmartContract) {
+export abstract class SimpleToken extends NEP5Token(SmartContract) {
   public readonly owner: Address;
   public readonly decimals: 8 = 8;
 

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestICO.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestICO.ts
@@ -1,8 +1,8 @@
 import { Address, Fixed, Integer, SmartContract } from '@neo-one/smart-contract';
 import { ICO } from '../../ICO';
-import { Token } from '../../Token';
+import { NEP5Token } from '../../NEP5Token';
 
-export class TestICO extends ICO(Token(SmartContract)) {
+export class TestICO extends ICO(NEP5Token(SmartContract)) {
   public readonly name: string = 'TestToken';
   public readonly decimals: 8 = 8;
   public readonly symbol: string = 'TT';

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestToken.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestToken.ts
@@ -1,8 +1,8 @@
 import { Address, SmartContract } from '@neo-one/smart-contract';
 // tslint:disable-next-line no-implicit-dependencies
-import { Token } from '@neo-one/smart-contract-lib';
+import { NEP5Token } from '@neo-one/smart-contract-lib';
 
-export class TestToken extends Token(SmartContract) {
+export class TestToken extends NEP5Token(SmartContract) {
   public readonly owner: Address;
   public readonly name: string = 'TestToken';
   public readonly decimals: 8 = 8;

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,2 +1,2 @@
 // tslint:disable-next-line export-name
-export { Token } from './Token';
+export { NEP5Token } from './NEP5Token';


### PR DESCRIPTION
To allow users to readily identify they are creating a NEP5-Token, the name of the base class will be renamed from Token to NEP5Token.