### PR TITLE
Add "Edit This Page" link to docs, tutorial, blog pages

### DIFF
--- a/packages/neo-one-website/src/components/blog/Blog.tsx
+++ b/packages/neo-one-website/src/components/blog/Blog.tsx
@@ -8,6 +8,7 @@ export interface BlogProps {
   readonly title: string;
   readonly content: MarkdownContent;
   readonly date: string;
+  readonly link: string;
   readonly author: Author;
   readonly sidebar: ReadonlyArray<SectionData>;
 }

--- a/packages/neo-one-website/src/components/content/Content.tsx
+++ b/packages/neo-one-website/src/components/content/Content.tsx
@@ -49,6 +49,7 @@ interface Props {
   readonly content: ContentType;
   readonly sidebar: ReadonlyArray<SectionData>;
   readonly date?: string;
+  readonly link: string;
   readonly author?: Author;
   readonly next?: AdjacentInfo;
   readonly previous?: AdjacentInfo;
@@ -63,6 +64,7 @@ export const Content = ({
   previous,
   sidebar,
   date,
+  link,
   author,
   ...props
 }: Props) => (
@@ -71,7 +73,7 @@ export const Content = ({
       <title>{`${title} - NEO•ONE`}</title>
     </Helmet>
     <LayoutWrapper omitSpacer>
-      <MainContent content={content} title={title} date={date} author={author} />
+      <MainContent content={content} title={title} date={date} link={link} author={author} />
       <Sidebar current={current} sections={sidebar} alwaysVisible={sidebarAlwaysVisible} />
     </LayoutWrapper>
     <DocFooter next={next} previous={previous} />

--- a/packages/neo-one-website/src/components/content/EditPageLink.tsx
+++ b/packages/neo-one-website/src/components/content/EditPageLink.tsx
@@ -1,6 +1,5 @@
 // tslint:disable no-null-keyword
 import { Link } from '@neo-one/react-common';
-import * as path from 'path';
 import * as React from 'react';
 import styled from 'styled-components';
 import { prop } from 'styled-tools';
@@ -19,10 +18,11 @@ interface Props {
 }
 
 const baseLink = 'https://github.com/neo-one-suite/neo-one/blob/master/';
+const cleanLink = (input: string): string => (input[0] === '/' ? input.substr(1, input.length) : input);
 
 export const EditPageLink = ({ link }: Props) => (
   <Div>
-    <StyledLink linkColor="accent" href={path.join(baseLink, link)} target="_blank">
+    <StyledLink linkColor="accent" href={baseLink + cleanLink(link)} target="_blank">
       Edit this page
     </StyledLink>
   </Div>

--- a/packages/neo-one-website/src/components/content/EditPageLink.tsx
+++ b/packages/neo-one-website/src/components/content/EditPageLink.tsx
@@ -1,0 +1,29 @@
+// tslint:disable no-null-keyword
+import { Link } from '@neo-one/react-common';
+import * as path from 'path';
+import * as React from 'react';
+import styled from 'styled-components';
+import { prop } from 'styled-tools';
+
+const StyledLink = styled(Link)`
+  ${prop('theme.fonts.axiformaRegular')}
+  ${prop('theme.fontStyles.subheading')}
+`;
+
+const Div = styled.div`
+  margin-top: 80px;
+`;
+
+interface Props {
+  readonly link: string;
+}
+
+const baseLink = 'https://github.com/neo-one-suite/neo-one/blob/master/';
+
+export const EditPageLink = ({ link }: Props) => (
+  <Div>
+    <StyledLink linkColor="accent" href={path.join(baseLink, link)} target="_blank">
+      Edit this page
+    </StyledLink>
+  </Div>
+);

--- a/packages/neo-one-website/src/components/content/MainContent.tsx
+++ b/packages/neo-one-website/src/components/content/MainContent.tsx
@@ -7,6 +7,7 @@ import { Markdown } from '../../elements';
 import { ReferenceContent } from '../reference';
 import { ContentType } from './Content';
 import { DateAndAuthor } from './DateAndAuthor';
+import { EditPageLink } from './EditPageLink';
 import { Author } from './types';
 
 const Wrapper = styled(Box)`
@@ -160,15 +161,19 @@ interface Props {
   readonly title: string;
   readonly content: ContentType;
   readonly date?: string;
+  readonly link: string;
   readonly author?: Author;
 }
 
-export const MainContent = ({ content, title, date, author, ...props }: Props) => (
+export const MainContent = ({ content, title, date, link, author, ...props }: Props) => (
   <Wrapper {...props}>
     <Title>{title}</Title>
     {date === undefined || author === undefined ? null : <DateAndAuthor date={date} author={author} />}
     {content.type === 'markdown' ? (
-      <StyledMarkdown source={content.value} linkColor="accent" light anchors />
+      <>
+        <StyledMarkdown source={content.value} linkColor="accent" light anchors />
+        <EditPageLink link={link} />
+      </>
     ) : (
       <ReferenceContent content={content} />
     )}

--- a/packages/neo-one-website/src/components/docs/Docs.tsx
+++ b/packages/neo-one-website/src/components/docs/Docs.tsx
@@ -6,6 +6,7 @@ import { Content, MarkdownContent } from '../content';
 export interface DocsProps {
   readonly current: string;
   readonly title: string;
+  readonly link: string;
   readonly content: MarkdownContent;
   readonly sidebar: ReadonlyArray<SectionData>;
   readonly next?: AdjacentInfo;

--- a/packages/neo-one-website/src/components/reference/Reference.tsx
+++ b/packages/neo-one-website/src/components/reference/Reference.tsx
@@ -5,6 +5,7 @@ import { Content, ReferenceItemContent, ReferenceItemsContent } from '../content
 export interface ReferenceProps {
   readonly current: string;
   readonly title: string;
+  readonly link: string;
   readonly content: ReferenceItemsContent | ReferenceItemContent;
   readonly sidebar: ReadonlyArray<SectionData>;
 }

--- a/packages/neo-one-website/src/components/tutorial/Tutorial.tsx
+++ b/packages/neo-one-website/src/components/tutorial/Tutorial.tsx
@@ -9,6 +9,7 @@ import { Content, MarkdownContent } from '../content';
 export interface TutorialProps {
   readonly title: string;
   readonly content: MarkdownContent;
+  readonly link: string;
   readonly sidebar: ReadonlyArray<SectionData>;
   readonly next?: AdjacentInfo;
   readonly previous?: AdjacentInfo;

--- a/packages/neo-one-website/src/utils/getBlogs.ts
+++ b/packages/neo-one-website/src/utils/getBlogs.ts
@@ -77,7 +77,7 @@ const getBlog = async (blogFile: string): Promise<BlogInfo> => {
   const contents = await fs.readFile(path.resolve(BLOG_SOURCE, blogFile), 'utf8');
   const blog = matter(contents);
   const blogHeader = blog.data as MDBlogHeader;
-  const blogSourceLessDirname = BLOG_SOURCE.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
+  const blogSourceLessDirname = path.relative(path.resolve(__dirname, '..', '..', '..', '..'), BLOG_SOURCE);
   const link = path.join(blogSourceLessDirname, blogFile);
 
   return {

--- a/packages/neo-one-website/src/utils/getBlogs.ts
+++ b/packages/neo-one-website/src/utils/getBlogs.ts
@@ -17,6 +17,7 @@ interface BlogInfo {
   readonly title: string;
   readonly slug: string;
   readonly date: string;
+  readonly link: string;
   readonly content: MarkdownContent;
   readonly author: Author;
 }
@@ -61,6 +62,7 @@ export const getBlogs = async (): Promise<{
       title: post.title,
       content: post.content,
       date: post.date,
+      link: post.link,
       author: post.author,
       sidebar,
     })),
@@ -75,11 +77,14 @@ const getBlog = async (blogFile: string): Promise<BlogInfo> => {
   const contents = await fs.readFile(path.resolve(BLOG_SOURCE, blogFile), 'utf8');
   const blog = matter(contents);
   const blogHeader = blog.data as MDBlogHeader;
+  const blogSourceLessDirname = BLOG_SOURCE.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
+  const link = path.join(blogSourceLessDirname, blogFile);
 
   return {
     slug: `/blog/${blogHeader.slug}`,
     title: blogHeader.title,
     date,
+    link,
     author: {
       name: blogHeader.author,
       twitter: blogHeader.twitter,

--- a/packages/neo-one-website/src/utils/getDocs.ts
+++ b/packages/neo-one-website/src/utils/getDocs.ts
@@ -13,6 +13,7 @@ interface MDDocHeader {
 
 interface DocInfoBase extends MDDocHeader {
   readonly content: MarkdownContent;
+  readonly link: string;
 }
 
 interface DocInfo extends DocInfoBase {
@@ -40,6 +41,7 @@ export const getDocs = async (): Promise<ReadonlyArray<DocsProps>> => {
     current: doc.slug,
     title: doc.title,
     content: doc.content,
+    link: doc.link,
     sidebar: Object.entries(
       _.groupBy(
         docs.map((document) => ({
@@ -74,12 +76,15 @@ const getDoc = async (section: string, docFile: string): Promise<DocInfoBase> =>
   const contents = await fs.readFile(docFile, 'utf8');
   const doc = matter(contents);
   const docHeader = doc.data as MDDocHeader;
+  const docSource = path.resolve(__dirname, '..', '..', 'docs', docFile);
+  const link = docSource.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
 
   return {
     slug: `/docs/${docHeader.slug}`,
     title: docHeader.title.replace(/\\@/g, '@'),
     section,
     content: { type: 'markdown', value: doc.content },
+    link,
   };
 };
 

--- a/packages/neo-one-website/src/utils/getDocs.ts
+++ b/packages/neo-one-website/src/utils/getDocs.ts
@@ -77,7 +77,7 @@ const getDoc = async (section: string, docFile: string): Promise<DocInfoBase> =>
   const doc = matter(contents);
   const docHeader = doc.data as MDDocHeader;
   const docSource = path.resolve(__dirname, '..', '..', 'docs', docFile);
-  const link = docSource.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
+  const link = path.relative(path.resolve(__dirname, '..', '..', '..', '..'), docSource);
 
   return {
     slug: `/docs/${docHeader.slug}`,

--- a/packages/neo-one-website/src/utils/getTutorial.ts
+++ b/packages/neo-one-website/src/utils/getTutorial.ts
@@ -12,7 +12,7 @@ const TUTORIAL_SOURCE = path.resolve(__dirname, '..', '..', 'tutorial', 'tutoria
 
 export const getTutorial = async (): Promise<TutorialProps> => {
   const content = await fs.readFile(TUTORIAL_SOURCE, 'utf-8');
-  const link = TUTORIAL_SOURCE.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
+  const link = path.relative(path.resolve(__dirname, '..', '..', '..', '..'), TUTORIAL_SOURCE);
 
   return {
     title: 'Tutorial: Intro to NEO•ONE',

--- a/packages/neo-one-website/src/utils/getTutorial.ts
+++ b/packages/neo-one-website/src/utils/getTutorial.ts
@@ -12,10 +12,12 @@ const TUTORIAL_SOURCE = path.resolve(__dirname, '..', '..', 'tutorial', 'tutoria
 
 export const getTutorial = async (): Promise<TutorialProps> => {
   const content = await fs.readFile(TUTORIAL_SOURCE, 'utf-8');
+  const link = TUTORIAL_SOURCE.replace(path.resolve(__dirname, '..', '..', '..', '..'), '');
 
   return {
     title: 'Tutorial: Intro to NEO•ONE',
     content: { type: 'markdown', value: content },
+    link,
     sidebar: [
       {
         title: 'TUTORIAL',


### PR DESCRIPTION
### Description of the Change

Adds an "Edit this page" link to every docs, tutorial, and blog page that links to that pages respective markdown file on GitHub per issue #690. To accomplish this the commit creates a new EditPageLink component to be added to the docs, tutorial, and blog pages. Modifies getBlogs, getDocs, getTutorial utils to pass down respective page file paths down to the Docs, Tutorial, Blog components, to the Content component, finally to the MainContent component, which passes link path to EditPageLink component to render the link below MainContents markdown. The EditPageLink component contains the root GitHub URL, then adds the trailing file path that is passed down from getBlogs, getDocs, getTutorial.

### Test Plan

I did not see any tests for the website. I'm happy to add tests if wanted. Otherwise I used `website:start-static` on my machine to see and manually test the links, which work in that case. Although, when running `website:start-static` I got this warning when visiting the "Blog" tab:

<img width="1127" alt="screen shot 2019-02-16 at 1 22 02 pm" src="https://user-images.githubusercontent.com/29364457/52906723-cd799280-3206-11e9-8847-06ec5d226f76.png">

This happened before and after I made these changes. I have a feeling this is due to my machine. I'm not sure. Regardless the website still works after exiting out of this warning.

### Alternate Designs

I think this is the most maintainable way to implement this feature.

### Benefits

It will encourage website visitors to edit documentation, tutorial, and blog posts.

### Possible Drawbacks

None.

### Applicable Issues

Just the possible issue noted above when visiting the "Blog" tab.
