### PR TITLE
fix(deps): update @ledgerhq dependencies for node / u2f

### DIFF
--- a/packages/neo-one-client-switch/package.json
+++ b/packages/neo-one-client-switch/package.json
@@ -6,7 +6,7 @@
   "browser": "./src/index.browser.ts",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
-    "@ledgerhq/hw-transport-u2f": "4.43.0",
+    "@ledgerhq/hw-transport-u2f": "4.44.2",
     "@neo-one/client-common": "^1.1.0",
     "@neo-one/node-vm": "^1.1.0",
     "@neo-one/types": "^1.1.0",
@@ -21,7 +21,7 @@
     "tslib": "^1.9.3"
   },
   "optionalDependencies": {
-    "@ledgerhq/hw-transport-node-hid": "4.42.0"
+    "@ledgerhq/hw-transport-node-hid": "4.44.2"
   },
   "sideEffects": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,67 +1195,46 @@
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
-"@ledgerhq/devices@^4.41.1":
-  version "4.41.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.41.1.tgz#a5bfa17aa9d0f0dc48506d765356d36edeef1fd9"
-  integrity sha512-8WDj38iR1Fow2JoEG9w8rJouJcXXObw3KeTrh3fUzZ0qap4o8Q3HIc8i1Hr6XGxAjX64YmtebTJil3HjiNNMtQ==
+"@ledgerhq/devices@^4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.44.2.tgz#9279c6c911d8242e96a3c0887a4e06fe8ffa83d6"
+  integrity sha512-nommnSn4wG6Ua0hj2BeodCYfBsjATvi7TiqZTS9reiAP5ehfvWBtK45TgZtWAXZ7qWnm2fMatJE451oboD4jcw==
   dependencies:
-    "@ledgerhq/errors" "^4.41.1"
+    "@ledgerhq/errors" "^4.44.0"
 
-"@ledgerhq/devices@^4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.43.0.tgz#5a26b2d74df52677021796c389ac49b1ddf4bed4"
-  integrity sha512-vU3a3sSavcm8cHkBXHQnxYAm0fay/rigUvh4kam9dSf3wfJMFP/bnymGfjJQyupxroVtgmjw55juFuBQho38Cw==
+"@ledgerhq/errors@^4.44.0":
+  version "4.44.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.44.0.tgz#2b4c95dd37df49d2ebb63845913ec423c0aa25dc"
+  integrity sha512-juASFB0ONgCdy37ys+yW8R3BxV+Q4DsOQYhJ2H+PADynd1cyR9f2iW6R1AlCPmqqmFOQatHs8rdxLZK2D8/Zjw==
+
+"@ledgerhq/hw-transport-node-hid@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.44.2.tgz#9448c4e32ade32bbb7b3c43810888026f4f824f2"
+  integrity sha512-cxwnLoFHuHZRLYY8fmmitOYi5l7mcc00s9WC5qdbPiNF17quV+a5d4cip6FvMAfO2bbXgX0jPFcC1BrWns9X8w==
   dependencies:
-    "@ledgerhq/errors" "^4.43.0"
-
-"@ledgerhq/errors@^4.41.1":
-  version "4.41.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.41.1.tgz#8047464bf81c755dc7239b0ffb73fbf17a1c97aa"
-  integrity sha512-MKYzYNT5AKKZu2Ss0QrMXUS7Zri1F0HpNI3yKGjnhXEVxtr2fvxFXKgqdw7sdo+cLtkbNTJhiclemt0e0HtL0Q==
-
-"@ledgerhq/errors@^4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.43.0.tgz#f5dd100952ab7da384a06b1e213a2cb21c712677"
-  integrity sha512-XEO6XCvXskerddJinAraembl5dWdOV1My1JrclEAALvPdXuU+OVUdAjesXZV08WHnL8pIkixJIgk9QogcyA+NQ==
-
-"@ledgerhq/hw-transport-node-hid@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.42.0.tgz#ac911726f3e6e4425a73b1538e2421045c3d017d"
-  integrity sha512-0+tPNpyQlkfW5s8KUOVVZe2+2DZpKhMvoe6cBsmHg55zR5jJqYiHuBu7QGgKqExG/dnOQp5khx14AA2P3SglWw==
-  dependencies:
-    "@ledgerhq/devices" "^4.41.1"
-    "@ledgerhq/errors" "^4.41.1"
-    "@ledgerhq/hw-transport" "^4.41.1"
+    "@ledgerhq/devices" "^4.44.2"
+    "@ledgerhq/errors" "^4.44.0"
+    "@ledgerhq/hw-transport" "^4.44.2"
     lodash "^4.17.11"
-    node-hid "^0.7.6"
+    node-hid "^0.7.7"
     usb "^1.5.0"
 
-"@ledgerhq/hw-transport-u2f@4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.43.0.tgz#bccca5154745f37275a0a08a0f6456a7524b0670"
-  integrity sha512-YW4xOSMjf5s/KJuZj+4LXqhnNNT1Nb+Af9x0c2/eDAsHK9ISfuQMsZ8yVZ4YXC1uMfVDh7iBv3dTI3JwXitErw==
+"@ledgerhq/hw-transport-u2f@4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.44.2.tgz#cc09e45e30ed915fccce8de1563c9ea3c717227f"
+  integrity sha512-U+isDrth4CcCi14XLrSnvkTJMv+TLXHB4zBhCg2wpwjwwZPTMPDXOgm0pjt1Vw3fn3DmDd7LrRLn5KKM8wyAaA==
   dependencies:
-    "@ledgerhq/errors" "^4.43.0"
-    "@ledgerhq/hw-transport" "^4.43.0"
+    "@ledgerhq/errors" "^4.44.0"
+    "@ledgerhq/hw-transport" "^4.44.2"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport@^4.41.1":
-  version "4.41.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.41.1.tgz#1c5cfa38a87d58bbb9fcc9fa0b4e8763365afeb9"
-  integrity sha512-0Q4djKCebQ0EAtkrYtD5vN7az580RY0LG3hzDwUabN8EqLWdSJElgB6OfYJk+wHUZAnVNFwXKRZ15cCFdbXExw==
+"@ledgerhq/hw-transport@^4.44.2":
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.44.2.tgz#e7f98b9053ebdbc28d4b82f5762432a351cea5b8"
+  integrity sha512-ZiA3mUXvbwVgrcOL4ZXdDVT8wZtE5MMCJKUmDFEmbRHxgHzKYRqdS1exV9SIOjancgQe+Fi3tRJEI3ky38vcCQ==
   dependencies:
-    "@ledgerhq/devices" "^4.41.1"
-    "@ledgerhq/errors" "^4.41.1"
-    events "^3.0.0"
-
-"@ledgerhq/hw-transport@^4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.43.0.tgz#6d4d82250316b1d533f5bd291f254439c3964095"
-  integrity sha512-6Rox3yYLaZGANPgNeD1evSlnzYwCDIFLYx5As5A1swsXGwEtbXSlHf4RLwPKL+QDqcUNkInrDoOmb5a3ikg2ww==
-  dependencies:
-    "@ledgerhq/devices" "^4.43.0"
-    "@ledgerhq/errors" "^4.43.0"
+    "@ledgerhq/devices" "^4.44.2"
+    "@ledgerhq/errors" "^4.44.0"
     events "^3.0.0"
 
 "@lerna/add@3.13.1":
@@ -4688,9 +4667,10 @@ binaryextensions@2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.2.tgz#c83c3d74233ba7674e4f313cb2a2b70f54e94b7c"
 
-bindings@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.4.0.tgz#909efa49f2ebe07ecd3cb136778f665052040127"
+bindings@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
 
@@ -13199,6 +13179,13 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
+node-abi@^2.7.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.7.1.tgz#a8997ae91176a5fbaa455b194976e32683cda643"
+  integrity sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==
+  dependencies:
+    semver "^5.4.1"
+
 node-cron@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-2.0.3.tgz#b9649784d0d6c00758410eef22fa54a10e3f602d"
@@ -13261,13 +13248,14 @@ node-gyp@^3.8.0:
     tar "^2.0.0"
     which "1"
 
-node-hid@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.6.tgz#61523694f1111d209fca55bb704732dad029f3bc"
+node-hid@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.7.tgz#3341630231b534226b86d6758caba48a646799ed"
+  integrity sha512-s6x8dU9/9+yKyeNw5xvU9FvQ1QGazVrDIG08/bixxCVQw98jfeFyz51C0T9/0KzKAYMOXMtElYvPIKmtY7eizw==
   dependencies:
-    bindings "^1.3.1"
+    bindings "^1.4.0"
     nan "^2.12.1"
-    prebuild-install "^5.2.2"
+    prebuild-install "^5.2.4"
 
 node-html-encoder@0.0.2:
   version "0.0.2"
@@ -15130,9 +15118,10 @@ prebuild-install@^4.0.0:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
-prebuild-install@^5.2.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.2.3.tgz#096f5116e63eeef57ae533a2ee460b13d7872704"
+prebuild-install@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.2.4.tgz#8cc41a217ef778a31d3a876fe6668d05406db750"
+  integrity sha512-CG3JnpTZXdmr92GW4zbcba4jkDha6uHraJ7hW4Fn8j0mExxwOKK20hqho8ZuBDCKYCHYIkFM1P2jhtG+KpP4fg==
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^2.0.3"
@@ -15140,7 +15129,7 @@ prebuild-install@^5.2.2:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
     napi-build-utils "^1.0.1"
-    node-abi "^2.2.0"
+    node-abi "^2.7.0"
     noop-logger "^0.1.1"
     npmlog "^4.0.1"
     os-homedir "^1.0.1"


### PR DESCRIPTION
Rennovate PRs are doing something crazy with `yarn.lock` right now, not sure why.

## Applicable
#1172 
#1173 