### PR TITLE
feat(browser compatibility): Generate a browser-compatible bundle for expo

### DIFF
--- a/packages/neo-one-client-core/src/provider/NEOONEOneDataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEOneDataProvider.ts
@@ -36,6 +36,7 @@ export interface NEOONEOneDataProviderOptions {
   readonly network: NetworkType;
   readonly projectID: string;
   readonly port: number;
+  readonly host?: string;
   readonly iterBlocksFetchTimeoutMS?: number;
   readonly iterBlocksBatchSize?: number;
 }
@@ -48,14 +49,16 @@ export class NEOONEOneDataProvider implements DeveloperProvider {
   private mutableProvider: NEOONEDataProvider | undefined;
   private readonly projectID: string;
   private readonly port: number;
+  private readonly host: string;
   private readonly iterBlocksFetchTimeoutMS: number | undefined;
   private readonly iterBlocksBatchSize: number | undefined;
 
   public constructor(options: NEOONEOneDataProviderOptions) {
-    const { network, projectID, port, iterBlocksFetchTimeoutMS, iterBlocksBatchSize } = options;
+    const { network, projectID, port, host = 'localhost', iterBlocksFetchTimeoutMS, iterBlocksBatchSize } = options;
     this.network = network;
     this.projectID = projectID;
     this.port = port;
+    this.host = host;
     this.iterBlocksFetchTimeoutMS = iterBlocksFetchTimeoutMS;
     this.iterBlocksBatchSize = iterBlocksBatchSize;
   }
@@ -235,14 +238,14 @@ export class NEOONEOneDataProvider implements DeveloperProvider {
   private async getProvider(): Promise<NEOONEDataProvider> {
     /* istanbul ignore next */
     if (this.mutableProvider === undefined) {
-      const client = new OneClient(this.port);
+      const client = new OneClient(this.port, this.host);
       const result = await client.request({
         plugin: '@neo-one/server-plugin-project',
         options: { type: 'network', projectID: this.projectID },
       });
       this.mutableProvider = new NEOONEDataProvider({
         network: this.network,
-        rpcURL: result.response.nodes[0].rpcAddress,
+        rpcURL: result.response.nodes[0].rpcAddress.replace('localhost', this.host),
         iterBlocksFetchTimeoutMS: this.iterBlocksFetchTimeoutMS,
         iterBlocksBatchSize: this.iterBlocksBatchSize,
       });

--- a/packages/neo-one-local-browser/src/build/build.ts
+++ b/packages/neo-one-local-browser/src/build/build.ts
@@ -125,6 +125,7 @@ export const build = async ({ fs, output$, providerManager }: BuildOptions): Pro
       createContractPath,
       abi: contractResult.abi,
       sourceMapsPath,
+      browser: false,
     });
 
     mutableFiles.push({ path: typesPath, content: typesContents.ts });
@@ -165,6 +166,7 @@ export const build = async ({ fs, output$, providerManager }: BuildOptions): Pro
     ].concat(wallets),
     networks: [],
     sourceMaps: mutableSourceMaps,
+    framework: 'react',
   });
 
   mutableFiles.push({ path: sourceMapsPath, content: sourceMapsContents.ts });

--- a/packages/neo-one-server-http-client/src/Client.ts
+++ b/packages/neo-one-server-http-client/src/Client.ts
@@ -17,9 +17,11 @@ interface RPCResult {
  */
 export class Client {
   private readonly port: number;
+  private readonly host: string;
 
-  public constructor(port: number) {
+  public constructor(port: number, host = 'localhost') {
     this.port = port;
+    this.host = host;
   }
 
   public async ready(): Promise<RPCResult> {
@@ -52,7 +54,7 @@ export class Client {
     const headers = {
       'Content-Type': 'application/json',
     };
-    const response = await fetch(`http://localhost:${this.port}/rpc`, {
+    const response = await fetch(`http://${this.host}:${this.port}/rpc`, {
       method: 'POST',
       headers,
       body: JSON.stringify(req),

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/client.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/client.ts
@@ -1,4 +1,4 @@
-/* @hash 98e1e69893a8b020e8f4bd487802298e */
+/* @hash 2cffd3ebf9b7be6cb6ac23ba20980064 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -32,19 +32,28 @@ const isLocalUserAccountProvider = (
 ): userAccountProvider is LocalUserAccountProvider<any, any> => userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = <TUserAccountProviders extends UserAccountProviders<any> = DefaultUserAccountProviders>(
-  getUserAccountProviders: (provider: NEOONEProvider) => TUserAccountProviders = getDefaultUserAccountProviders as any,
+  getUserAccountProvidersOrHost?: string | ((provider: NEOONEProvider) => TUserAccountProviders),
 ): Client<
   TUserAccountProviders extends UserAccountProviders<infer TUserAccountProvider> ? TUserAccountProvider : never,
   TUserAccountProviders
 > => {
+  let getUserAccountProviders = getDefaultUserAccountProviders as any;
+  let host = 'localhost';
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers: Array<NEOONEOneDataProvider | NEOONEDataProviderOptions> = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 13319 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 46625 }));
   }
   const provider = new NEOONEProvider(providers);
 
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.keys(userAccountProviders)
+    .map((key) => userAccountProviders[key])
+    .filter(isLocalUserAccountProvider);
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
@@ -118,12 +127,12 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
   return new Client(userAccountProviders);
 };
 
-export const createDeveloperClients = (): { [network: string]: DeveloperClient } => ({
-  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 13319 })),
+export const createDeveloperClients = (host = 'localhost'): { [network: string]: DeveloperClient } => ({
+  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 46625 })),
 });
 
-export const createLocalClients = (): { [network: string]: LocalClient } => {
-  const client = new OneClient(13319);
+export const createLocalClients = (host = 'localhost'): { [network: string]: LocalClient } => {
+  const client = new OneClient(46625, host);
   return {
     local: {
       getNEOTrackerURL: async () => {

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/index.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/index.ts
@@ -1,8 +1,7 @@
-/* @hash e0e6ef59fb1a5e0fe367c68eff29ebb1 */
+/* @hash 85a13698b2c418e37ce9d9084abfc00e */
 // tslint:disable
 /* eslint-disable */
 export * from './types';
-export * from './react';
 export * from './client';
 export * from './Escrow/contract';
 export * from './Escrow/types';

--- a/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/sourceMaps.ts
+++ b/packages/neo-one-server-plugin-project/src/__data__/ico/one/generated/sourceMaps.ts
@@ -1,14 +1,14 @@
-/* @hash d903d85dfe21b9da3359234d9c393437 */
+/* @hash 1560bad57ccb9cd8c8cd162998bfca83 */
 // tslint:disable
 /* eslint-disable */
-/* @source-map-hash ce0712dd5ed0e0059fefadc69473ac47 */
+/* @source-map-hash 0a21b7cbb0e3b872db7c6c36b44a5697 */
 import { OneClient, SourceMaps } from '@neo-one/client';
 import { projectID } from './projectID';
 
 let sourceMapsIn: Promise<SourceMaps> = Promise.resolve({});
 if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
   sourceMapsIn = Promise.resolve().then(async () => {
-    const client = new OneClient(13319);
+    const client = new OneClient(46625);
     const result = await client.request({
       plugin: '@neo-one/server-plugin-project',
       options: { type: 'sourceMaps', projectID },

--- a/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/client.js
+++ b/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/client.js
@@ -1,4 +1,4 @@
-/* @hash 06d52bc52c2cd8b862d9eef6ad59ed35 */
+/* @hash 86ce2b8c3944a3a575f113b01392ccd3 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -22,10 +22,17 @@ const getDefaultUserAccountProviders = (provider) => ({
 
 const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
-export const createClient = (getUserAccountProviders = getDefaultUserAccountProviders) => {
+export const createClient = (getUserAccountProvidersOrHost) => {
+  let getUserAccountProviders = getDefaultUserAccountProviders;
+  let host = 'localhost';
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 31804 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 43987 }));
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -103,12 +110,12 @@ export const createClient = (getUserAccountProviders = getDefaultUserAccountProv
   return new Client(userAccountProviders);
 };
 
-export const createDeveloperClients = () => ({
-  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 31804 })),
+export const createDeveloperClients = (host = 'localhost') => ({
+  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 43987 })),
 });
 
-export const createLocalClients = () => {
-  const client = new OneClient(31804);
+export const createLocalClients = (host = 'localhost') => {
+  const client = new OneClient(43987, host);
   return {
     local: {
       getNEOTrackerURL: async () => {

--- a/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/index.js
+++ b/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/index.js
@@ -1,7 +1,6 @@
-/* @hash c5c6dd8ea4b4e673054a086812313d0e */
+/* @hash d697750fbbadc746847f28f1bfea9ec6 */
 // tslint:disable
 /* eslint-disable */
-export * from './react';
 export * from './client';
 export * from './Escrow/contract';
 export * from './Escrow/abi';

--- a/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/sourceMaps.js
+++ b/packages/neo-one-server-plugin-project/src/__data__/icojs/one/generated/sourceMaps.js
@@ -1,7 +1,7 @@
-/* @hash de3c1d5897ec0df57f54f9ebe1874335 */
+/* @hash 6e6420d58bfda29c46d8be62f51891e8 */
 // tslint:disable
 /* eslint-disable */
-/* @source-map-hash 32e0931b0fbfae6bbcd23bc02c2be884 */
+/* @source-map-hash c157903e3f7668726aad17f0d09d154c */
 import { OneClient } from '@neo-one/client';
 import { projectID } from './projectID';
 
@@ -9,7 +9,7 @@ let sourceMapsIn = Promise.resolve({});
 
 if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
   sourceMapsIn = Promise.resolve().then(async () => {
-    const client = new OneClient(31804);
+    const client = new OneClient(43987);
     const result = await client.request({
       plugin: '@neo-one/server-plugin-project',
       options: { type: 'sourceMaps', projectID },

--- a/packages/neo-one-server-plugin-project/src/build/generateCode.ts
+++ b/packages/neo-one-server-plugin-project/src/build/generateCode.ts
@@ -16,6 +16,7 @@ export const generateCode = async (
     readonly sourceMap: RawSourceMap;
   },
   networksDefinition: SmartContractNetworksDefinition,
+  browser: boolean,
 ) => {
   const base = path.resolve(project.paths.generated, contractResult.name);
   const sourceMapsPath = getCommonPaths(project).sourceMapsPath;
@@ -29,6 +30,7 @@ export const generateCode = async (
     createContractPath,
     abi: contractResult.abi,
     sourceMapsPath,
+    browser,
   });
 
   await fs.ensureDir(base);

--- a/packages/neo-one-server-plugin-project/src/build/generateCommonCode.ts
+++ b/packages/neo-one-server-plugin-project/src/build/generateCommonCode.ts
@@ -19,6 +19,7 @@ export const generateCommonCode = async (
   networks: ReadonlyArray<NetworkDefinition>,
   httpServerPort: number,
   sourceMapsIn: SourceMaps,
+  browser: boolean,
 ) => {
   const contractsPaths = contracts.map(({ name, filePath, sourceMap, addresses }) => ({
     ...getContractPaths(project, { name, filePath }),
@@ -65,6 +66,8 @@ export const generateCommonCode = async (
     projectIDPath,
     sourceMapsPath,
     sourceMaps: sourceMapsIn,
+    framework: project.codegen.framework,
+    browser,
   });
 
   await fs.ensureDir(project.paths.generated);

--- a/packages/neo-one-server-plugin-project/src/build/index.ts
+++ b/packages/neo-one-server-plugin-project/src/build/index.ts
@@ -317,13 +317,14 @@ export const build = (
                           const project = getProjectConfig(ctx);
                           const networksDefinition = getSmartContractNetworksDefinitions(ctx)[contract.name];
 
-                          await generateCode(project, contract, networksDefinition);
+                          await generateCode(project, contract, networksDefinition, project.codegen.browser);
                         },
                       }))
                       .concat([
                         {
                           title: 'Generate common code',
                           task: async () => {
+                            const project = getProjectConfig(ctx);
                             await generateCommonCode(
                               getProjectConfig(ctx),
                               getProjectID(ctx),
@@ -339,6 +340,7 @@ export const build = (
                               getNetworkDefinitions(ctx),
                               pluginManager.httpServerPort,
                               getSourceMaps(ctx),
+                              project.codegen.browser,
                             );
                           },
                         },

--- a/packages/neo-one-server-plugin-project/src/types.ts
+++ b/packages/neo-one-server-plugin-project/src/types.ts
@@ -1,3 +1,4 @@
+import { CodegenFramework } from '@neo-one/smart-contract-codegen';
 import convict from 'convict';
 import * as path from 'path';
 
@@ -32,7 +33,6 @@ export interface NEOTrackerRequestOptions {
 export type RequestOptions = NetworkRequestOptions | SourceMapsRequestOptions | NEOTrackerRequestOptions;
 
 export type CodegenLanguage = 'typescript' | 'javascript';
-export type CodegenFramework = 'none' | 'react' | 'angular' | 'vue';
 export interface ProjectConfig {
   readonly paths: {
     readonly contracts: string;
@@ -41,6 +41,7 @@ export interface ProjectConfig {
   readonly codegen: {
     readonly language: CodegenLanguage;
     readonly framework: CodegenFramework;
+    readonly browser: boolean;
   };
 }
 
@@ -63,6 +64,10 @@ export const projectConfigSchema: convict.Schema<ProjectConfig> = {
     framework: {
       format: ['none', 'react', 'angular', 'vue'],
       default: 'none',
+    },
+    browser: {
+      format: Boolean,
+      default: false,
     },
   },
 };

--- a/packages/neo-one-smart-contract-codegen/src/__data__/testUtils.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__data__/testUtils.ts
@@ -5,7 +5,7 @@ const testABI = (abi: ABI, name: string) => {
   test(name, () => {
     expect({
       inputABI: abi,
-      types: genSmartContractTypes(name, abi),
+      types: genSmartContractTypes(name, abi, false),
     }).toMatchSnapshot();
   });
 };

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonBrowserFiles.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonBrowserFiles.test.ts.snap
@@ -23,6 +23,12 @@ export class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 ",
     "ts": "// tslint:disable
@@ -58,6 +64,12 @@ export class ContractsService {
     this.localClients = createLocalClients();
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
+  }
+
+  public setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
 ",
@@ -216,8 +228,6 @@ export interface Contracts {
     "js": "// tslint:disable
 /* eslint-disable */
 export * from './react';
-export * from './angular.service';
-export * from './vue';
 export * from './client';
 export * from './Token/contract';
 export * from './Token/abi';
@@ -228,8 +238,6 @@ export * from './ICO/abi';
 /* eslint-disable */
 export * from './types';
 export * from './react';
-export * from './angular.service';
-export * from './vue';
 export * from './client';
 export * from './Token/contract';
 export * from './Token/types';
@@ -254,11 +262,12 @@ export const ContractsProvider = ({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -296,6 +305,7 @@ export interface WithClients<TClient extends Client> {
   readonly localClients: {
     readonly [network: string]: LocalClient;
   };
+  readonly host?: string;
 }
 export type ContractsWithClients<TClient extends Client> = Contracts & WithClients<TClient>;
 const Context: any = React.createContext<ContractsWithClients<Client>>(undefined as any);
@@ -307,11 +317,12 @@ export const ContractsProvider = <TClient extends Client>({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }: ContractsProviderProps<TClient>) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -417,6 +428,12 @@ class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 
 export const contractsService = new ContractsService();
@@ -450,6 +467,12 @@ class ContractsService {
     this.localClients = createLocalClients();
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
+  }
+
+  public setHost(host: string) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
 

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
@@ -23,6 +23,12 @@ export class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 ",
     "ts": "// tslint:disable
@@ -59,6 +65,12 @@ export class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  public setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 ",
   },
@@ -86,10 +98,17 @@ const getDefaultUserAccountProviders = (provider) => ({
 
 const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
-export const createClient = (getUserAccountProviders = getDefaultUserAccountProviders) => {
+export const createClient = (getUserAccountProvidersOrHost) => {
+  let getUserAccountProviders = getDefaultUserAccountProviders;
+  let host = 'localhost';
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 }));
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -117,12 +136,12 @@ export const createClient = (getUserAccountProviders = getDefaultUserAccountProv
   return new Client(userAccountProviders);
 };
 
-export const createDeveloperClients = () => ({
-  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 })),
+export const createDeveloperClients = (host = 'localhost') => ({
+  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 })),
 });
 
-export const createLocalClients = () => {
-  const client = new OneClient(40100);
+export const createLocalClients = (host = 'localhost') => {
+  const client = new OneClient(40100, host);
   return {
     local: {
       getNEOTrackerURL: async () => {
@@ -179,14 +198,21 @@ const isLocalUserAccountProvider = (
 ): userAccountProvider is LocalUserAccountProvider<any, any> => userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = <TUserAccountProviders extends UserAccountProviders<any> = DefaultUserAccountProviders>(
-  getUserAccountProviders: (provider: NEOONEProvider) => TUserAccountProviders = getDefaultUserAccountProviders as any,
+  getUserAccountProvidersOrHost?: string | ((provider: NEOONEProvider) => TUserAccountProviders),
 ): Client<
   TUserAccountProviders extends UserAccountProviders<infer TUserAccountProvider> ? TUserAccountProvider : never,
   TUserAccountProviders
 > => {
+  let getUserAccountProviders = getDefaultUserAccountProviders as any;
+  let host = 'localhost';
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers: Array<NEOONEOneDataProvider | NEOONEDataProviderOptions> = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 }));
   }
   const provider = new NEOONEProvider(providers);
 
@@ -217,12 +243,12 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
   return new Client(userAccountProviders);
 };
 
-export const createDeveloperClients = (): { [network: string]: DeveloperClient } => ({
-  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 })),
+export const createDeveloperClients = (host = 'localhost'): { [network: string]: DeveloperClient } => ({
+  local: new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 })),
 });
 
-export const createLocalClients = (): { [network: string]: LocalClient } => {
-  const client = new OneClient(40100);
+export const createLocalClients = (host = 'localhost'): { [network: string]: LocalClient } => {
+  const client = new OneClient(40100, host);
   return {
     local: {
       getNEOTrackerURL: async () => {
@@ -263,8 +289,6 @@ export interface Contracts {
   "generated": Object {
     "js": "// tslint:disable
 /* eslint-disable */
-export * from './react';
-export * from './angular.service';
 export * from './vue';
 export * from './client';
 export * from './Token/contract';
@@ -275,8 +299,6 @@ export * from './ICO/abi';
     "ts": "// tslint:disable
 /* eslint-disable */
 export * from './types';
-export * from './react';
-export * from './angular.service';
 export * from './vue';
 export * from './client';
 export * from './Token/contract';
@@ -320,11 +342,12 @@ export const ContractsProvider = ({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -362,6 +385,7 @@ export interface WithClients<TClient extends Client> {
   readonly localClients: {
     readonly [network: string]: LocalClient;
   };
+  readonly host?: string;
 }
 export type ContractsWithClients<TClient extends Client> = Contracts & WithClients<TClient>;
 const Context: any = React.createContext<ContractsWithClients<Client>>(undefined as any);
@@ -373,11 +397,12 @@ export const ContractsProvider = <TClient extends Client>({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }: ContractsProviderProps<TClient>) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -501,6 +526,12 @@ class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 
 export const contractsService = new ContractsService();
@@ -534,6 +565,12 @@ class ContractsService {
     this.localClients = createLocalClients();
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
+  }
+
+  public setHost(host: string) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
 

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/abi/genABI.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/abi/genABI.test.ts
@@ -3,6 +3,6 @@ import { genABI } from '../../abi';
 
 describe('genABI', () => {
   test('NEP5', () => {
-    expect(genABI('Token', nep5.abi(4))).toMatchSnapshot();
+    expect(genABI('Token', nep5.abi(4), false)).toMatchSnapshot();
   });
 });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/angular/__snapshots__/genAngular.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/angular/__snapshots__/genAngular.test.ts.snap
@@ -21,6 +21,12 @@ export class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
     ",
   "ts": "
@@ -55,6 +61,12 @@ export class ContractsService {
     this.localClients = createLocalClients();
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
+  }
+
+  public setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
   ",

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/angular/genAngular.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/angular/genAngular.test.ts
@@ -9,6 +9,7 @@ describe('genAngular', () => {
         commonTypesPath: '/foo/bar/one/generated/types.js',
         angularPath: '/foo/bar/one/generated/angular.service.js',
         clientPath: '/foo/bar/one/generated/client.js',
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genClient.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genClient.test.ts.snap
@@ -16,12 +16,19 @@ const getDefaultUserAccountProviders = (provider) => ({
 const isLocalUserAccountProvider = (userAccountProvider) =>
   userAccountProvider instanceof LocalUserAccountProvider;
 
-export const createClient = (getUserAccountProviders = getDefaultUserAccountProviders) => {
+export const createClient = (getUserAccountProvidersOrHost) => {
+  let getUserAccountProviders = getDefaultUserAccountProviders;
+  let host = 'localhost'
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers = [
     
   ];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 }));
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -45,12 +52,12 @@ export const createClient = (getUserAccountProviders = getDefaultUserAccountProv
   return new Client(userAccountProviders);
 };
 
-export const createDeveloperClients = () => ({
-  'local': new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 })),
+export const createDeveloperClients = (host = 'localhost') => ({
+  'local': new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 })),
 });
 
-export const createLocalClients = () => {
-  const client = new OneClient(40100);
+export const createLocalClients = (host = 'localhost') => {
+  const client = new OneClient(40100, host);
   return {
     'local': {
       getNEOTrackerURL: async () => {
@@ -92,13 +99,20 @@ const isLocalUserAccountProvider = (userAccountProvider: UserAccountProvider): u
   userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = <TUserAccountProviders extends UserAccountProviders<any> = DefaultUserAccountProviders>(
-  getUserAccountProviders: (provider: NEOONEProvider) => TUserAccountProviders = getDefaultUserAccountProviders as any,
+  getUserAccountProvidersOrHost?: string | ((provider: NEOONEProvider) => TUserAccountProviders),
 ): Client<TUserAccountProviders extends UserAccountProviders<infer TUserAccountProvider> ? TUserAccountProvider : never, TUserAccountProviders> => {
+  let getUserAccountProviders = getDefaultUserAccountProviders as any;
+  let host = 'localhost'
+  if (typeof getUserAccountProvidersOrHost === 'string') {
+    host = getUserAccountProvidersOrHost;
+  } else if (getUserAccountProvidersOrHost !== undefined) {
+    getUserAccountProviders = getUserAccountProvidersOrHost;
+  }
   const providers: Array<NEOONEOneDataProvider | NEOONEDataProviderOptions> = [
     
   ];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 }));
+    providers.push(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 }));
   }
   const provider = new NEOONEProvider(providers);
 
@@ -123,12 +137,12 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
   return new Client(userAccountProviders);
 }
 
-export const createDeveloperClients = (): { [network: string]: DeveloperClient } => ({
-  'local': new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, port: 40100 })),
+export const createDeveloperClients = (host = 'localhost'): { [network: string]: DeveloperClient } => ({
+  'local': new DeveloperClient(new NEOONEOneDataProvider({ network: 'local', projectID, host, port: 40100 })),
 });
 
-export const createLocalClients = (): { [network: string]: LocalClient } => {
-  const client = new OneClient(40100);
+export const createLocalClients = (host = 'localhost'): { [network: string]: LocalClient } => {
+  const client = new OneClient(40100, host);
   return {
     'local': {
       getNEOTrackerURL: async () => {

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/client/genClient.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/client/genClient.test.ts
@@ -21,6 +21,7 @@ describe('genClient', () => {
         projectIDPath: '/foo/bar/one/generated/projectID.js',
         clientPath: '/foo/bar/one/generated/client.js',
         httpServerPort: 40100,
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/contract/genContract.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/contract/genContract.test.ts
@@ -14,6 +14,7 @@ describe('genContract', () => {
             address: 'iamahash',
           },
         },
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/genCommonBrowserFiles.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/genCommonBrowserFiles.test.ts
@@ -27,6 +27,7 @@ describe('genCommonBrowserFiles', () => {
             dev: true,
           },
         ],
+        framework: 'react',
         sourceMaps: {},
       }),
     ).toMatchSnapshot();

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/genCommonFiles.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/genCommonFiles.test.ts
@@ -32,6 +32,8 @@ describe('genCommonFiles', () => {
         httpServerPort: 40100,
         sourceMapsPath: '/foo/bar/one/generated/sourceMaps.js',
         sourceMaps: {},
+        framework: 'vue',
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/genFiles.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/genFiles.test.ts
@@ -17,6 +17,7 @@ describe('genFiles', () => {
             address: 'iamahash',
           },
         },
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/generated/__snapshots__/genGenerated.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/generated/__snapshots__/genGenerated.test.ts.snap
@@ -3,9 +3,8 @@
 exports[`genGenerated Token 1`] = `
 Object {
   "js": "
-export * from './react';
+
 export * from './angular.service';
-export * from './vue';
 export * from './client';
 export * from './Token/contract';
 export * from './Token/abi';
@@ -14,9 +13,7 @@ export * from './ICO/abi';
 ",
   "ts": "
 export * from './types';
-export * from './react';
 export * from './angular.service';
-export * from './vue';
 export * from './client';
 export * from './Token/contract';
 export * from './Token/types';

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/generated/genGenerated.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/generated/genGenerated.test.ts
@@ -12,6 +12,7 @@ describe('genGenerated', () => {
         vuePath: '/foo/bar/one/generated/vue.js',
         clientPath: '/foo/bar/one/generated/client.js',
         generatedPath: '/foo/bar/one/generated/index.js',
+        framework: 'angular',
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/react/__snapshots__/genReact.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/react/__snapshots__/genReact.test.ts.snap
@@ -15,11 +15,12 @@ export const ContractsProvider = ({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -56,10 +57,11 @@ export interface WithClients<TClient extends Client> {
   readonly client: TClient;
   readonly developerClients: {
     readonly [network: string]: DeveloperClient;
-  },
+  };
   readonly localClients: {
     readonly [network: string]: LocalClient;
-  },
+  };
+  readonly host?: string;
 }
 export type ContractsWithClients<TClient extends Client> = Contracts & WithClients<TClient>;
 const Context: any = React.createContext<ContractsWithClients<Client>>(undefined as any);
@@ -71,11 +73,12 @@ export const ContractsProvider = <TClient extends Client>({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }: ContractsProviderProps<TClient>) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/react/genReact.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/react/genReact.test.ts
@@ -9,6 +9,7 @@ describe('genReact', () => {
         commonTypesPath: '/foo/bar/one/generated/types.js',
         reactPath: '/foo/bar/one/generated/react.js',
         clientPath: '/foo/bar/one/generated/client.js',
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/sourceMaps/genSourceMaps.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/sourceMaps/genSourceMaps.test.ts
@@ -8,6 +8,7 @@ describe('genSourceMaps', () => {
         projectIDPath: '/foo/bar/one/generated/projectID.js',
         sourceMapsPath: '/foo/bar/one/generated/sourceMaps.js',
         sourceMaps: {},
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/types/genSmartContractTypes.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/types/genSmartContractTypes.test.ts
@@ -3,6 +3,6 @@ import { genSmartContractTypes } from '../../types';
 
 describe('genSmartContractTypes', () => {
   test('NEP5', () => {
-    expect(genSmartContractTypes('Token', nep5.abi(4))).toMatchSnapshot();
+    expect(genSmartContractTypes('Token', nep5.abi(4), false)).toMatchSnapshot();
   });
 });

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/vue/__snapshots__/genVue.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/vue/__snapshots__/genVue.test.ts.snap
@@ -17,6 +17,12 @@ class ContractsService {
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 
 export const contractsService = new ContractsService();
@@ -49,6 +55,12 @@ class ContractsService {
     this.localClients = createLocalClients();
     this.token = createTokenSmartContract(this.client);
     this.ico = createICOSmartContract(this.client);
+  }
+
+  public setHost(host: string) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
 

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/vue/genVue.test.ts
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/vue/genVue.test.ts
@@ -9,6 +9,7 @@ describe('genVue', () => {
         commonTypesPath: '/foo/bar/one/generated/types.js',
         vuePath: '/foo/bar/one/generated/vue.js',
         clientPath: '/foo/bar/one/generated/client.js',
+        browser: false,
       }),
     ).toMatchSnapshot();
   });

--- a/packages/neo-one-smart-contract-codegen/src/abi/genABI.ts
+++ b/packages/neo-one-smart-contract-codegen/src/abi/genABI.ts
@@ -2,9 +2,9 @@ import { ABI } from '@neo-one/client-common';
 import stringify from 'safe-stable-stringify';
 import { getABIName } from './getABIName';
 
-export const genABI = (name: string, abi: ABI) => ({
+export const genABI = (name: string, abi: ABI, browser: boolean) => ({
   js: `export const ${getABIName(name)} = ${stringify(abi, undefined, 2)};`,
-  ts: `import { ABI } from '@neo-one/client';
+  ts: `import { ABI } from '@neo-one/client${browser ? '-browserify' : ''}';
 
 export const ${getABIName(name)}: ABI = ${stringify(abi, undefined, 2)};
 `,

--- a/packages/neo-one-smart-contract-codegen/src/angular/genAngular.ts
+++ b/packages/neo-one-smart-contract-codegen/src/angular/genAngular.ts
@@ -7,15 +7,17 @@ export const genAngular = ({
   angularPath,
   commonTypesPath,
   clientPath,
+  browser,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly angularPath: string;
   readonly commonTypesPath: string;
   readonly clientPath: string;
+  readonly browser: boolean;
 }) => ({
   js: `
 import { Injectable } from '@angular/core';
-import { Client, DeveloperClient, LocalClient } from '@neo-one/client';
+import { Client, DeveloperClient, LocalClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(
     angularPath,
     clientPath,
@@ -40,11 +42,17 @@ export class ContractsService {
       .map(({ name }) => `this.${lowerCaseFirst(name)} = ${getCreateSmartContractName(name)}(this.client);`)
       .join('\n    ')}
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
     `,
   ts: `
 import { Injectable } from '@angular/core';
-import { Client, DeveloperClient, LocalClient } from '@neo-one/client';
+import { Client, DeveloperClient, LocalClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(
     angularPath,
     clientPath,
@@ -83,6 +91,12 @@ export class ContractsService {
     ${contractsPaths
       .map(({ name }) => `this.${lowerCaseFirst(name)} = ${getCreateSmartContractName(name)}(this.client);`)
       .join('\n    ')}
+  }
+
+  public setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
   `,

--- a/packages/neo-one-smart-contract-codegen/src/contract/genContract.ts
+++ b/packages/neo-one-smart-contract-codegen/src/contract/genContract.ts
@@ -12,6 +12,7 @@ export const genContract = ({
   sourceMapsPath,
   abiPath,
   networksDefinition,
+  browser,
 }: {
   readonly name: string;
   readonly createContractPath: string;
@@ -19,6 +20,7 @@ export const genContract = ({
   readonly abiPath: string;
   readonly sourceMapsPath: string;
   readonly networksDefinition: SmartContractNetworksDefinition;
+  readonly browser: boolean;
 }) => {
   const relativeTypes = getRelativeImport(createContractPath, typesPath);
   const smartContract = getSmartContractName(name);
@@ -43,7 +45,9 @@ export const ${getCreateSmartContractName(name)} = (
 ) => client.smartContract(definition);
   `,
     ts: `
-import { Client, SmartContractDefinition } from '@neo-one/client';${abiName >= 'sourceMaps' ? sourceMapsImport : ''}
+import { Client, SmartContractDefinition } from '@neo-one/client${browser ? '-browserify' : ''}';${
+      abiName >= 'sourceMaps' ? sourceMapsImport : ''
+    }
 import { ${abiName} } from '${relativeABI}';
 import { ${smartContract} } from '${relativeTypes}';${abiName >= 'sourceMaps' ? '' : sourceMapsImport}
 

--- a/packages/neo-one-smart-contract-codegen/src/genCommonBrowserFiles.ts
+++ b/packages/neo-one-smart-contract-codegen/src/genCommonBrowserFiles.ts
@@ -7,7 +7,7 @@ import { genGenerated } from './generated';
 import { genReact } from './react';
 import { genBrowserSourceMaps } from './sourceMaps';
 import { genTest } from './test';
-import { ContractPaths, FileResult } from './type';
+import { CodegenFramework, ContractPaths, FileResult } from './type';
 import { genVue } from './vue';
 
 export interface CommonBrowserFilesResult {
@@ -34,6 +34,7 @@ export const genCommonBrowserFiles = ({
   wallets,
   networks,
   sourceMaps,
+  framework,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly testPath: string;
@@ -47,15 +48,18 @@ export const genCommonBrowserFiles = ({
   readonly wallets: ReadonlyArray<Wallet>;
   readonly networks: ReadonlyArray<NetworkDefinition>;
   readonly sourceMaps: SourceMaps;
+  readonly framework: CodegenFramework;
 }): CommonBrowserFilesResult => {
   const testFile = formatFile(
     genTest({ contractsPaths, testPath, commonTypesPath, mod: '@neo-one/smart-contract-test-browser' }),
   );
   const commonTypesFile = formatFile(genCommonTypes({ contractsPaths, commonTypesPath }));
   const sourceMapsFile = formatFile(genBrowserSourceMaps({ sourceMaps }));
-  const reactFile = formatFile(genReact({ contractsPaths, reactPath, commonTypesPath, clientPath }));
-  const angularFile = formatFile(genAngular({ contractsPaths, angularPath, commonTypesPath, clientPath }));
-  const vueFile = formatFile(genVue({ contractsPaths, vuePath, commonTypesPath, clientPath }));
+  const reactFile = formatFile(genReact({ contractsPaths, reactPath, commonTypesPath, clientPath, browser: false }));
+  const angularFile = formatFile(
+    genAngular({ contractsPaths, angularPath, commonTypesPath, clientPath, browser: false }),
+  );
+  const vueFile = formatFile(genVue({ contractsPaths, vuePath, commonTypesPath, clientPath, browser: false }));
   const clientFile = formatFile(genBrowserClient({ localDevNetworkName, wallets, networks }));
   const generatedFile = formatFile(
     genGenerated({
@@ -66,6 +70,7 @@ export const genCommonBrowserFiles = ({
       vuePath,
       clientPath,
       generatedPath,
+      framework,
     }),
   );
 

--- a/packages/neo-one-smart-contract-codegen/src/genCommonFiles.ts
+++ b/packages/neo-one-smart-contract-codegen/src/genCommonFiles.ts
@@ -8,7 +8,7 @@ import { genProjectID } from './projectID';
 import { genReact } from './react';
 import { genSourceMaps } from './sourceMaps';
 import { genTest } from './test';
-import { ContractPaths, FileResult } from './type';
+import { CodegenFramework, ContractPaths, FileResult } from './type';
 import { genVue } from './vue';
 
 export interface CommonFilesResult {
@@ -40,6 +40,8 @@ export const genCommonFiles = ({
   httpServerPort,
   sourceMapsPath,
   sourceMaps,
+  framework,
+  browser,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly projectID: string;
@@ -57,15 +59,19 @@ export const genCommonFiles = ({
   readonly httpServerPort: number;
   readonly sourceMapsPath: string;
   readonly sourceMaps: SourceMaps;
+  readonly framework: CodegenFramework;
+  readonly browser: boolean;
 }): CommonFilesResult => {
   const testFile = formatFile(genTest({ contractsPaths, testPath, commonTypesPath }));
   const commonTypesFile = formatFile(genCommonTypes({ contractsPaths, commonTypesPath }));
-  const sourceMapsFile = formatFile(genSourceMaps({ httpServerPort, sourceMapsPath, projectIDPath, sourceMaps }));
-  const reactFile = formatFile(genReact({ contractsPaths, reactPath, commonTypesPath, clientPath }));
-  const angularFile = formatFile(genAngular({ contractsPaths, angularPath, commonTypesPath, clientPath }));
-  const vueFile = formatFile(genVue({ contractsPaths, vuePath, commonTypesPath, clientPath }));
+  const sourceMapsFile = formatFile(
+    genSourceMaps({ httpServerPort, sourceMapsPath, projectIDPath, sourceMaps, browser }),
+  );
+  const reactFile = formatFile(genReact({ contractsPaths, reactPath, commonTypesPath, clientPath, browser }));
+  const angularFile = formatFile(genAngular({ contractsPaths, angularPath, commonTypesPath, clientPath, browser }));
+  const vueFile = formatFile(genVue({ contractsPaths, vuePath, commonTypesPath, clientPath, browser }));
   const clientFile = formatFile(
-    genClient({ localDevNetworkName, wallets, networks, clientPath, projectIDPath, httpServerPort }),
+    genClient({ localDevNetworkName, wallets, networks, clientPath, projectIDPath, httpServerPort, browser }),
   );
   const generatedFile = formatFile(
     genGenerated({
@@ -76,6 +82,7 @@ export const genCommonFiles = ({
       vuePath,
       clientPath,
       generatedPath,
+      framework,
     }),
   );
   const projectIDFile = formatFile(genProjectID({ projectID }));

--- a/packages/neo-one-smart-contract-codegen/src/genFiles.ts
+++ b/packages/neo-one-smart-contract-codegen/src/genFiles.ts
@@ -19,6 +19,7 @@ export const genFiles = ({
   typesPath,
   abiPath,
   abi,
+  browser,
 }: {
   readonly name: string;
   readonly networksDefinition: SmartContractNetworksDefinition;
@@ -28,8 +29,9 @@ export const genFiles = ({
   readonly abiPath: string;
   readonly contractPath: string;
   readonly abi: ABI;
+  readonly browser: boolean;
 }) => {
-  const abiFile = formatFile(genABI(name, abi));
+  const abiFile = formatFile(genABI(name, abi, browser));
   const contractFile = formatFile(
     genContract({
       name,
@@ -38,9 +40,10 @@ export const genFiles = ({
       typesPath,
       abiPath,
       networksDefinition,
+      browser,
     }),
   );
-  const typesFile = formatFile(genSmartContractTypes(name, abi));
+  const typesFile = formatFile(genSmartContractTypes(name, abi, browser));
 
   return {
     abi: abiFile,

--- a/packages/neo-one-smart-contract-codegen/src/generated/genGenerated.ts
+++ b/packages/neo-one-smart-contract-codegen/src/generated/genGenerated.ts
@@ -1,9 +1,12 @@
 import _ from 'lodash';
-import { ContractPaths } from '../type';
+import { CodegenFramework, ContractPaths } from '../type';
 import { getRelativeImport } from '../utils';
 
 const createExport = (generatedPath: string, importPath: string) =>
   `export * from '${getRelativeImport(generatedPath, importPath)}';`;
+
+const createNewLineExport = (generatedPath: string, importPath: string) =>
+  `\n${createExport(generatedPath, importPath)}`;
 
 export const genGenerated = ({
   contractsPaths,
@@ -13,6 +16,7 @@ export const genGenerated = ({
   vuePath,
   clientPath,
   generatedPath,
+  framework,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly commonTypesPath: string;
@@ -21,21 +25,23 @@ export const genGenerated = ({
   readonly vuePath: string;
   readonly clientPath: string;
   readonly generatedPath: string;
+  readonly framework: CodegenFramework;
 }) => ({
   ts: `
-${createExport(generatedPath, commonTypesPath)}
-${createExport(generatedPath, reactPath)}
-${createExport(generatedPath, angularPath)}
-${createExport(generatedPath, vuePath)}
+${createExport(generatedPath, commonTypesPath)}${
+    framework === 'react' ? createNewLineExport(generatedPath, reactPath) : ''
+  }${framework === 'angular' ? createNewLineExport(generatedPath, angularPath) : ''}${
+    framework === 'vue' ? createNewLineExport(generatedPath, vuePath) : ''
+  }
 ${createExport(generatedPath, clientPath)}
 ${_.flatMap(contractsPaths, ({ createContractPath, typesPath, abiPath }) => [createContractPath, typesPath, abiPath])
   .map((importPath) => createExport(generatedPath, importPath))
   .join('\n')}
 `,
   js: `
-${createExport(generatedPath, reactPath)}
-${createExport(generatedPath, angularPath)}
-${createExport(generatedPath, vuePath)}
+${framework === 'react' ? createNewLineExport(generatedPath, reactPath) : ''}${
+    framework === 'angular' ? createNewLineExport(generatedPath, angularPath) : ''
+  }${framework === 'vue' ? createNewLineExport(generatedPath, vuePath) : ''}
 ${createExport(generatedPath, clientPath)}
 ${_.flatMap(contractsPaths, ({ createContractPath, abiPath }) => [createContractPath, abiPath])
   .map((importPath) => createExport(generatedPath, importPath))

--- a/packages/neo-one-smart-contract-codegen/src/react/genReact.ts
+++ b/packages/neo-one-smart-contract-codegen/src/react/genReact.ts
@@ -7,14 +7,16 @@ export const genReact = ({
   reactPath,
   commonTypesPath,
   clientPath,
+  browser,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly reactPath: string;
   readonly commonTypesPath: string;
   readonly clientPath: string;
+  readonly browser: boolean;
 }) => ({
   js: `
-import { DeveloperTools } from '@neo-one/client';
+import { DeveloperTools } from '@neo-one/client${browser ? '-browserify' : ''}';
 import * as React from 'react';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(reactPath, clientPath)}';
 ${contractsPaths
@@ -30,11 +32,12 @@ export const ContractsProvider = ({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (
@@ -60,7 +63,7 @@ export const WithContracts = ({ children }) => (
 );
 `,
   ts: `
-import { Client, DeveloperClient, DeveloperTools, LocalClient } from '@neo-one/client';
+import { Client, DeveloperClient, DeveloperTools, LocalClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import * as React from 'react';
 import { Contracts } from '${getRelativeImport(reactPath, commonTypesPath)}';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(reactPath, clientPath)}';
@@ -76,10 +79,11 @@ export interface WithClients<TClient extends Client> {
   readonly client: TClient;
   readonly developerClients: {
     readonly [network: string]: DeveloperClient;
-  },
+  };
   readonly localClients: {
     readonly [network: string]: LocalClient;
-  },
+  };
+  readonly host?: string;
 }
 export type ContractsWithClients<TClient extends Client> = Contracts & WithClients<TClient>;
 const Context: any = React.createContext<ContractsWithClients<Client>>(undefined as any);
@@ -91,11 +95,12 @@ export const ContractsProvider = <TClient extends Client>({
   client: clientIn,
   developerClients: developerClientsIn,
   localClients: localClientsIn,
+  host,
   children,
 }: ContractsProviderProps<TClient>) => {
-  const client = clientIn === undefined ? createClient() : clientIn;
-  const developerClients = developerClientsIn === undefined ? createDeveloperClients() : developerClientsIn;
-  const localClients = localClientsIn === undefined ? createLocalClients() : localClientsIn;
+  const client = clientIn === undefined ? createClient(host) : clientIn;
+  const developerClients = developerClientsIn === undefined ? createDeveloperClients(host) : developerClientsIn;
+  const localClients = localClientsIn === undefined ? createLocalClients(host) : localClientsIn;
   DeveloperTools.enable({ client, developerClients, localClients });
 
   return (

--- a/packages/neo-one-smart-contract-codegen/src/sourceMaps/genSourceMaps.ts
+++ b/packages/neo-one-smart-contract-codegen/src/sourceMaps/genSourceMaps.ts
@@ -22,17 +22,19 @@ export const genSourceMaps = ({
   sourceMapsPath,
   projectIDPath,
   sourceMaps,
+  browser,
 }: {
   readonly httpServerPort: number;
   readonly sourceMapsPath: string;
   readonly projectIDPath: string;
   readonly sourceMaps: SourceMaps;
+  readonly browser: boolean;
 }) => {
   const hash = hashSourceMaps(sourceMaps);
 
   return {
     js: `/* @source-map-hash ${hash} */
-import { OneClient } from '@neo-one/client';
+import { OneClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { projectID } from '${getRelativeImport(sourceMapsPath, projectIDPath)}';
 
 let sourceMapsIn = Promise.resolve({});
@@ -52,7 +54,7 @@ if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true')
 export const sourceMaps = sourceMapsIn;
 `,
     ts: `/* @source-map-hash ${hash} */
-import { OneClient, SourceMaps } from '@neo-one/client';
+import { OneClient, SourceMaps } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { projectID } from '${getRelativeImport(sourceMapsPath, projectIDPath)}';
 
 let sourceMapsIn: Promise<SourceMaps> = Promise.resolve({});

--- a/packages/neo-one-smart-contract-codegen/src/type.ts
+++ b/packages/neo-one-smart-contract-codegen/src/type.ts
@@ -14,3 +14,5 @@ export interface FileResult {
   readonly ts: string;
   readonly js?: string;
 }
+
+export type CodegenFramework = 'none' | 'react' | 'angular' | 'vue';

--- a/packages/neo-one-smart-contract-codegen/src/types/genSmartContractTypes.ts
+++ b/packages/neo-one-smart-contract-codegen/src/types/genSmartContractTypes.ts
@@ -98,7 +98,7 @@ const getImportClauses = (text: string) => {
   return mutableClauses;
 };
 
-export const genSmartContractTypes = (name: string, abi: ABI) => {
+export const genSmartContractTypes = (name: string, abi: ABI, browser: boolean) => {
   const events = abi.events === undefined ? [] : abi.events;
   const eventType = `export type ${getEventName(name)} = ${
     events.length === 0 ? 'never' : events.map((event) => getSingleEventName(name, event.name)).join(' | ')
@@ -113,7 +113,9 @@ ${genSmartContract(name, abi)}`;
   importClauses.sort();
 
   const bigNumberImport = text.includes('BigNumber') ? "\nimport BigNumber from 'bignumber.js';" : '';
-  const importDecl = `import { ${importClauses.join(', ')} } from '@neo-one/client';${bigNumberImport}`;
+  const importDecl = `import { ${importClauses.join(', ')} } from '@neo-one/client${
+    browser ? '-browserify' : ''
+  }';${bigNumberImport}`;
 
   return {
     ts: `${importDecl}

--- a/packages/neo-one-smart-contract-codegen/src/vue/genVue.ts
+++ b/packages/neo-one-smart-contract-codegen/src/vue/genVue.ts
@@ -7,14 +7,16 @@ export const genVue = ({
   vuePath,
   commonTypesPath,
   clientPath,
+  browser,
 }: {
   readonly contractsPaths: ReadonlyArray<ContractPaths>;
   readonly vuePath: string;
   readonly commonTypesPath: string;
   readonly clientPath: string;
+  readonly browser: boolean;
 }) => ({
   js: `
-import { Client, DeveloperClient, LocalClient } from '@neo-one/client';
+import { Client, DeveloperClient, LocalClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(vuePath, clientPath)}';
 
 ${contractsPaths
@@ -33,12 +35,18 @@ class ContractsService {
       .map(({ name }) => `this.${lowerCaseFirst(name)} = ${getCreateSmartContractName(name)}(this.client);`)
       .join('\n    ')}
   }
+
+  setHost(host) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
+  }
 }
 
 export const contractsService = new ContractsService();
     `,
   ts: `
-import { Client, DeveloperClient, LocalClient } from '@neo-one/client';
+import { Client, DeveloperClient, LocalClient } from '@neo-one/client${browser ? '-browserify' : ''}';
 import { createClient, createDeveloperClients, createLocalClients } from '${getRelativeImport(vuePath, clientPath)}';
 import { Contracts } from '${getRelativeImport(vuePath, commonTypesPath)}';
 
@@ -71,6 +79,12 @@ class ContractsService {
     ${contractsPaths
       .map(({ name }) => `this.${lowerCaseFirst(name)} = ${getCreateSmartContractName(name)}(this.client);`)
       .join('\n    ')}
+  }
+
+  public setHost(host: string) {
+    this.client = createClient(host);
+    this.developerClients = createDeveloperClients(host);
+    this.localClients = createLocalClients(host);
   }
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change

Generate a browser-comaptible bundle for client & client full packages using webpack. All packages
which rely on nodejs builtins are bundled, others are left as external.  Also allow createClient to
be configured with a host so that a private network running on localhost can be accessed from a
phone or emulator. This is all to aid with requested expo compatibility.

### Test Plan
Tested produced bundles in an expo project and observed ability to compile and use neo-one client functionality.

### Alternate Designs


### Benefits
This produces a browser compatible version of the neo-one client for use with tools like expo which do not allow nodejs builtin modules in their bundling process.  

### Possible Drawbacks


### Applicable Issues
