### PR TITLE
fix(jest): remove unnecessary 'async' flags from test

### DIFF
--- a/packages/neo-one-client-core/src/__tests__/sc/BaseFunctionSmartContracts.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/sc/BaseFunctionSmartContracts.test.ts
@@ -53,7 +53,7 @@ const events: ReadonlyArray<any> = [
   },
 ];
 
-describe('Transfer - No Function Options', async () => {
+describe('Transfer - No Function Options', () => {
   // tslint:disable-next-line:no-any
   const parameters: ReadonlyArray<any> = [
     {
@@ -198,7 +198,7 @@ describe('Transfer - Complete Send - Optional ForwardValues', () => {
   testFunc(testArgsThrow, 'throws-noHash', 'Expected to find a hash argument');
 });
 
-describe('Transfer - Send - Optional ForwardValue', async () => {
+describe('Transfer - Send - Optional ForwardValue', () => {
   // tslint:disable-next-line:no-any
   const parameters: ReadonlyArray<any> = [
     {
@@ -334,7 +334,7 @@ describe('Transfer - SendUnsafe&Receive', () => {
   testFunc(testArgsAllOptions, 'all-allOptions');
 });
 
-describe('Transfer - No Forward Values', async () => {
+describe('Transfer - No Forward Values', () => {
   // tslint:disable-next-line:no-any
   const parameters: ReadonlyArray<any> = [
     {


### PR DESCRIPTION
Simple fix, jest was giving us warnings about `describe` returning a promise which is a no no. Looks like it was just a typo anyway as the `async` flags served no purpose (is there a tslint rule we can use to make sure this doesn't come up? I don't think the normal function one affects in-line functions like this example).