### PR TITLE
refactor(PACK+NEWSTRUCT): Replace PACKSTRUCT with PACK+NEWSTRUCT

### DIFF
--- a/packages/neo-one-client-common/src/models/vm.ts
+++ b/packages/neo-one-client-common/src/models/vm.ts
@@ -183,7 +183,6 @@ export enum Op {
   HASKEY = 0xcb,
   KEYS = 0xcc,
   VALUES = 0xcd,
-  PACKSTRUCT = 0xce,
   CALL_I = 0xe0,
   CALL_E = 0xe1,
   CALL_ED = 0xe2,

--- a/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
@@ -1331,19 +1331,6 @@ const OPCODES = ([
       },
 
       {
-        op: 'PACKSTRUCT',
-        args: [new BN(1), Buffer.alloc(1, 0), Buffer.alloc(1, 1), Buffer.alloc(1, 2)],
-
-        result: [
-          new StructStackItem([new BufferStackItem(Buffer.alloc(1, 0))]),
-          new BufferStackItem(Buffer.alloc(1, 1)),
-          new BufferStackItem(Buffer.alloc(1, 2)),
-        ],
-
-        gas: FEES.ONE,
-      },
-
-      {
         op: 'UNPACK',
         args: [[new BN(4), new BN(5)]],
         result: [new IntegerStackItem(new BN(2)), new IntegerStackItem(new BN(4)), new IntegerStackItem(new BN(5))],
@@ -1431,11 +1418,55 @@ const OPCODES = ([
       },
 
       {
+        op: 'NEWARRAY',
+        args: [[new BN(1), new BN(2), new BN(3)]],
+        result: [
+          new ArrayStackItem([
+            new IntegerStackItem(new BN(1)),
+            new IntegerStackItem(new BN(2)),
+            new IntegerStackItem(new BN(3)),
+          ]),
+        ],
+
+        gas: FEES.ONE,
+      },
+
+      {
+        op: 'NEWARRAY',
+        stackItems: [simpleStruct],
+        result: [new ArrayStackItem([new IntegerStackItem(new BN(1))])],
+
+        gas: FEES.ONE,
+      },
+
+      {
         op: 'NEWSTRUCT',
         args: [new BN(3)],
         result: [
           new StructStackItem([new BooleanStackItem(false), new BooleanStackItem(false), new BooleanStackItem(false)]),
         ],
+
+        gas: FEES.ONE,
+      },
+
+      {
+        op: 'NEWSTRUCT',
+        args: [[new BN(1), new BN(2), new BN(3)]],
+        result: [
+          new StructStackItem([
+            new IntegerStackItem(new BN(1)),
+            new IntegerStackItem(new BN(2)),
+            new IntegerStackItem(new BN(3)),
+          ]),
+        ],
+
+        gas: FEES.ONE,
+      },
+
+      {
+        op: 'NEWSTRUCT',
+        stackItems: [simpleStruct],
+        result: [new StructStackItem([new IntegerStackItem(new BN(1))])],
 
         gas: FEES.ONE,
       },

--- a/packages/neo-one-server-plugin-project/src/__e2e__/__snapshots__/buildCommand.test.ts.snap
+++ b/packages/neo-one-server-plugin-project/src/__e2e__/__snapshots__/buildCommand.test.ts.snap
@@ -4,6 +4,6 @@ exports[`buildCommand build: mint consumed 1`] = `"0"`;
 
 exports[`buildCommand build: mint consumed 2`] = `"0"`;
 
-exports[`buildCommand build: mint cost 1`] = `"6.426"`;
+exports[`buildCommand build: mint cost 1`] = `"6.519"`;
 
-exports[`buildCommand build: mint cost 2`] = `"6.426"`;
+exports[`buildCommand build: mint cost 2`] = `"6.519"`;

--- a/packages/neo-one-server-plugin-project/src/__e2e__/__snapshots__/buildCommandJs.test.ts.snap
+++ b/packages/neo-one-server-plugin-project/src/__e2e__/__snapshots__/buildCommandJs.test.ts.snap
@@ -4,6 +4,6 @@ exports[`buildCommand build: mint consumed 1`] = `"0"`;
 
 exports[`buildCommand build: mint consumed 2`] = `"0"`;
 
-exports[`buildCommand build: mint cost 1`] = `"6.426"`;
+exports[`buildCommand build: mint cost 1`] = `"6.519"`;
 
-exports[`buildCommand build: mint cost 2`] = `"6.426"`;
+exports[`buildCommand build: mint cost 2`] = `"6.519"`;

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/__snapshots__/InvokeSmartContractHelper6.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/__snapshots__/InvokeSmartContractHelper6.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 1`] = `"1.047"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 1`] = `"1.053"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 2`] = `"1.873"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 2`] = `"1.885"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 3`] = `"1.882"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 3`] = `"1.894"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 4`] = `"1.562"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 4`] = `"1.574"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 5`] = `"3.337"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 5`] = `"3.371"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 6`] = `"0.72"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 6`] = `"0.725"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 7`] = `"3.306"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 7`] = `"3.34"`;
 
-exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 8`] = `"0.72"`;
+exports[`InvokeSmartContractHelper class that used processedTransactions, send, receive and claim 8`] = `"0.725"`;

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CreateStructuredStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CreateStructuredStorageHelper.ts
@@ -37,7 +37,8 @@ export class CreateStructuredStorageHelper extends StructuredStorageBaseHelper {
     // [3, prefix, size, arr]
     sb.emitPushInt(node, 3);
     // [struct]
-    sb.emitOp(node, 'PACKSTRUCT');
+    sb.emitOp(node, 'PACK');
+    sb.emitOp(node, 'NEWSTRUCT');
     // [val]
     sb.emitHelper(node, options, sb.helpers.wrapVal({ type: this.type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/WrapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/WrapHelper.ts
@@ -22,6 +22,7 @@ export abstract class WrapHelper extends Helper {
     // [2, type, value]
     sb.emitPushInt(node, this.length);
     // [[type, value]]
-    sb.emitOp(node, 'PACKSTRUCT');
+    sb.emitOp(node, 'PACK');
+    sb.emitOp(node, 'NEWSTRUCT');
   }
 }

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.389"`;
+exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.433"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestDesignatedCallerContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestDesignatedCallerContract.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`TestDesignatedCaller deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestDesignatedCaller deploy + transfer: deploy cost 1`] = `"1.503"`;
+exports[`TestDesignatedCaller deploy + transfer: deploy cost 1`] = `"1.51"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestICO.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestICO.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TestICO smart contract: deploy consumed 1`] = `"0"`;
 
-exports[`TestICO smart contract: deploy cost 1`] = `"1.321"`;
+exports[`TestICO smart contract: deploy cost 1`] = `"1.34"`;
 
 exports[`TestICO smart contract: mint consumed 1`] = `"0"`;
 
-exports[`TestICO smart contract: mint cost 1`] = `"4.548"`;
+exports[`TestICO smart contract: mint cost 1`] = `"4.61"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"2.993"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.021"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.389"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.433"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestTransferableOwnership.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestTransferableOwnership.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`TestTransferableOwnership deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestTransferableOwnership deploy + transfer: deploy cost 1`] = `"1.173"`;
+exports[`TestTransferableOwnership deploy + transfer: deploy cost 1`] = `"1.178"`;


### PR DESCRIPTION
### Description of the Change
Removes the PACKSTRUCT Opcode and modifies NEWSTRUCT/NEWARRAY to be able to convert an existing array into a struct and struct into array.  This allows the use of a PACK+NEWSTRUCT pair of opcodes in place of PACKSTRUCT.

### Test Plan
Added tests for the conversions in NEWSTRUCT and NEWARRAY.  Updated existing tests to reflect the slightly higher GAS costs of neo-one compiled contracts.

### Alternate Designs
Previously the plan was to implement our PACKSTRUCT in the neo-vm as per https://github.com/neo-project/neo-vm/issues/51 and https://github.com/neo-project/neo-vm/pull/88.  This new solution was suggested and implemented here: https://github.com/neo-project/neo-vm/pull/91.
### Benefits

### Possible Drawbacks
Very slightly higher GAS cost for neo-one compiled smart contracts.  

### Applicable Issues
https://github.com/neo-one-suite/neo-one/issues/1254