### PR TITLE
feat(contract-mixins): add TransferableContract

### DIFF
--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestTransferableContract.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestTransferableContract.ts
@@ -1,0 +1,12 @@
+import { Address, SmartContract } from '@neo-one/smart-contract';
+// tslint:disable-next-line no-implicit-dependencies
+import { TransferableOwnership } from '@neo-one/smart-contract-lib';
+
+export class TransferableContract extends TransferableOwnership(SmartContract) {
+  protected mutableOwner: Address;
+
+  public constructor(owner: Address) {
+    super();
+    this.mutableOwner = owner;
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__tests__/TestTransferableOwnership.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/TestTransferableOwnership.test.ts
@@ -1,0 +1,105 @@
+import { common, crypto } from '@neo-one/client-common';
+import { SmartContractAny } from '@neo-one/client-core';
+import { withContracts } from '@neo-one/smart-contract-test';
+import * as path from 'path';
+
+const RECIPIENT = {
+  PRIVATE_KEY: '9c111f04a34b3a07600fe701d308dce6e20c86268c105f21c2f30e9fef7e7968',
+  PUBLIC_KEY: '027f73dbc47133b08a4bc0fc04589fc76525baaf3bebe71bdd78053d559c41db70',
+};
+
+describe('TestTransferableOwnership', () => {
+  test('deploy + transfer', async () => {
+    await withContracts<{ testTransferableContract: SmartContractAny }>(
+      [
+        {
+          filePath: path.resolve(__dirname, '..', '__data__', 'contracts', 'TestTransferableContract.ts'),
+          name: 'TestTransferableContract',
+        },
+      ],
+      async ({ client, networkName, testTransferableContract: smartContract, masterAccountID }) => {
+        crypto.addPublicKey(
+          common.stringToPrivateKey(RECIPIENT.PRIVATE_KEY),
+          common.stringToECPoint(RECIPIENT.PUBLIC_KEY),
+        );
+
+        const deployResult = await smartContract.deploy(masterAccountID.address, { from: masterAccountID });
+
+        const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
+        if (deployReceipt.result.state !== 'HALT') {
+          throw new Error(deployReceipt.result.message);
+        }
+
+        expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
+        expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
+        expect(deployReceipt.result.value).toBeTruthy();
+
+        const [origOwnerResult, recipient] = await Promise.all([
+          smartContract.owner(),
+
+          client.providers.memory.keystore.addUserAccount({
+            network: networkName,
+            name: 'recipient',
+            privateKey: RECIPIENT.PRIVATE_KEY,
+          }),
+        ]);
+
+        expect(origOwnerResult.toString()).toEqual(masterAccountID.address);
+
+        const firstTransferResult = await smartContract.transferContract(
+          recipient.userAccount.id.address,
+
+          { from: masterAccountID },
+        );
+
+        const firstTransferReceipt = await firstTransferResult.confirmed({ timeoutMS: 2500 });
+        if (firstTransferReceipt.result.state !== 'HALT') {
+          throw new Error(firstTransferReceipt.result.message);
+        }
+        expect(firstTransferReceipt.events).toHaveLength(1);
+        const initEvent = firstTransferReceipt.events[0];
+        expect(initEvent.name).toEqual('contract ownership transfer initiated');
+        const initOwnerResult = await smartContract.owner();
+        expect(initOwnerResult.toString()).toEqual(masterAccountID.address);
+
+        const canceledOwnerResult = await smartContract.transferContract(
+          masterAccountID.address,
+
+          { from: masterAccountID },
+        );
+        const canceledOwnerReceipt = await canceledOwnerResult.confirmed({ timeoutMS: 2500 });
+        expect(canceledOwnerReceipt.events).toHaveLength(1);
+        const cancelEvent = canceledOwnerReceipt.events[0];
+        expect(cancelEvent.name).toEqual('contract ownership transfer canceled');
+        const cancelOwnerResult = await smartContract.owner();
+        expect(cancelOwnerResult.toString()).toEqual(masterAccountID.address);
+
+        const bogusClaimResult = await smartContract.transferContract(recipient.userAccount.id.address, {
+          from: recipient.userAccount.id,
+        });
+        const bogusClaimReceipt = await bogusClaimResult.confirmed({ timeoutMS: 2500 });
+        expect(bogusClaimReceipt.value).toBeFalsy();
+
+        const init2TransferResult = await smartContract.transferContract(recipient.userAccount.id.address, {
+          from: masterAccountID,
+        });
+        const init2TransferReceipt = await init2TransferResult.confirmed({ timeoutMS: 2500 });
+        expect(init2TransferReceipt.events).toHaveLength(1);
+        const init2Event = init2TransferReceipt.events[0];
+        expect(init2Event.name).toEqual('contract ownership transfer initiated');
+
+        const finalizeTransferResult = await smartContract.transferContract(recipient.userAccount.id.address, {
+          from: recipient.userAccount.id,
+        });
+        const finalizeTransferReceipt = await finalizeTransferResult.confirmed({ timeoutMS: 2500 });
+        expect(finalizeTransferReceipt.events).toHaveLength(1);
+        const finalEvent = finalizeTransferReceipt.events[0];
+        expect(finalEvent.name).toEqual('contract ownership transfer');
+
+        const finalOwnerResult = await smartContract.owner();
+        expect(finalOwnerResult.toString()).toEqual(recipient.userAccount.id.address);
+      },
+      { deploy: false },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestTransferableOwnership.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestTransferableOwnership.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestTransferableOwnership deploy + transfer: deploy consumed 1`] = `"0"`;
+
+exports[`TestTransferableOwnership deploy + transfer: deploy cost 1`] = `"1.173"`;

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,3 +1,4 @@
 // tslint:disable-next-line export-name
 export { NEP5Token } from './NEP5Token';
 export { DesignatedCaller } from './ownership/DesignatedCaller';
+export { TransferableOwnership } from './ownership/TransferableOwnership';

--- a/packages/neo-one-smart-contract-lib/src/ownership/TransferableOwnership.ts
+++ b/packages/neo-one-smart-contract-lib/src/ownership/TransferableOwnership.ts
@@ -1,0 +1,76 @@
+import { Address, constant, createEventNotifier, SmartContract } from '@neo-one/smart-contract';
+
+/**
+ * @title Transferable
+ * @dev A TransferableOwnership contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+
+export function TransferableOwnership<TBase extends Constructor<SmartContract>>(Base: TBase) {
+  abstract class TransferableOwnershipClass extends Base {
+    protected abstract mutableOwner: Address;
+    private mutableTransferTo: Address | undefined;
+
+    @constant
+    public get owner(): Address {
+      return this.mutableOwner;
+    }
+
+    /* tslint:disable-next-line: variable-name */
+    private readonly transfer_initiated = createEventNotifier<Address, Address>(
+      'contract ownership transfer initiated',
+      'from',
+      'to',
+    );
+
+    /* tslint:disable-next-line: variable-name */
+    private readonly transfer_canceled = createEventNotifier<Address, Address>(
+      'contract ownership transfer canceled',
+      'from',
+      'to',
+    );
+
+    private readonly transferred = createEventNotifier<Address, Address>('contract ownership transfer', 'from', 'to');
+
+    public transferContract(to: Address): boolean {
+      if (Address.isCaller(this.owner)) {
+        if (this.owner === to) {
+          return this.cancelTransfer();
+        }
+
+        return this.initiateTransfer(to);
+      }
+
+      if (Address.isCaller(to) && this.mutableTransferTo === to) {
+        return this.claimContract(to);
+      }
+
+      return false;
+    }
+
+    private claimContract(to: Address) {
+      this.transferred(this.owner, to);
+      this.mutableOwner = to;
+
+      return true;
+    }
+
+    private initiateTransfer(to: Address) {
+      this.transfer_initiated(this.owner, to);
+      this.mutableTransferTo = to;
+
+      return true;
+    }
+
+    private cancelTransfer() {
+      if (this.mutableTransferTo !== undefined) {
+        this.transfer_canceled(this.owner, this.mutableTransferTo);
+        this.mutableTransferTo = undefined;
+      }
+
+      return true;
+    }
+  }
+
+  return TransferableOwnershipClass;
+}


### PR DESCRIPTION
Branched off https://github.com/neo-one-suite/neo-one/pull/1054 NEP5 Token Rename 

### Description of the Change
Introduce a SmartContract Mix-in that provides basic "transferable contract" functionality with a suite of tests.  

### Test Plan
Run the included test suite:

     yarn jest packages/neo-one-smart-contract-lib/src/__tests__/TestTransferableOwnership.test.ts
