### PR TITLE
fix(deps): update dependency bignumber.js to v8.1.1

### DIFF
--- a/packages/neo-one-client-common/package.json
+++ b/packages/neo-one-client-common/package.json
@@ -14,7 +14,7 @@
     "@types/lodash": "^4.14.120",
     "@types/scrypt-js": "^2.0.2",
     "@types/wif": "^2.0.1",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "bn.js": "^4.11.8",
     "bs58": "^4.0.1",
     "buffer-xor": "^2.0.2",

--- a/packages/neo-one-client-core/package.json
+++ b/packages/neo-one-client-core/package.json
@@ -13,7 +13,7 @@
     "@reactivex/ix-es2015-cjs": "2.5.2",
     "@types/lodash": "^4.14.120",
     "@types/tapable": "^1.0.4",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "bn.js": "^4.11.8",
     "cross-fetch": "^3.0.1",
     "dataloader": "^1.4.0",

--- a/packages/neo-one-client-full-core/package.json
+++ b/packages/neo-one-client-full-core/package.json
@@ -12,7 +12,7 @@
     "@neo-one/types": "^1.1.0",
     "@neo-one/utils": "^1.1.0",
     "@types/lodash": "^4.14.120",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "lodash": "^4.17.11",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-developer-tools-frame/package.json
+++ b/packages/neo-one-developer-tools-frame/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "^16.0.11",
     "@types/react-select": "^2.0.11",
     "@types/styled-components": "^4.1.8",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "date-fns": "^2.0.0-alpha.27",
     "localforage": "^1.7.3",
     "lodash": "^4.17.11",

--- a/packages/neo-one-local/package.json
+++ b/packages/neo-one-local/package.json
@@ -9,7 +9,7 @@
     "@neo-one/client-full-core": "^1.1.0",
     "@neo-one/types": "^1.1.0",
     "@neo-one/utils": "^1.1.0",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "tslib": "^1.9.3"
   },
   "sideEffects": false

--- a/packages/neo-one-node-consensus/package.json
+++ b/packages/neo-one-node-consensus/package.json
@@ -11,7 +11,7 @@
     "@neo-one/utils": "^1.1.0",
     "@reactivex/ix-es2015-cjs": "2.5.2",
     "@types/lodash": "^4.14.120",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "bn.js": "^4.11.8",
     "lodash": "^4.17.11",
     "rxjs": "^6.4.0",

--- a/packages/neo-one-node-core/package.json
+++ b/packages/neo-one-node-core/package.json
@@ -11,7 +11,7 @@
     "@neo-one/utils": "^1.1.0",
     "@types/lodash": "^4.14.120",
     "@types/through": "^0.0.29",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "bn.js": "^4.11.8",
     "lodash": "^4.17.11",
     "rxjs": "^6.4.0",

--- a/packages/neo-one-server-plugin-project/package.json
+++ b/packages/neo-one-server-plugin-project/package.json
@@ -37,7 +37,7 @@
     "@neo-one/smart-contract": "^1.1.0",
     "@neo-one/smart-contract-test": "1.0.0-alpha.44",
     "@types/react": "16.8.5",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4"
   },
   "sideEffects": false

--- a/packages/neo-one-server-plugin-wallet/package.json
+++ b/packages/neo-one-server-plugin-wallet/package.json
@@ -18,7 +18,7 @@
     "@types/fs-extra": "^5.0.4",
     "@types/lodash": "^4.14.120",
     "@types/ora": "^3.0.0",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.11",
     "ora": "^3.0.0",

--- a/packages/neo-one-smart-contract-compiler/package.json
+++ b/packages/neo-one-smart-contract-compiler/package.json
@@ -33,7 +33,7 @@
     "@types/levelup": "3.1.0",
     "@types/memdown": "3.0.0",
     "app-root-dir": "1.0.2",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "levelup": "4.0.0",
     "memdown": "3.0.0"
   },

--- a/packages/neo-one-smart-contract-lib/package.json
+++ b/packages/neo-one-smart-contract-lib/package.json
@@ -13,7 +13,7 @@
     "@neo-one/smart-contract-test": "^1.1.0",
     "@types/app-root-dir": "0.1.0",
     "app-root-dir": "1.0.2",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "tslib": "1.9.3"
   },
   "sideEffects": false

--- a/packages/neo-one-smart-contract-test-common/package.json
+++ b/packages/neo-one-smart-contract-test-common/package.json
@@ -10,7 +10,7 @@
     "@neo-one/local": "^1.1.0",
     "@neo-one/smart-contract-compiler": "^1.1.0",
     "@neo-one/types": "^1.1.0",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^8.1.1",
     "change-case": "^3.1.0",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/0-contracts/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/0-contracts/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/1-properties/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/1-properties/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/2-storage/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/2-storage/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/3-structured-storage/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/3-structured-storage/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/4-constructors/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/4-constructors/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/5-methods/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/5-methods/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/6-events/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/6-events/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/0-token/7-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/0-token/7-transfer/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/0-receiving/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/0-receiving/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/1-processing/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/1-processing/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/2-mint/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/2-mint/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/3-duration/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/3-duration/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/1-ico/4-withdraw/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/1-ico/4-withdraw/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/package.json
@@ -5,7 +5,7 @@
     "@types/react": "16.8.5",
     "@types/react-dom": "16.8.2",
     "@types/styled-components": "4.1.12",
-    "bignumber.js": "8.0.2",
+    "bignumber.js": "8.1.1",
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "rxjs": "6.4.0",

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/0-approvals/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/0-approvals/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/1-deposit/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/1-deposit/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/2-transfer/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/2-transfer/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/3-claim/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/3-claim/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/4-refund/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/4-refund/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/5-generalize/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/5-generalize/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/6-cneo/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/6-cneo/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/3-escrow/7-forward/package.json
+++ b/packages/neo-one-website/courses/0-tokenomics/3-escrow/7-forward/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bignumber.js": "8.0.2"
+    "bignumber.js": "8.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4668,13 +4668,17 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
 
-bignumber.js@8.0.2, bignumber.js@^8.0.1, bignumber.js@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.2.tgz#d8c4e1874359573b1ef03011a2d861214aeef137"
+bignumber.js@8.1.1, bignumber.js@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
 
 bignumber.js@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+
+bignumber.js@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.2.tgz#d8c4e1874359573b1ef03011a2d861214aeef137"
 
 binary-extensions@^1.0.0:
   version "1.13.0"


### PR DESCRIPTION
#1129 - fixed tsc throws by updating some of our `^8.0.2` resolutions. I think a breaking change must have happened that caused an issue when `@neo-one/smart-contract-compiler` used `@8.1.1` but `@neo-one/client-common` (for example) used `@8.0.2`.