### PR TITLE
feat(contract-mixins): add DesignatedCaller

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -407,7 +407,7 @@ const copyTypescript = ((cache) =>
       .src(globs.typescript)
       .pipe(
         gulpFilter([
-          'packages/neo-one-smart-contract-lib/src/*.ts',
+          'packages/neo-one-smart-contract-lib/src/**/*.ts',
           'packages/neo-one-smart-contract/src/*.ts',
           'packages/neo-one-server-plugin-wallet/src/contracts/*.ts',
         ]),

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestDesignatedCaller.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/TestDesignatedCaller.ts
@@ -1,0 +1,14 @@
+import { Address, SmartContract } from '@neo-one/smart-contract';
+import { DesignatedCaller } from '../../ownership/DesignatedCaller';
+
+export class TestDesignatedCaller extends DesignatedCaller(SmartContract) {
+  protected mutableDesignatedCaller: Address;
+
+  public constructor(owner: Address) {
+    super();
+    if (!Address.isCaller(owner)) {
+      throw new Error('Sender was not the owner.');
+    }
+    this.mutableDesignatedCaller = owner;
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__tests__/TestDesignatedCallerContract.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/TestDesignatedCallerContract.test.ts
@@ -1,0 +1,76 @@
+import { common, crypto } from '@neo-one/client-common';
+import { SmartContractAny } from '@neo-one/client-core';
+import { withContracts } from '@neo-one/smart-contract-test';
+import * as path from 'path';
+
+const RECIPIENT = {
+  PRIVATE_KEY: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+  PUBLIC_KEY: '02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef',
+};
+
+describe('TestDesignatedCaller', () => {
+  test('deploy + transfer', async () => {
+    await withContracts<{ testDesignatedCaller: SmartContractAny }>(
+      [
+        {
+          filePath: path.resolve(__dirname, '..', '__data__', 'contracts', 'TestDesignatedCaller.ts'),
+          name: 'TestDesignatedCaller',
+        },
+      ],
+      async ({ client, networkName, testDesignatedCaller: smartContract, masterAccountID }) => {
+        crypto.addPublicKey(
+          common.stringToPrivateKey(RECIPIENT.PRIVATE_KEY),
+          common.stringToECPoint(RECIPIENT.PUBLIC_KEY),
+        );
+
+        const deployResult = await smartContract.deploy(masterAccountID.address, { from: masterAccountID });
+
+        const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
+        if (deployReceipt.result.state !== 'HALT') {
+          throw new Error(deployReceipt.result.message);
+        }
+
+        expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
+        expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
+        expect(deployReceipt.result.value).toBeTruthy();
+
+        const [designatedCaller, recipient] = await Promise.all([
+          smartContract.designatedCaller(),
+
+          client.providers.memory.keystore.addUserAccount({
+            network: networkName,
+            name: 'recipient',
+            privateKey: RECIPIENT.PRIVATE_KEY,
+          }),
+        ]);
+
+        expect(designatedCaller.toString()).toEqual(masterAccountID.address);
+        expect(designatedCaller.toString()).not.toEqual(recipient.userAccount.id.address);
+
+        const transferResult = await smartContract.designateCaller(recipient.userAccount.id.address, {
+          from: masterAccountID,
+        });
+        const transferReciept = await transferResult.confirmed({ timeoutMS: 2500 });
+        const newCaller = await smartContract.designatedCaller();
+        if (transferReciept.result.state !== 'HALT') {
+          throw new Error(transferReciept.result.message);
+        }
+
+        expect(newCaller.toString()).toEqual(recipient.userAccount.id.address);
+
+        const bogusTransferResult = await smartContract.designateCaller(masterAccountID.address, {
+          from: masterAccountID,
+        });
+        const bogusTransferReciept = await bogusTransferResult.confirmed({ timeoutMS: 2500 });
+        if (bogusTransferReciept.result.state !== 'HALT') {
+          throw new Error(bogusTransferReciept.result.message);
+        }
+        const noopCaller = await smartContract.designatedCaller();
+        expect(noopCaller.toString()).toEqual(recipient.userAccount.id.address);
+
+        expect(bogusTransferReciept.result.value).toBeFalsy();
+      },
+      { deploy: false },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestDesignatedCallerContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestDesignatedCallerContract.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestDesignatedCaller deploy + transfer: deploy consumed 1`] = `"0"`;
+
+exports[`TestDesignatedCaller deploy + transfer: deploy cost 1`] = `"1.503"`;

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,2 +1,3 @@
 // tslint:disable-next-line export-name
 export { NEP5Token } from './NEP5Token';
+export { DesignatedCaller } from './ownership/DesignatedCaller';

--- a/packages/neo-one-smart-contract-lib/src/ownership/DesignatedCaller.ts
+++ b/packages/neo-one-smart-contract-lib/src/ownership/DesignatedCaller.ts
@@ -1,0 +1,37 @@
+import { Address, constant, createEventNotifier, SmartContract } from '@neo-one/smart-contract';
+
+/**
+ * @title Designated Caller
+ * @dev This contract can only be called by 1 other address.
+ */
+
+export function DesignatedCaller<TBase extends Constructor<SmartContract>>(Base: TBase) {
+  abstract class DesignatedCallerClass extends Base {
+    protected abstract mutableDesignatedCaller: Address;
+
+    /* tslint:disable-next-line:variable-name */
+    private readonly assigned_designated_caller = createEventNotifier<Address, Address>(
+      'assigned designated caller',
+      'previously',
+      'now',
+    );
+
+    @constant
+    public get designatedCaller(): Address {
+      return this.mutableDesignatedCaller;
+    }
+
+    public designateCaller(assignee: Address): boolean {
+      if (Address.isCaller(this.mutableDesignatedCaller) && assignee !== this.mutableDesignatedCaller) {
+        this.assigned_designated_caller(this.mutableDesignatedCaller, assignee);
+        this.mutableDesignatedCaller = assignee;
+
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  return DesignatedCallerClass;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "packages/neo-one-server-plugin-wallet/src/contracts/*.ts",
     "packages/neo-one-smart-contract-lib/src/*.ts",
     "packages/neo-one-smart-contract/src/*.d.ts",
+    "packages/neo-one-smart-contract-lib/src/ownership/*.ts",
     "packages/neo-one-smart-contract-compiler/src/__data__/snippets/**/*.ts",
     "packages/*/src/__data__/contracts/*.ts",
     "packages/*/template/**/*.ts",


### PR DESCRIPTION
### Description of the Change
Introduce a SmartContract Mix-in that provides basic "designated caller" functionality with a suite of tests.  This contract can only be called by a DesignatedCaller address. 

### Test Plan
Run the included test suite:

     yarn jest packages/neo-one-smart-contract-lib/src/__tests__/TestDesignatedCallerContract.test.ts
