### PR TITLE
feat(RemoteUserAccountProvider): Base implementation for RemoteUserAc…

### DIFF
--- a/jest/other.js
+++ b/jest/other.js
@@ -1,0 +1,8 @@
+// Tests which are not meant to run in the standard test suite.
+const unit = require('./unit');
+
+module.exports = {
+  ...unit,
+  displayName: 'other',
+  testRegex: '^.*/__other_tests__/.*\\.test\\.tsx?$',
+};

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test": "yarn run jest --config jest/unit.js",
     "test-ci": "yarn run jest --config jest/unit-ci.js --ci -w 1",
     "test:ledger": "yarn run jest --config jest/ledger.js --w 1",
+    "test:other": "yarn run jest --config jest/other.js --w 1",
     "e2e": "yarn run jest --config jest/e2e.js",
     "e2e-ci": "yarn run jest --config jest/e2e-ci.js --ci -w 1",
     "tsc": "cross-env NODE_OPTIONS=\"--max-old-space-size=3072\" tsc && tsc -p packages/neo-one-smart-contract && tsc -p packages/neo-one-smart-contract-lib && tsc -p packages/neo-one-smart-contract-lib/src/__data__/contracts && tsc -p packages/neo-one-smart-contract-compiler/src/__data__/contracts && tsc -p packages/neo-one-server-plugin-project/src/__data__/ico/one/contracts",

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -754,11 +754,11 @@ export interface UserAccountProvider {
    *
    * If the `UserAccountProvider` does not support programatically selecting a `UserAccountID`, it should only ever expose one available `UserAccount` and manage selecting other `UserAccount`s outside of the application.
    */
-  readonly selectUserAccount: (id?: UserAccountID) => Promise<void>;
+  readonly selectUserAccount: (id?: UserAccountID, monitor?: Monitor) => Promise<void>;
   /**
    * Optional support for deleting a `UserAccount`
    */
-  readonly deleteUserAccount?: (id: UserAccountID) => Promise<void>;
+  readonly deleteUserAccount?: (id: UserAccountID, monitor?: Monitor) => Promise<void>;
   /**
    * Optional support for updating the name of a `UserAccount`
    */

--- a/packages/neo-one-client-core/src/__other_tests__/RemoteUserAccountProvider.test.ts
+++ b/packages/neo-one-client-core/src/__other_tests__/RemoteUserAccountProvider.test.ts
@@ -1,0 +1,422 @@
+import { ECPoint, Param, TransactionResult, UInt160, UInt256 } from '@neo-one/client-common';
+import { AsyncIterableX, toArray } from '@reactivex/ix-es2015-cjs/asynciterable';
+import { interval } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+// tslint:disable-next-line no-implicit-dependencies
+import { MessageChannel } from 'worker_threads';
+import { data, factory, keys } from '../__data__';
+import { Hash256 } from '../Hash256';
+import { connectRemoteUserAccountProvider, RemoteUserAccountProvider } from '../user';
+
+describe('RemoteUserAccountProvider', () => {
+  const unlockedWallet = factory.createUnlockedWallet();
+  const unlockedWallet1 = factory.createUnlockedWallet({
+    userAccount: factory.createUserAccount({ id: factory.createUserAccountID({ address: keys[2].address }) }),
+  });
+  const allScriptBuilderParams = [
+    data.bns.a,
+    data.numbers.a,
+    Buffer.alloc(20, 7) as UInt160,
+    Buffer.alloc(32, 8) as UInt256,
+    Buffer.alloc(33, 9) as ECPoint,
+    'stringData',
+    Buffer.from('abc123', 'hex'),
+    true,
+    [data.bns.b, data.numbers.b],
+    new Map([[data.bns.a, data.numbers.b]]),
+    { key: false },
+    undefined,
+  ];
+  const allParamsZipped = [
+    ['undefined', undefined],
+    ['bignumber', data.bigNumbers.a],
+    ['buffer', data.buffers.a],
+    ['address', unlockedWallet.userAccount.id.address],
+    ['hash256', data.hash256s.a],
+    ['publicKey', keys[0].publicKeyString],
+    ['boolean', true],
+    ['array', [['undefined', undefined], ['bignumber', data.bigNumbers.a]]],
+    ['map', new Map([[data.bns.a, data.numbers.b]])],
+    ['object', { key: false }],
+    ['forward', { name: 'forwardValue', converted: Buffer.alloc(20, 7), param: unlockedWallet.userAccount.id.address }],
+  ] as ReadonlyArray<[string, Param | undefined]>;
+  const transactionOptions = {
+    from: unlockedWallet1.userAccount.id,
+    attributes: [
+      factory.createAddressAttribute(),
+      factory.createBufferAttribute(),
+      factory.createPublicKeyAttribute(),
+      factory.createHash256Attribute(),
+    ],
+    networkFee: data.bigNumbers.a,
+    systemFee: data.bigNumbers.b,
+  };
+  const sourceMap = Promise.resolve({
+    [keys[0].address]: {
+      version: 1,
+      sources: ['source1', 'source2'],
+      names: ['name1', 'name2'],
+      sourceRoot: 'root',
+      sourcesContent: ['content1', 'content2'],
+      mappings: 'mapping',
+      file: 'file.ts',
+    },
+  });
+  const blockCount = 1337;
+  const block = factory.createBlock();
+  const rawAction = factory.createRawLog();
+  const selectUserAccount = jest.fn(async () => Promise.resolve(undefined));
+  const deleteUserAccount = jest.fn(async () => Promise.resolve(undefined));
+  const updateUserAccountName = jest.fn(async () => Promise.resolve(undefined));
+  const commonRawCallReceipt = factory.createRawCallReceipt();
+  const call = jest.fn(async () => commonRawCallReceipt);
+  const iterBlocks = jest.fn(() => AsyncIterableX.from([block]));
+  const getBlockCount = jest.fn(async () => blockCount);
+  const getAccount = jest.fn(async () => unlockedWallet.userAccount);
+  const iterActionsRaw = jest.fn(() => AsyncIterableX.from([rawAction]));
+  let transfer: jest.Mock<Promise<TransactionResult>>;
+
+  // tslint:disable-next-line no-any
+  let provider: any;
+  // tslint:disable-next-line no-any
+  let port1: any;
+  // tslint:disable-next-line no-any
+  let port2: any;
+  let cleanupSubscriptions: () => void;
+  let remoteUserAccountProvider: RemoteUserAccountProvider;
+  let commonTransactionResult = factory.createTransactionResult();
+  beforeEach(() => {
+    transfer = jest.fn(async () => factory.createTransactionResult());
+    commonTransactionResult = factory.createTransactionResult();
+
+    provider = {
+      currentUserAccount$: interval(50).pipe(map(() => unlockedWallet.userAccount)),
+      userAccounts$: interval(50).pipe(map(() => [unlockedWallet.userAccount])),
+      networks$: interval(50).pipe(map(() => [unlockedWallet.userAccount.id.network])),
+      getCurrentUserAccount: jest.fn(() => unlockedWallet.userAccount),
+      getUserAccounts: jest.fn(() => [unlockedWallet.userAccount]),
+      getNetworks: jest.fn(() => [unlockedWallet.userAccount.id.network]),
+      selectUserAccount,
+      deleteUserAccount,
+      updateUserAccountName,
+      transfer,
+      claim: jest.fn(async () => commonTransactionResult),
+      invoke: jest.fn(async () => commonTransactionResult),
+      invokeSend: jest.fn(async () => commonTransactionResult),
+      invokeRefundAssets: jest.fn(async () => commonTransactionResult),
+      invokeCompleteSend: jest.fn(async () => commonTransactionResult),
+      invokeClaim: jest.fn(async () => commonTransactionResult),
+      call,
+      iterBlocks,
+      getBlockCount,
+      getAccount,
+      iterActionsRaw,
+    };
+
+    const messageChannel = new MessageChannel();
+    port1 = messageChannel.port1;
+    port2 = messageChannel.port2;
+    // tslint:disable-next-line:no-object-mutation
+    port1.addEventListener = (listener: (message: string) => void) => port1.on('message', listener);
+    // tslint:disable-next-line:no-object-mutation
+    port2.addEventListener = (listener: (message: string) => void) => port2.on('message', listener);
+
+    remoteUserAccountProvider = new RemoteUserAccountProvider({
+      endpoint: port1,
+    });
+
+    cleanupSubscriptions = connectRemoteUserAccountProvider({
+      endpoint: port2,
+      userAccountProvider: provider,
+    });
+  });
+
+  afterEach(() => {
+    cleanupSubscriptions();
+    port1.close();
+    port2.close();
+  });
+
+  test('currentUserAccount$', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const currentUserAccount = await remoteUserAccountProvider.currentUserAccount$.pipe(take(1)).toPromise();
+
+    expect(currentUserAccount).toEqual(unlockedWallet.userAccount);
+  });
+
+  test('userAccounts$', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const userAccounts = await remoteUserAccountProvider.userAccounts$.pipe(take(1)).toPromise();
+
+    expect(userAccounts).toEqual([unlockedWallet.userAccount]);
+  });
+
+  test('networks$', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const networks = await remoteUserAccountProvider.networks$.pipe(take(1)).toPromise();
+
+    expect(networks).toEqual([unlockedWallet.userAccount.id.network]);
+  });
+
+  test('getCurrentUserAccount', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const currentUserAccount = remoteUserAccountProvider.getCurrentUserAccount();
+
+    expect(currentUserAccount).toEqual(unlockedWallet.userAccount);
+  });
+
+  test('getUserAccounts', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const userAccounts = remoteUserAccountProvider.getUserAccounts();
+
+    expect(userAccounts).toEqual([unlockedWallet.userAccount]);
+  });
+
+  test('getNetworks', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const networks = remoteUserAccountProvider.getNetworks();
+
+    expect(networks).toEqual([unlockedWallet.userAccount.id.network]);
+  });
+
+  test('selectUserAccount', async () => {
+    await remoteUserAccountProvider.selectUserAccount(unlockedWallet1.userAccount.id);
+
+    expect(selectUserAccount.mock.calls).toMatchSnapshot();
+  });
+
+  test('deleteUserAccount', async () => {
+    await remoteUserAccountProvider.deleteUserAccount(unlockedWallet.userAccount.id);
+
+    expect(deleteUserAccount.mock.calls).toMatchSnapshot();
+  });
+
+  test('updateUserAccountName', async () => {
+    await remoteUserAccountProvider.updateUserAccountName({ id: unlockedWallet.userAccount.id, name: 'newName' });
+
+    expect(updateUserAccountName.mock.calls).toMatchSnapshot();
+  });
+
+  test('getBlockCount', async () => {
+    const count = await remoteUserAccountProvider.getBlockCount(unlockedWallet.userAccount.id.network);
+
+    expect(count).toEqual(blockCount);
+  });
+
+  test('getAccount', async () => {
+    const account = await remoteUserAccountProvider.getAccount(
+      unlockedWallet.userAccount.id.network,
+      unlockedWallet.userAccount.id.address,
+    );
+
+    expect(account).toEqual(unlockedWallet.userAccount);
+  });
+
+  test('transfer', async () => {
+    const transactionResult = factory.createTransactionResult();
+    transfer.mockImplementation(async () => transactionResult);
+
+    const result = await remoteUserAccountProvider.transfer(
+      [{ amount: data.bigNumbers.a, asset: Hash256.NEO, to: keys[0].address }],
+      {
+        from: unlockedWallet1.userAccount.id,
+      },
+    );
+
+    expect(transfer.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(transactionResult.transaction);
+
+    const receipt = await result.confirmed();
+    expect((transactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await transactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('claim', async () => {
+    const result = await remoteUserAccountProvider.claim(transactionOptions);
+
+    expect(provider.claim.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('invoke', async () => {
+    const result = await remoteUserAccountProvider.invoke(
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+      allParamsZipped,
+      true,
+      {
+        sendFrom: [{ amount: data.bigNumbers.a, asset: Hash256.NEO, to: keys[0].address }],
+        sendTo: [{ amount: data.bigNumbers.a, asset: Hash256.NEO }],
+      },
+      sourceMap,
+    );
+
+    expect(provider.invoke.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+    expect(provider.invoke.mock.calls[0][6]).toEqual(sourceMap);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('invokeSend', async () => {
+    const result = await remoteUserAccountProvider.invokeSend(
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+      allParamsZipped,
+      {
+        amount: data.bigNumbers.a,
+        asset: Hash256.NEO,
+        to: keys[0].address,
+      },
+      transactionOptions,
+      sourceMap,
+    );
+
+    expect(provider.invokeSend.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+    expect(provider.invokeSend.mock.calls[0][6]).toEqual(sourceMap);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('invokeCompleteSend', async () => {
+    const result = await remoteUserAccountProvider.invokeCompleteSend(
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+      allParamsZipped,
+      Hash256.NEO,
+      transactionOptions,
+    );
+
+    expect(provider.invokeCompleteSend.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('invokeRefundAssets', async () => {
+    const result = await remoteUserAccountProvider.invokeRefundAssets(
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+      allParamsZipped,
+      Hash256.NEO,
+      transactionOptions,
+      sourceMap,
+    );
+
+    expect(provider.invokeRefundAssets.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+    expect(provider.invokeRefundAssets.mock.calls[0][6]).toEqual(sourceMap);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('invokeClaim', async () => {
+    const result = await remoteUserAccountProvider.invokeClaim(
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+      allParamsZipped,
+      transactionOptions,
+    );
+
+    expect(provider.invokeClaim.mock.calls).toMatchSnapshot();
+    expect(result.transaction).toEqual(commonTransactionResult.transaction);
+
+    const receipt = await result.confirmed({ timeoutMS: 1257 });
+    expect((commonTransactionResult.confirmed as jest.Mock).mock.calls).toMatchSnapshot();
+
+    const expectedReceipt = await commonTransactionResult.confirmed();
+    expect(receipt).toEqual(expectedReceipt);
+  });
+
+  test('call', async () => {
+    const result = await remoteUserAccountProvider.call(
+      unlockedWallet.userAccount.id.network,
+      keys[0].address,
+      'deploy',
+      allScriptBuilderParams,
+    );
+
+    expect(call.mock.calls).toMatchSnapshot();
+    expect(result).toEqual(commonRawCallReceipt);
+  });
+
+  test('iterBlocks', async () => {
+    const blockIterator = remoteUserAccountProvider.iterBlocks(unlockedWallet.userAccount.id.network, {
+      indexStart: 1,
+      indexStop: 3,
+    });
+
+    const value = await toArray(blockIterator);
+    expect(value).toEqual([block]);
+  });
+
+  test('iterActionsRaw', async () => {
+    const actionIterator = remoteUserAccountProvider.iterActionsRaw(unlockedWallet.userAccount.id.network, {
+      indexStart: 1,
+      indexStop: 3,
+    });
+
+    const value = await toArray(actionIterator);
+    expect(value).toEqual([rawAction]);
+  });
+
+  test('stress test', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    const blockIterator = remoteUserAccountProvider.iterBlocks(unlockedWallet.userAccount.id.network, {
+      indexStart: 1,
+      indexStop: 3,
+    });
+    const networks = remoteUserAccountProvider.getNetworks();
+    const [currentAccount, invokeClaimResult, count, callResult, account, blockIteratorResult] = await Promise.all([
+      remoteUserAccountProvider.currentUserAccount$.pipe(take(1)).toPromise(),
+      remoteUserAccountProvider.invokeClaim(keys[0].address, 'deploy', [], []),
+      remoteUserAccountProvider.getBlockCount(unlockedWallet.userAccount.id.network),
+      remoteUserAccountProvider.call(unlockedWallet.userAccount.id.network, keys[0].address, 'deploy', []),
+      remoteUserAccountProvider.getAccount(
+        unlockedWallet.userAccount.id.network,
+        unlockedWallet.userAccount.id.address,
+      ),
+      toArray(blockIterator),
+    ]);
+
+    expect(currentAccount).toEqual(unlockedWallet.userAccount);
+    expect(invokeClaimResult.transaction).toEqual(commonTransactionResult.transaction);
+    expect(provider.invokeClaim.mock.calls).toMatchSnapshot();
+    expect(count).toEqual(blockCount);
+    expect(callResult).toEqual(commonRawCallReceipt);
+    expect(call.mock.calls).toMatchSnapshot();
+    expect(account).toEqual(unlockedWallet.userAccount);
+    expect(blockIteratorResult).toEqual([block]);
+    expect(networks).toEqual([unlockedWallet.userAccount.id.network]);
+  });
+});

--- a/packages/neo-one-client-core/src/__other_tests__/__snapshots__/RemoteUserAccountProvider.test.ts.snap
+++ b/packages/neo-one-client-core/src/__other_tests__/__snapshots__/RemoteUserAccountProvider.test.ts.snap
@@ -1,0 +1,872 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RemoteUserAccountProvider call 1`] = `
+Array [
+  Array [
+    "main",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider claim 1`] = `
+Array [
+  Array [
+    Object {
+      "attributes": Array [
+        Object {
+          "data": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+          "usage": "Script",
+        },
+        Object {
+          "data": "b500",
+          "usage": "Description",
+        },
+        Object {
+          "data": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+          "usage": "ECDH02",
+        },
+        Object {
+          "data": "0x0621113df436c180a47b833a2814008dc4f332915b22253651593a40a342e0fb",
+          "usage": "Hash1",
+        },
+      ],
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+      "networkFee": "10",
+      "systemFee": "100",
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider claim 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider deleteUserAccount 1`] = `
+Array [
+  Array [
+    Object {
+      "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      "network": "main",
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invoke 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        "undefined",
+        undefined,
+      ],
+      Array [
+        "bignumber",
+        "10",
+      ],
+      Array [
+        "buffer",
+        "b500",
+      ],
+      Array [
+        "address",
+        "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      ],
+      Array [
+        "hash256",
+        "0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234",
+      ],
+      Array [
+        "publicKey",
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+      ],
+      Array [
+        "boolean",
+        true,
+      ],
+      Array [
+        "array",
+        Array [
+          Array [
+            "undefined",
+            undefined,
+          ],
+          Array [
+            "bignumber",
+            "10",
+          ],
+        ],
+      ],
+      Array [
+        "map",
+        Array [
+          Array [
+            "100000000",
+            8,
+          ],
+        ],
+      ],
+      Array [
+        "object",
+        Object {
+          "key": false,
+        },
+      ],
+      Array [
+        "forward",
+        Object {
+          "converted": "0707070707070707070707070707070707070707",
+          "name": "forwardValue",
+          "param": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+    ],
+    true,
+    Object {
+      "sendFrom": Array [
+        Object {
+          "amount": "10",
+          "asset": "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+          "to": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+      "sendTo": Array [
+        Object {
+          "amount": "10",
+          "asset": "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+        },
+      ],
+    },
+    Promise {},
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invoke 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeClaim 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        "undefined",
+        undefined,
+      ],
+      Array [
+        "bignumber",
+        "10",
+      ],
+      Array [
+        "buffer",
+        "b500",
+      ],
+      Array [
+        "address",
+        "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      ],
+      Array [
+        "hash256",
+        "0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234",
+      ],
+      Array [
+        "publicKey",
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+      ],
+      Array [
+        "boolean",
+        true,
+      ],
+      Array [
+        "array",
+        Array [
+          Array [
+            "undefined",
+            undefined,
+          ],
+          Array [
+            "bignumber",
+            "10",
+          ],
+        ],
+      ],
+      Array [
+        "map",
+        Array [
+          Array [
+            "100000000",
+            8,
+          ],
+        ],
+      ],
+      Array [
+        "object",
+        Object {
+          "key": false,
+        },
+      ],
+      Array [
+        "forward",
+        Object {
+          "converted": "0707070707070707070707070707070707070707",
+          "name": "forwardValue",
+          "param": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+    ],
+    Object {
+      "attributes": Array [
+        Object {
+          "data": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+          "usage": "Script",
+        },
+        Object {
+          "data": "b500",
+          "usage": "Description",
+        },
+        Object {
+          "data": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+          "usage": "ECDH02",
+        },
+        Object {
+          "data": "0x0621113df436c180a47b833a2814008dc4f332915b22253651593a40a342e0fb",
+          "usage": "Hash1",
+        },
+      ],
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+      "networkFee": "10",
+      "systemFee": "100",
+    },
+    undefined,
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeClaim 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeCompleteSend 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        "undefined",
+        undefined,
+      ],
+      Array [
+        "bignumber",
+        "10",
+      ],
+      Array [
+        "buffer",
+        "b500",
+      ],
+      Array [
+        "address",
+        "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      ],
+      Array [
+        "hash256",
+        "0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234",
+      ],
+      Array [
+        "publicKey",
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+      ],
+      Array [
+        "boolean",
+        true,
+      ],
+      Array [
+        "array",
+        Array [
+          Array [
+            "undefined",
+            undefined,
+          ],
+          Array [
+            "bignumber",
+            "10",
+          ],
+        ],
+      ],
+      Array [
+        "map",
+        Array [
+          Array [
+            "100000000",
+            8,
+          ],
+        ],
+      ],
+      Array [
+        "object",
+        Object {
+          "key": false,
+        },
+      ],
+      Array [
+        "forward",
+        Object {
+          "converted": "0707070707070707070707070707070707070707",
+          "name": "forwardValue",
+          "param": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+    ],
+    "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+    Object {
+      "attributes": Array [
+        Object {
+          "data": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+          "usage": "Script",
+        },
+        Object {
+          "data": "b500",
+          "usage": "Description",
+        },
+        Object {
+          "data": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+          "usage": "ECDH02",
+        },
+        Object {
+          "data": "0x0621113df436c180a47b833a2814008dc4f332915b22253651593a40a342e0fb",
+          "usage": "Hash1",
+        },
+      ],
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+      "networkFee": "10",
+      "systemFee": "100",
+    },
+    undefined,
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeCompleteSend 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeRefundAssets 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        "undefined",
+        undefined,
+      ],
+      Array [
+        "bignumber",
+        "10",
+      ],
+      Array [
+        "buffer",
+        "b500",
+      ],
+      Array [
+        "address",
+        "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      ],
+      Array [
+        "hash256",
+        "0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234",
+      ],
+      Array [
+        "publicKey",
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+      ],
+      Array [
+        "boolean",
+        true,
+      ],
+      Array [
+        "array",
+        Array [
+          Array [
+            "undefined",
+            undefined,
+          ],
+          Array [
+            "bignumber",
+            "10",
+          ],
+        ],
+      ],
+      Array [
+        "map",
+        Array [
+          Array [
+            "100000000",
+            8,
+          ],
+        ],
+      ],
+      Array [
+        "object",
+        Object {
+          "key": false,
+        },
+      ],
+      Array [
+        "forward",
+        Object {
+          "converted": "0707070707070707070707070707070707070707",
+          "name": "forwardValue",
+          "param": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+    ],
+    "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+    Object {
+      "attributes": Array [
+        Object {
+          "data": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+          "usage": "Script",
+        },
+        Object {
+          "data": "b500",
+          "usage": "Description",
+        },
+        Object {
+          "data": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+          "usage": "ECDH02",
+        },
+        Object {
+          "data": "0x0621113df436c180a47b833a2814008dc4f332915b22253651593a40a342e0fb",
+          "usage": "Hash1",
+        },
+      ],
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+      "networkFee": "10",
+      "systemFee": "100",
+    },
+    Promise {},
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeRefundAssets 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeSend 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        "undefined",
+        undefined,
+      ],
+      Array [
+        "bignumber",
+        "10",
+      ],
+      Array [
+        "buffer",
+        "b500",
+      ],
+      Array [
+        "address",
+        "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      ],
+      Array [
+        "hash256",
+        "0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234",
+      ],
+      Array [
+        "publicKey",
+        "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+      ],
+      Array [
+        "boolean",
+        true,
+      ],
+      Array [
+        "array",
+        Array [
+          Array [
+            "undefined",
+            undefined,
+          ],
+          Array [
+            "bignumber",
+            "10",
+          ],
+        ],
+      ],
+      Array [
+        "map",
+        Array [
+          Array [
+            "100000000",
+            8,
+          ],
+        ],
+      ],
+      Array [
+        "object",
+        Object {
+          "key": false,
+        },
+      ],
+      Array [
+        "forward",
+        Object {
+          "converted": "0707070707070707070707070707070707070707",
+          "name": "forwardValue",
+          "param": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        },
+      ],
+    ],
+    Object {
+      "amount": "10",
+      "asset": "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+      "to": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    },
+    Object {
+      "attributes": Array [
+        Object {
+          "data": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+          "usage": "Script",
+        },
+        Object {
+          "data": "b500",
+          "usage": "Description",
+        },
+        Object {
+          "data": "02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef",
+          "usage": "ECDH02",
+        },
+        Object {
+          "data": "0x0621113df436c180a47b833a2814008dc4f332915b22253651593a40a342e0fb",
+          "usage": "Hash1",
+        },
+      ],
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+      "networkFee": "10",
+      "systemFee": "100",
+    },
+    Promise {},
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider invokeSend 2`] = `
+Array [
+  Array [
+    Object {
+      "timeoutMS": 1257,
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider selectUserAccount 1`] = `
+Array [
+  Array [
+    Object {
+      "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+      "network": "main",
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider stress test 1`] = `
+Array [
+  Array [
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [],
+    Array [],
+    undefined,
+    undefined,
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider stress test 2`] = `
+Array [
+  Array [
+    "main",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [
+      "100000000",
+      20,
+      "0707070707070707070707070707070707070707",
+      "0808080808080808080808080808080808080808080808080808080808080808",
+      "090909090909090909090909090909090909090909090909090909090909090909",
+      "stringData",
+      "abc123",
+      true,
+      Array [
+        "1000000000",
+        8,
+      ],
+      Array [
+        Array [
+          "100000000",
+          8,
+        ],
+      ],
+      Object {
+        "key": false,
+      },
+      undefined,
+    ],
+  ],
+  Array [
+    "main",
+    "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+    "deploy",
+    Array [],
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider transfer 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "amount": "10",
+        "asset": "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+        "to": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+      },
+    ],
+    Object {
+      "from": Object {
+        "address": "AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx",
+        "network": "main",
+      },
+    },
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider transfer 2`] = `
+Array [
+  Array [
+    undefined,
+  ],
+]
+`;
+
+exports[`RemoteUserAccountProvider updateUserAccountName 1`] = `
+Array [
+  Array [
+    Object {
+      "id": Object {
+        "address": "ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW",
+        "network": "main",
+      },
+      "name": "newName",
+    },
+  ],
+]
+`;

--- a/packages/neo-one-client-core/src/user/RemoteUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/RemoteUserAccountProvider.ts
@@ -1,0 +1,379 @@
+import {
+  Account,
+  AddressString,
+  Block,
+  ClaimTransaction,
+  GetOptions,
+  Hash256String,
+  InvocationTransaction,
+  InvokeSendUnsafeReceiveTransactionOptions,
+  IterOptions,
+  NetworkType,
+  Param,
+  RawAction,
+  RawCallReceipt,
+  RawInvokeReceipt,
+  ScriptBuilderParam,
+  SourceMaps,
+  TransactionOptions,
+  TransactionReceipt,
+  TransactionResult,
+  Transfer,
+  UpdateAccountNameOptions,
+  UserAccount,
+  UserAccountID,
+  UserAccountProvider,
+} from '@neo-one/client-common';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
+import { Endpoint, Message } from './messageTypes';
+import { deserialize, serialize } from './serializeUtils';
+
+// tslint:disable no-let
+let messageID = 0;
+const getID = () => {
+  const currentID = messageID;
+  messageID = currentID === Number.MAX_SAFE_INTEGER ? 0 : messageID + 1;
+
+  return `${currentID}`;
+};
+
+const handleReceiveResponse = async (id: string, messageEndpoint: Endpoint) =>
+  // tslint:disable-next-line no-any
+  new Promise<any>((resolve, reject) => {
+    function listener(event: Message) {
+      if (event.id === id && event.type !== 'NEXT') {
+        if (event.type === 'RETURN') {
+          resolve(deserialize(event.value));
+        }
+        if (event.type === 'ERROR') {
+          reject(deserialize(event.value));
+        }
+      }
+    }
+
+    messageEndpoint.addEventListener(listener);
+  });
+
+async function* asyncGenerator(messageEndpoint: Endpoint, method: string, network: NetworkType, options?: IterOptions) {
+  const id = getID();
+  messageEndpoint.postMessage({
+    type: 'ASYNCITERABLE',
+    method,
+    args: [serialize(network), serialize(options)],
+    id,
+  });
+  // tslint:disable-next-line:no-loop-statement
+  while (true) {
+    // tslint:disable-next-line no-any
+    const rawActionIterator = handleReceiveResponse(id, messageEndpoint);
+    messageEndpoint.postMessage({ type: 'NEXT', id });
+
+    const result = await rawActionIterator;
+    if (result.done) {
+      break;
+    }
+
+    yield result.value;
+  }
+}
+
+export class RemoteUserAccountProvider implements UserAccountProvider {
+  public readonly currentUserAccount$: Observable<UserAccount | undefined>;
+  public readonly userAccounts$: Observable<ReadonlyArray<UserAccount>>;
+  public readonly networks$: Observable<ReadonlyArray<NetworkType>>;
+  private readonly messageEndpoint: Endpoint;
+  private readonly currentAccountInternal$: BehaviorSubject<UserAccount | undefined>;
+  private readonly userAccountsInternal$: BehaviorSubject<ReadonlyArray<UserAccount>>;
+  private readonly networksInternal$: BehaviorSubject<ReadonlyArray<NetworkType>>;
+
+  public constructor({ endpoint }: { readonly endpoint: Endpoint }) {
+    this.messageEndpoint = endpoint;
+
+    this.userAccountsInternal$ = new BehaviorSubject<ReadonlyArray<UserAccount>>([]);
+    this.currentAccountInternal$ = new BehaviorSubject<UserAccount | undefined>(undefined);
+    this.networksInternal$ = new BehaviorSubject<ReadonlyArray<NetworkType>>([]);
+    this.messageEndpoint.addEventListener((event: Message) => {
+      switch (event.type) {
+        case 'OBSERVABLE': {
+          if (event.id === 'userAccounts$') {
+            this.userAccountsInternal$.next(deserialize(event.value) as ReadonlyArray<UserAccount>);
+          }
+          if (event.id === 'currentUserAccount$') {
+            this.currentAccountInternal$.next(deserialize(event.value) as UserAccount | undefined);
+          }
+          if (event.id === 'networks$') {
+            this.networksInternal$.next(deserialize(event.value) as ReadonlyArray<NetworkType>);
+          }
+          break;
+        }
+        case 'ERROR': {
+          try {
+            deserialize(event.value);
+          } catch (error) {
+            if (event.id === 'userAccounts$') {
+              this.userAccountsInternal$.error(error);
+            }
+            if (event.id === 'currentUserAccount$') {
+              this.currentAccountInternal$.error(error);
+            }
+            if (event.id === 'networks$') {
+              this.networksInternal$.error(error);
+            }
+          }
+          break;
+        }
+        case 'RETURN': {
+          if (event.id === 'userAccounts$') {
+            this.userAccountsInternal$.complete();
+          }
+          if (event.id === 'currentUserAccount$') {
+            this.currentAccountInternal$.complete();
+          }
+          if (event.id === 'networks$') {
+            this.networksInternal$.complete();
+          }
+          break;
+        }
+        default:
+      }
+    });
+    this.userAccounts$ = this.userAccountsInternal$;
+    this.currentUserAccount$ = this.currentAccountInternal$.pipe(distinctUntilChanged());
+    this.networks$ = this.networksInternal$;
+  }
+
+  public getCurrentUserAccount(): UserAccount | undefined {
+    return this.currentAccountInternal$.getValue();
+  }
+
+  public async selectUserAccount(userAccountID?: UserAccountID): Promise<void> {
+    const result = await this.handleRelayMethod({
+      method: 'selectUserAccount',
+      args: [userAccountID],
+    });
+
+    return result.result;
+  }
+
+  public async deleteUserAccount(userAccountID?: UserAccountID): Promise<void> {
+    const result = await this.handleRelayMethod({ method: 'deleteUserAccount', args: [userAccountID] });
+
+    return result.result;
+  }
+
+  public getUserAccounts(): ReadonlyArray<UserAccount> {
+    return this.userAccountsInternal$.getValue();
+  }
+
+  public getNetworks(): ReadonlyArray<NetworkType> {
+    return this.networksInternal$.getValue();
+  }
+
+  public async updateUserAccountName(options: UpdateAccountNameOptions): Promise<void> {
+    const result = await this.handleRelayMethod({ method: 'updateUserAccountName', args: [options] });
+
+    return result.result;
+  }
+
+  public async getBlockCount(network: NetworkType): Promise<number> {
+    const result = await this.handleRelayMethod({ method: 'getBlockCount', args: [network] });
+
+    return result.result;
+  }
+
+  public async getAccount(network: NetworkType, address: AddressString): Promise<Account> {
+    const result = await this.handleRelayMethod({ method: 'getAccount', args: [network, address] });
+
+    return result.result;
+  }
+
+  public iterBlocks(network: NetworkType, options?: IterOptions): AsyncIterable<Block> {
+    return asyncGenerator(this.messageEndpoint, 'iterBlocks', network, options);
+  }
+
+  public iterActionsRaw(network: NetworkType, options?: IterOptions): AsyncIterable<RawAction> {
+    return asyncGenerator(this.messageEndpoint, 'iterActionsRaw', network, options);
+  }
+
+  public async transfer(
+    transfers: ReadonlyArray<Transfer>,
+    options?: TransactionOptions,
+  ): Promise<TransactionResult<TransactionReceipt, InvocationTransaction>> {
+    return this.handleMethodWithConfirmation({
+      method: 'transfer',
+      args: [transfers, options],
+    });
+  }
+
+  public async claim(options?: TransactionOptions): Promise<TransactionResult<TransactionReceipt, ClaimTransaction>> {
+    return this.handleMethodWithConfirmation({ method: 'claim', args: [options] });
+  }
+
+  public async invoke(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<[string, Param | undefined]>,
+    verify: boolean,
+    options?: InvokeSendUnsafeReceiveTransactionOptions,
+    sourceMaps?: Promise<SourceMaps>,
+  ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
+    const sourceMapsArg = await this.handleSourceMapArg(sourceMaps);
+
+    return this.handleMethodWithConfirmation({
+      method: 'invoke',
+      args: [contract, method, params, paramsZipped, verify, options, sourceMapsArg],
+    });
+  }
+
+  public async invokeSend(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<[string, Param | undefined]>,
+    transfer: Transfer,
+    options?: TransactionOptions,
+    sourceMaps?: Promise<SourceMaps>,
+  ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
+    const sourceMapsArg = await this.handleSourceMapArg(sourceMaps);
+
+    return this.handleMethodWithConfirmation({
+      method: 'invokeSend',
+      args: [contract, method, params, paramsZipped, transfer, options, sourceMapsArg],
+    });
+  }
+
+  public async invokeCompleteSend(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<[string, Param | undefined]>,
+    hash: Hash256String,
+    options?: TransactionOptions,
+    sourceMaps?: Promise<SourceMaps>,
+  ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
+    const sourceMapsArg = await this.handleSourceMapArg(sourceMaps);
+
+    return this.handleMethodWithConfirmation({
+      method: 'invokeCompleteSend',
+      args: [contract, method, params, paramsZipped, hash, options, sourceMapsArg],
+    });
+  }
+
+  public async invokeRefundAssets(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<[string, Param | undefined]>,
+    hash: Hash256String,
+    options?: TransactionOptions,
+    sourceMaps?: Promise<SourceMaps>,
+  ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
+    const sourceMapsArg = await this.handleSourceMapArg(sourceMaps);
+
+    return this.handleMethodWithConfirmation({
+      method: 'invokeRefundAssets',
+      args: [contract, method, params, paramsZipped, hash, options, sourceMapsArg],
+    });
+  }
+
+  public async invokeClaim(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<[string, Param | undefined]>,
+    options?: TransactionOptions,
+    sourceMaps?: Promise<SourceMaps>,
+  ): Promise<TransactionResult<TransactionReceipt, ClaimTransaction>> {
+    const sourceMapsArg = await this.handleSourceMapArg(sourceMaps);
+
+    return this.handleMethodWithConfirmation({
+      method: 'invokeClaim',
+      args: [contract, method, params, paramsZipped, options, sourceMapsArg],
+    });
+  }
+
+  public async call(
+    network: NetworkType,
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+  ): Promise<RawCallReceipt> {
+    const result = await this.handleRelayMethod({
+      method: 'call',
+      args: [network, contract, method, params],
+    });
+
+    return result.result;
+  }
+
+  private async handleRelayMethod({
+    method,
+    args,
+    confirm = false,
+  }: {
+    readonly method: string;
+    // tslint:disable-next-line no-any
+    readonly args: ReadonlyArray<any>;
+    readonly confirm?: boolean;
+  }) {
+    const id = getID();
+    this.messageEndpoint.postMessage({
+      type: 'METHOD',
+      method,
+      confirm,
+      args: args.map(serialize),
+      id,
+    });
+
+    const result = await handleReceiveResponse(id, this.messageEndpoint);
+
+    return { id, result };
+  }
+
+  private handleConfirmation(id: string) {
+    return async (options?: GetOptions) => {
+      this.messageEndpoint.postMessage({
+        type: 'CONFIRMATION',
+        method: 'confirmed',
+        args: [serialize(options)],
+        id,
+      });
+
+      return handleReceiveResponse(id, this.messageEndpoint);
+    };
+  }
+
+  private async handleMethodWithConfirmation({
+    method,
+    args,
+  }: {
+    readonly method: string;
+    // tslint:disable-next-line no-any
+    readonly args: ReadonlyArray<any>;
+  }) {
+    const result = await this.handleRelayMethod({
+      method,
+      args,
+      confirm: true,
+    });
+
+    return {
+      ...result.result,
+      confirmed: this.handleConfirmation(result.id),
+    };
+  }
+
+  private async handleSourceMapArg(sourceMaps?: Promise<SourceMaps>) {
+    if (sourceMaps === undefined) {
+      return undefined;
+    }
+    const sourceMapsResolve = await sourceMaps;
+
+    return {
+      type: 'SourceMap',
+      value: sourceMapsResolve,
+    };
+  }
+}

--- a/packages/neo-one-client-core/src/user/connectRemoteUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/connectRemoteUserAccountProvider.ts
@@ -1,0 +1,163 @@
+// tslint:disable only-arrow-functions
+import { Block, GetOptions, RawAction, TransactionReceipt, UserAccountProvider } from '@neo-one/client-common';
+import { Endpoint, Message } from './messageTypes';
+import { deserialize, serialize } from './serializeUtils';
+
+export interface ConnectRemoteUserAccountProviderOptions {
+  readonly endpoint: Endpoint;
+  readonly userAccountProvider: UserAccountProvider;
+}
+
+export const connectRemoteUserAccountProvider = ({
+  endpoint,
+  userAccountProvider: userAccountProviderIn,
+}: ConnectRemoteUserAccountProviderOptions) => {
+  // tslint:disable-next-line no-any
+  const userAccountProvider: any = userAccountProviderIn;
+  const asyncIterableInstanceMap: { [id: string]: AsyncIterator<Block | RawAction> } = {};
+  const confirmationCallbackMap: { [id: string]: (options?: GetOptions) => Promise<TransactionReceipt> } = {};
+
+  endpoint.addEventListener((event: Message) => {
+    if (event.type === 'METHOD') {
+      try {
+        if (userAccountProvider[event.method] === undefined) {
+          throw new Error(`Method ${event.method} is not implemented by the requested Provider.`);
+        }
+
+        // tslint:disable-next-line no-any
+        userAccountProvider[event.method](...event.args.map(deserialize)).then((value: any) => {
+          let returnValue = value;
+          if (event.confirm) {
+            // tslint:disable-next-line no-object-mutation
+            confirmationCallbackMap[event.id] = value.confirmed;
+            returnValue = {
+              ...value,
+              confirmed: undefined,
+            };
+          }
+
+          endpoint.postMessage({ type: 'RETURN', value: serialize(returnValue), id: event.id });
+        });
+      } catch (error) {
+        endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+      }
+    }
+  });
+
+  const handleConfirm = async (event: Message) => {
+    if (event.type === 'CONFIRMATION') {
+      if (
+        (confirmationCallbackMap[event.id] as ((options?: GetOptions) => Promise<TransactionReceipt>) | undefined) ===
+        undefined
+      ) {
+        endpoint.postMessage({
+          type: 'ERROR',
+          value: serialize(new Error(`No confirmation callback registered for id: ${event.id}`)),
+          id: event.id,
+        });
+      }
+      confirmationCallbackMap[event.id](deserialize(event.args[0]) as GetOptions | undefined)
+        .then((value) => {
+          endpoint.postMessage({
+            type: 'RETURN',
+            value: serialize(value),
+            id: event.id,
+          });
+        })
+        .catch((error) => {
+          endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+        });
+    }
+  };
+
+  endpoint.addEventListener((event: Message) => {
+    handleConfirm(event).catch((error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+    });
+  });
+
+  const handleRegisterAsyncIterable = async (event: Message) => {
+    if (event.type === 'ASYNCITERABLE') {
+      // tslint:disable-next-line no-object-mutation
+      asyncIterableInstanceMap[event.id] = userAccountProvider[event.method](...event.args.map(deserialize))[
+        Symbol.asyncIterator
+      ]();
+    }
+  };
+
+  endpoint.addEventListener((event: Message) => {
+    handleRegisterAsyncIterable(event).catch((error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+    });
+  });
+
+  const handleNext = async (event: Message) => {
+    if (event.type === 'NEXT') {
+      if ((asyncIterableInstanceMap[event.id] as AsyncIterator<Block | RawAction> | undefined) === undefined) {
+        endpoint.postMessage({
+          type: 'ERROR',
+          value: serialize(new Error(`No async iterable registered for id: ${event.id}`)),
+          id: event.id,
+        });
+      }
+      asyncIterableInstanceMap[event.id]
+        .next()
+        .then((value) => {
+          endpoint.postMessage({
+            type: 'RETURN',
+            value: serialize(value),
+            id: event.id,
+          });
+        })
+        .catch((error) => {
+          endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+        });
+    }
+  };
+
+  endpoint.addEventListener((event: Message) => {
+    handleNext(event).catch((error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: event.id });
+    });
+  });
+
+  const currentUserAccountSubscription = userAccountProviderIn.currentUserAccount$.subscribe({
+    next: (value) => {
+      endpoint.postMessage({ type: 'OBSERVABLE', id: 'currentUserAccount$', value: serialize(value) });
+    },
+    error: (error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: 'currentUserAccount$' });
+    },
+    complete: () => {
+      endpoint.postMessage({ type: 'RETURN', id: 'currentUserAccount$', value: serialize('Complete') });
+    },
+  });
+  const userAccountsSubscription = userAccountProviderIn.userAccounts$.subscribe({
+    next: (value) => {
+      endpoint.postMessage({ type: 'OBSERVABLE', id: 'userAccounts$', value: serialize(value) });
+    },
+    error: (error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: 'userAccounts$' });
+    },
+    complete: () => {
+      endpoint.postMessage({ type: 'RETURN', id: 'userAccounts$', value: serialize('Complete') });
+    },
+  });
+  const networksSubscription = userAccountProviderIn.networks$.subscribe({
+    next: (value) => {
+      endpoint.postMessage({ type: 'OBSERVABLE', id: 'networks$', value: serialize(value) });
+    },
+    error: (error) => {
+      endpoint.postMessage({ type: 'ERROR', value: serialize(error), id: 'networks$' });
+    },
+    complete: () => {
+      endpoint.postMessage({ type: 'RETURN', id: 'networks$', value: serialize('Complete') });
+    },
+  });
+
+  return () => {
+    currentUserAccountSubscription.unsubscribe();
+    userAccountsSubscription.unsubscribe();
+    networksSubscription.unsubscribe();
+  };
+};

--- a/packages/neo-one-client-core/src/user/index.ts
+++ b/packages/neo-one-client-core/src/user/index.ts
@@ -1,3 +1,6 @@
 export * from './converters';
+export * from './connectRemoteUserAccountProvider';
 export * from './keystore';
 export * from './LocalUserAccountProvider';
+export * from './messageTypes';
+export * from './RemoteUserAccountProvider';

--- a/packages/neo-one-client-core/src/user/messageTypes.ts
+++ b/packages/neo-one-client-core/src/user/messageTypes.ts
@@ -1,0 +1,60 @@
+// tslint:disable no-any
+import { SerializedValueToken } from './serializeUtils';
+
+interface BaseMessage {
+  readonly id: string;
+}
+
+interface BaseMethodCall extends BaseMessage {
+  readonly method: string;
+  readonly args: ReadonlyArray<SerializedValueToken>;
+  readonly confirm?: boolean;
+}
+
+export interface MethodCall extends BaseMethodCall {
+  readonly type: 'METHOD';
+}
+
+export interface ConfirmationCall extends BaseMethodCall {
+  readonly type: 'CONFIRMATION';
+}
+
+export interface AsyncIterableReturn extends BaseMethodCall {
+  readonly type: 'ASYNCITERABLE';
+}
+
+export interface NextCall extends BaseMessage {
+  readonly type: 'NEXT';
+}
+
+export interface ObservableValue extends BaseMessage {
+  readonly type: 'OBSERVABLE';
+  readonly value: SerializedValueToken;
+}
+
+export interface ReturnValue extends BaseMessage {
+  readonly type: 'RETURN';
+  readonly value: SerializedValueToken;
+}
+
+export interface ErrorValue extends BaseMessage {
+  readonly type: 'ERROR';
+  readonly value: SerializedValueToken;
+}
+
+export type Message =
+  | MethodCall
+  | ConfirmationCall
+  | AsyncIterableReturn
+  | ObservableValue
+  | NextCall
+  | ReturnValue
+  | ErrorValue;
+
+export type MessageType = Message['type'];
+
+export interface Endpoint {
+  readonly postMessage: (message: Message) => void;
+  readonly addEventListener: (listener: (event: Message) => void) => void;
+  readonly close: () => void;
+}

--- a/packages/neo-one-client-core/src/user/serializeUtils.ts
+++ b/packages/neo-one-client-core/src/user/serializeUtils.ts
@@ -1,0 +1,271 @@
+import { utils } from '@neo-one/utils';
+import BigNumber from 'bignumber.js';
+import BN from 'bn.js';
+
+export interface SerializedObject {
+  readonly [key: string]: SerializedValueToken;
+}
+
+export type SerializedArray = ReadonlyArray<SerializedValueToken>;
+
+export type SerializedMap = ReadonlyArray<SerializedArrayToken>;
+
+export interface SerializedStringToken {
+  readonly type: 'String';
+  readonly value: string;
+}
+
+export interface SerializedNumberToken {
+  readonly type: 'Number';
+  readonly value: number;
+}
+
+export interface SerializedBooleanToken {
+  readonly type: 'Boolean';
+  readonly value: boolean;
+}
+
+export interface SerializedBigNumberToken {
+  readonly type: 'BigNumber';
+  readonly value: string;
+}
+
+export interface SerializedBNToken {
+  readonly type: 'BN';
+  readonly value: string;
+}
+
+export interface SerializedBufferToken {
+  readonly type: 'Buffer';
+  readonly value: string;
+}
+
+export interface SerializedUndefinedToken {
+  readonly type: 'Undefined';
+}
+
+export interface SerializedNullToken {
+  readonly type: 'Null';
+}
+
+export interface SerializedObjectToken {
+  readonly type: 'Object';
+  readonly value: SerializedObject;
+}
+
+export interface SerializedArrayToken {
+  readonly type: 'Array';
+  readonly value: SerializedArray;
+}
+
+export interface SerializedMapToken {
+  readonly type: 'Map';
+  readonly value: SerializedMap;
+}
+
+export interface SerializedSourceMapToken {
+  readonly type: 'SourceMap';
+  readonly value: SerializedObject;
+}
+
+export interface SerializedErrorToken {
+  readonly type: 'Error';
+  readonly message: string;
+  readonly stack: string | undefined;
+}
+
+export type SerializedValueToken =
+  | SerializedStringToken
+  | SerializedNumberToken
+  | SerializedBooleanToken
+  | SerializedBigNumberToken
+  | SerializedBNToken
+  | SerializedBufferToken
+  | SerializedObjectToken
+  | SerializedArrayToken
+  | SerializedMapToken
+  | SerializedSourceMapToken
+  | SerializedUndefinedToken
+  | SerializedNullToken
+  | SerializedErrorToken;
+
+export type DeserializedValue =
+  | string
+  | number
+  | boolean
+  | BigNumber
+  | BN
+  | Buffer
+  | DeserializedObject
+  | Promise<DeserializedObject>
+  | DeserializedArray
+  | DeserializedMap
+  | undefined
+  | null
+  | Error;
+
+export interface DeserializedObject {
+  readonly [key: string]: DeserializedValue;
+}
+// tslint:disable-next-line no-any
+export type DeserializedArray = ReadonlyArray<any>;
+
+// tslint:disable-next-line no-any
+export type DeserializedMap = Map<any, any>;
+
+export const serializeObject = (object: DeserializedObject): SerializedObject =>
+  Object.entries(object).reduce<SerializedObject>(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key]: serialize(value),
+    }),
+    {},
+  );
+
+export const serializeObjectToken = (object: DeserializedObject): SerializedObjectToken => ({
+  type: 'Object',
+  value: serializeObject(object),
+});
+
+export const serializeArray = (array: DeserializedArray): SerializedArrayToken => ({
+  type: 'Array',
+  value: array.map(serialize),
+});
+
+export const serializeMap = (map: DeserializedMap): SerializedMapToken => {
+  // tslint:disable-next-line no-any
+  const result: any[] = [];
+  // tslint:disable-next-line no-array-mutation
+  map.forEach((value, key) => result.push(serialize([key, value])));
+
+  return {
+    type: 'Map',
+    value: result,
+  };
+};
+
+// tslint:disable-next-line no-any
+export const serialize = (value: any): SerializedValueToken => {
+  if (value === null) {
+    return {
+      type: 'Null',
+    };
+  }
+  if (value === undefined) {
+    return {
+      type: 'Undefined',
+    };
+  }
+  if (typeof value === 'boolean') {
+    return {
+      type: 'Boolean',
+      value,
+    };
+  }
+  if (typeof value === 'number') {
+    return {
+      type: 'Number',
+      value,
+    };
+  }
+  if (typeof value === 'string') {
+    return {
+      type: 'String',
+      value,
+    };
+  }
+  if (value instanceof Buffer) {
+    return {
+      type: 'Buffer',
+      value: value.toString('hex'),
+    };
+  }
+  if (value instanceof Map) {
+    return serializeMap(value);
+  }
+  if (BN.isBN(value)) {
+    return {
+      type: 'BN',
+      value: value.toString(),
+    };
+  }
+  if (BigNumber.isBigNumber(value)) {
+    return {
+      type: 'BigNumber',
+      value: value.toString(),
+    };
+  }
+  if (Array.isArray(value)) {
+    return serializeArray(value);
+  }
+  if (value instanceof Error) {
+    return {
+      type: 'Error',
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+  if (value.type === 'SourceMap') {
+    return {
+      type: 'SourceMap',
+      value: serializeObject(value.value),
+    };
+  }
+  if (typeof value === 'object') {
+    return serializeObjectToken(value);
+  }
+
+  throw new Error(`Attempted to serialize invalid value: ${JSON.stringify(value)}`);
+};
+
+export const deserializeObject = (serializedObject: SerializedObject): DeserializedObject =>
+  Object.entries(serializedObject).reduce<DeserializedObject>(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key]: deserialize(value),
+    }),
+    {},
+  );
+
+export const deserializeArray = (serializedArray: SerializedArray): DeserializedArray =>
+  serializedArray.map(deserialize);
+
+export const deserialize = (serializedValue: SerializedValueToken) => {
+  switch (serializedValue.type) {
+    case 'Undefined':
+      return undefined;
+    case 'Null':
+      // tslint:disable-next-line no-null-keyword
+      return null;
+    case 'String':
+      return serializedValue.value;
+    case 'Number':
+      return serializedValue.value;
+    case 'Boolean':
+      return serializedValue.value;
+    case 'BigNumber':
+      return new BigNumber(serializedValue.value);
+    case 'BN':
+      return new BN(serializedValue.value);
+    case 'Buffer':
+      return Buffer.from(serializedValue.value, 'hex');
+    case 'Object':
+      return deserializeObject(serializedValue.value);
+    case 'Array':
+      return deserializeArray(serializedValue.value);
+    case 'Map':
+      return deserializeArray(serializedValue.value);
+    case 'SourceMap':
+      return Promise.resolve(deserializeObject(serializedValue.value));
+    case 'Error':
+      const err = new Error(serializedValue.message);
+      // tslint:disable-next-line no-object-mutation
+      err.stack = serializedValue.stack;
+      throw err;
+    default:
+      /* istanbul ignore next */
+      utils.assertNever(serializedValue);
+      /* istanbul ignore next */
+      throw new Error('For TS');
+  }
+};


### PR DESCRIPTION
…countProvider + Receiver

Implement RemoteUserAccountProvider and RemoteReceiveUserAccountProvider to be able to access
locally stored accounts from a remote endpoint. Added associated tests.

#721

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change
Implement RemoteUserAccountProvider and RemoteReceiveUserAccountProvider to be able to access
locally stored accounts from a remote endpoint. Added associated tests.

### Test Plan
Added unit tests.

### Applicable Issues
#721 