### PR TITLE
fix(e2e): reduce expected peer connections to 3

### DIFF
--- a/packages/neo-one-server-plugin-network/src/__e2e__/createNetworkMain.test.ts
+++ b/packages/neo-one-server-plugin-network/src/__e2e__/createNetworkMain.test.ts
@@ -14,8 +14,8 @@ describe('create network', () => {
       expect(description.nodes[0].name).toEqual('main');
       expect(description.nodes[0].live).toBeTruthy();
       expect(description.nodes[0].ready).toBeFalsy();
-      expect(description.height).toBeGreaterThan(5);
-      expect(description.peers).toBeGreaterThan(5);
+      expect(description.height).toBeGreaterThan(3);
+      expect(description.peers).toBeGreaterThan(3);
 
       const endpoint = description.nodes[0].telemetryAddress;
       const response = await fetch(endpoint);


### PR DESCRIPTION
### Description of the Change

Reduces the expected peers in `createNetworkMain` test to 3 since this flakes all the time in CI. Only a suggestion do with this what you will.

### Test Plan

Hopefully CI doesn't fail this again, and if it does hopefully it actually indicates something.

### Alternate Designs

:thinking: a retry approach?

### Benefits

less e2e flakiness
