### PR TITLE
Fix typo in courses

### DIFF
--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/chapter.md
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/chapter.md
@@ -17,7 +17,7 @@ The two most commonly used properties of the `Client` are the `block$` `Observab
 Let's take a look at an example.
 
 ```typescript
-import { Address, contstant, Fixed, SmartContract } from '@neo-one/smart-contract';
+import { Address, constant, Fixed, SmartContract } from '@neo-one/smart-contract';
 
 export class Example extends SmartContract {
   @constant


### PR DESCRIPTION
### Description of the Change

Typo in courses: "contstant" should be "constant"

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Clarity.

### Possible Drawbacks

None.

### Applicable Issues

None.
