### PR TITLE
fix(jest): fix a flaky crypto test - createKeyPair

### DIFF
--- a/packages/neo-one-client-common/src/crypto.ts
+++ b/packages/neo-one-client-common/src/crypto.ts
@@ -22,11 +22,10 @@ import { p256 } from './precomputed';
 import { ScriptBuilder } from './ScriptBuilder';
 
 // tslint:disable-next-line no-let
-let ecCache: any;
+let ecCache: EC | undefined;
 const ec = () => {
   if (ecCache === undefined) {
-    // tslint:disable-next-line no-any
-    ecCache = new EC(p256) as any;
+    ecCache = new EC(p256);
   }
 
   return ecCache;
@@ -172,6 +171,11 @@ const privateKeyToPublicKey = (privateKey: PrivateKey): ECPoint => {
 
 const createKeyPair = (): { readonly privateKey: PrivateKey; readonly publicKey: ECPoint } => {
   const key = ec().genKeyPair();
+  const validation = key.validate();
+
+  if (!validation.result) {
+    return createKeyPair();
+  }
 
   return {
     privateKey: common.bufferToPrivateKey(key.getPrivate().toArrayLike(Buffer, 'be')),

--- a/scripts/e2e/One.js
+++ b/scripts/e2e/One.js
@@ -66,7 +66,7 @@ class One {
 
     this.dir = tmp.dirSync();
     this.dirName = this.dir.name;
-    this.serverPort = await this.getAvailableMinPortForRange(15);
+    this.serverPort = await this.getAvailableMinPortForRange(30);
     this.httpServerPort = this.serverPort + 1;
     this.minPort = this.serverPort + 2;
     const [cmd, args] = this._createCommand('start server --static-neo-one');


### PR DESCRIPTION
### Description of the Change

`crypto.createKeyPair` used to fail occasionally. `ec().genKeyPair()` can sometimes return a bad value, so we just need to `validate()` it before we attempt to use it. This fixes the issue.

Also, I saw an e2e test fail sometime recently I think with the EADDRINUSE again, so going to pump the range on `getAvailableMinPortForRange` and see if that nips it in the bud for good.

### Test Plan

I tested it by isolating the currently failing test and running it x *N* to watch it fail. Then I found a solution in the `validate` function.

### Alternate Designs

??

### Benefits

FLAKY TESTS ARE SCARED OF ME

### Possible Drawbacks

PRs might go through faster now, not sure if we can keep up with them in terms of reviews. ;)
