### PR TITLE
feat(config): add default .onerc config

### DIFF
--- a/packages/neo-one-server-plugin-project/src/initCommand.ts
+++ b/packages/neo-one-server-plugin-project/src/initCommand.ts
@@ -7,37 +7,55 @@ import jsonFile from 'json-file-plus';
 import * as path from 'path';
 import { loadProjectConfig } from './utils';
 
+interface InitDataFileOpts {
+  readonly folder: string;
+  readonly name: string;
+  // tslint:disable-next-line:no-any
+  readonly data: string;
+  readonly cli: InteractiveCLIArgs['cli'];
+}
+export const initDataFile = async ({ folder, name, data, cli }: InitDataFileOpts) => {
+  const filePath = path.resolve(folder, name);
+  await fs.ensureDir(folder);
+  const createdUpdated = fs.existsSync(filePath) ? 'updated' : 'created';
+  await fs.writeFile(
+    filePath,
+    JSON.stringify(
+      JSON.parse(data),
+      // tslint:disable-next-line:no-null-keyword
+      null,
+      2,
+    ),
+  );
+  cli.print(`${createdUpdated} ${name} at ${filePath}.`);
+};
+
 export const initCommand = ({ cli }: InteractiveCLIArgs) =>
   cli.vorpal.command('init', 'Initialize neo-one in the current directory.').action(async () => {
     const cwd = process.cwd();
     const projectConfig = await loadProjectConfig(cwd);
     const tsconfigPath = path.resolve(projectConfig.paths.contracts, 'tsconfig.json');
     const contractsPath = path.dirname(tsconfigPath);
-
-    await fs.ensureDir(contractsPath);
-    await fs.writeFile(
-      tsconfigPath,
-      JSON.stringify(
-        {
-          compilerOptions: {
-            ...COMPILER_OPTIONS,
-            target: 'esnext',
-            module: 'esnext',
-            moduleResolution: 'node',
-            jsx: 'react',
-            plugins: [
-              {
-                name: '@neo-one/smart-contract-typescript-plugin',
-              },
-            ],
+    const tsData = {
+      compilerOptions: {
+        ...COMPILER_OPTIONS,
+        target: 'esnext',
+        module: 'esnext',
+        moduleResolution: 'node',
+        jsx: 'react',
+        plugins: [
+          {
+            name: '@neo-one/smart-contract-typescript-plugin',
           },
-        },
-        // tslint:disable-next-line:no-null-keyword
-        null,
-        2,
-      ),
-    );
-    cli.print(`Created tsconfig.json at ${tsconfigPath}.`);
+        ],
+      },
+    };
+
+    await Promise.all([
+      initDataFile({ folder: projectConfig.paths.contracts, name: 'tsconfig.json', data: JSON.stringify(tsData), cli }),
+      initDataFile({ folder: cwd, name: '.onerc', data: JSON.stringify(projectConfig), cli }),
+    ]);
+
     const rootTsConfigPath = path.resolve(cwd, 'tsconfig.json');
     const exists = await fs.pathExists(rootTsConfigPath);
     if (exists) {


### PR DESCRIPTION
write ` .onerc ` with default config values.

### Requirements

Produce a .onerc config file with when ` yarn neo-one init ` is called

### Description of the Change

adds a new ` .onerc ` config file during the init process containing the default configuration as specified in ` packages/neo-one-server-plugin-project/src/types.ts `

### Test Plan

    yarn neo-one init

see that the ` .onerc ` file contains the appropriate defaults as defined by ` packages/neo-one-server-plugin-project/src/types.ts `

fixes: #1175