### PR TITLE
feat(contract-crowdsale): add Crowdsale contract

### DIFF
--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/TestCrowdsaleContract.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/TestCrowdsaleContract.ts
@@ -1,0 +1,18 @@
+import { Address, Deploy, Fixed } from '@neo-one/smart-contract';
+// tslint:disable-next-line:no-implicit-dependencies
+import { CrowdsaleContract } from '@neo-one/smart-contract-lib';
+
+export class TestCrowdsaleContract extends CrowdsaleContract() {
+  public constructor(protected initialOwner: Address = Deploy.senderAddress) {
+    super();
+  }
+  protected initialCrowdsaleWallet(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleRate(): Fixed<8> {
+    return 1_20000000;
+  }
+  protected initialCrowdsaleToken(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.499"`;
+exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.087"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.153"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.499"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/TestCrowdsaleContract.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/TestCrowdsaleContract.test.ts
@@ -1,0 +1,60 @@
+import { common, crypto } from '@neo-one/client-common';
+import { SmartContractAny } from '@neo-one/client-core';
+import { withContracts } from '@neo-one/smart-contract-test';
+import * as path from 'path';
+
+const RECIPIENT = {
+  PRIVATE_KEY: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+  PUBLIC_KEY: '02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef',
+};
+
+describe('Crowdsale', () => {
+  test('deploy + transfer', async () => {
+    await withContracts<{ testCrowdsaleContract: SmartContractAny }>(
+      [
+        {
+          filePath: path.resolve(
+            __dirname,
+            '..',
+            '..',
+            '__data__',
+            'contracts',
+            'crowdsale',
+            'TestCrowdsaleContract.ts',
+          ),
+          name: 'TestCrowdsaleContract',
+        },
+      ],
+      async ({ testCrowdsaleContract: smartContract, masterAccountID }) => {
+        crypto.addPublicKey(
+          common.stringToPrivateKey(RECIPIENT.PRIVATE_KEY),
+          common.stringToECPoint(RECIPIENT.PUBLIC_KEY),
+        );
+
+        const deployResult = await smartContract.deploy(masterAccountID.address, { from: masterAccountID });
+
+        const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
+        if (deployReceipt.result.state !== 'HALT') {
+          throw new Error(deployReceipt.result.message);
+        }
+
+        expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
+        expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
+        expect(deployReceipt.result.value).toBeTruthy();
+
+        const [initialOwner, initialRate, token, wallet] = await Promise.all([
+          smartContract.owner.confirmed(),
+          smartContract.rate(),
+          smartContract.token(),
+          smartContract.wallet(),
+        ]);
+
+        expect(initialOwner.result.value).toEqual(masterAccountID.address);
+        expect(initialRate.toNumber()).toEqual(1.2);
+        expect(wallet.toString()).toEqual('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+        expect(token.toString()).toEqual('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+      },
+      { deploy: false },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Crowdsale deploy + transfer: deploy consumed 1`] = `"0"`;
+
+exports[`Crowdsale deploy + transfer: deploy cost 1`] = `"1.398"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/TestOwnableContract.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/TestOwnableContract.test.ts
@@ -31,7 +31,7 @@ describe('Ownable', () => {
 
         expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
         expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
-        expect(deployReceipt.result.value).toBeTruthy();
+        expect(deployReceipt.result.value).toEqual(true);
 
         const [initialOwner, recipient] = await Promise.all([
           smartContract.owner.confirmed(),

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Ownable deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.272"`;
+exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.332"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Secondary deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.266"`;
+exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.326"`;

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/CrowdsaleContract.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/CrowdsaleContract.ts
@@ -1,0 +1,105 @@
+import {
+  Address,
+  Blockchain,
+  constant,
+  createEventNotifier,
+  Fixed,
+  Hash256,
+  receive,
+  SmartContract,
+} from '@neo-one/smart-contract';
+import { Ownable } from '../ownership/Ownable';
+
+const notifyTokensPurchased = createEventNotifier<Address, Fixed<8>, Fixed<8>>(
+  'tokens_purchased',
+  'account',
+  'NEO',
+  'qty tokens',
+);
+
+export function CrowdsaleContract() {
+  abstract class CrowdsaleContractClass extends Ownable(SmartContract) {
+    public readonly token: Address = this.initialCrowdsaleToken();
+    public readonly rate: Fixed<8> = this.initialCrowdsaleRate();
+    public readonly wallet: Address = this.initialCrowdsaleWallet();
+    protected mutableNeoRaised: Fixed<8> = 0;
+
+    @constant
+    public get neoRaised(): Fixed<8> {
+      return this.mutableNeoRaised;
+    }
+
+    @receive
+    public mintTokens(): boolean {
+      const { references } = Blockchain.currentTransaction;
+      if (references.length === 0) {
+        return false;
+      }
+      const sender = references[0].address;
+
+      let amountNeo = 0;
+      // tslint:disable-next-line no-loop-statement
+      for (const output of Blockchain.currentTransaction.outputs) {
+        if (output.address.equals(this.address)) {
+          if (!output.asset.equals(Hash256.NEO)) {
+            return false;
+          }
+
+          amountNeo += output.value;
+        }
+      }
+
+      this.issue(sender, amountNeo);
+
+      return true;
+    }
+
+    protected issue(account: Address, amountNeo: Fixed<8>): boolean {
+      this.preValidatePurchase(account, amountNeo);
+      const tokens = this.getTokenAmount(amountNeo);
+      this.mutableNeoRaised += amountNeo;
+      this.processPurchase(account, tokens);
+      notifyTokensPurchased(account, amountNeo, tokens);
+      this.updatePurchasingState(account, amountNeo);
+      this.forwardFunds(amountNeo, account);
+      this.postValidatePurchase(account, amountNeo);
+
+      return true;
+    }
+
+    // Override these functions with your configuration.
+    protected abstract initialCrowdsaleWallet(): Address;
+    protected abstract initialCrowdsaleRate(): Fixed<8>;
+    protected abstract initialCrowdsaleToken(): Address;
+
+    // PITFALL: Remember, when layering functionality in different classes, remember to
+    // call the corresponding super._fnx() to ensure the chain of checks is maintained.
+
+    /* tslint:disable: no-unused no-empty */
+    protected preValidatePurchase(purchaser: Address, amount: Fixed<8>) {
+      // override with any pre-purchase checks
+    }
+
+    protected processPurchase(purchaser: Address, tokens: Fixed<8>) {
+      // override with any purchase-process
+    }
+
+    protected updatePurchasingState(purchaser: Address, amount: Fixed<8>) {
+      // override with any state updates required
+    }
+
+    protected forwardFunds(amount: Fixed<8>, account: Address) {
+      // override with your method of forwarding funds
+    }
+
+    protected postValidatePurchase(purchaser: Address, amount: Fixed<8>) {
+      // override with any post purchase validation checks
+    }
+
+    protected getTokenAmount(amountNeo: Fixed<8>) {
+      return amountNeo * this.rate;
+    }
+  }
+
+  return CrowdsaleContractClass;
+}

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:export-name
+export { CrowdsaleContract } from './CrowdsaleContract';

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,2 +1,3 @@
 export { NEP5Token } from './NEP5Token';
 export { Ownable, Secondary } from './ownership';
+export { CrowdsaleContract } from './crowdsale';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
     "packages/neo-one-smart-contract/src/*.d.ts",
     "packages/neo-one-smart-contract-lib/src/index.ts",
     "packages/neo-one-smart-contract-lib/src/ownership/*.ts",
+    "packages/neo-one-smart-contract-lib/src/crowdsale/**/*.ts",
     "packages/neo-one-smart-contract-lib/src/ICO.ts",
     "packages/neo-one-smart-contract-lib/src/NEP5Token.ts",
     "packages/neo-one-smart-contract-compiler/src/__data__/snippets/**/*.ts",


### PR DESCRIPTION
The `Crowdsale` contract extends the mix-in `Ownable` with the key feature of `buyToken()` which provides a basic flow. 

## Data: 
`rate` - get NEO-to-Token exchange rate
`token` - `address`  of the token being sold
`wallet` - `address` for the wallet funds will be transferred to
`neoRaised()` - how many total funds have been captured 
`totalSupply()` - what's the total supply of token issued

## Buying Tokens:
   ` mintTokens(purchaser: Address, beneficiary: Address, amount: Fixed<8>) : boolean `

### Configuration
Provide the appropriate configuration by overriding these `protected` functions to return the appropriate configuration.  
`initialCrowdsaleWallet()=> Address for funds to be deposited
`initialCrowdsaleToken()=> Address of token to purchase
`initialCrowdsaleRate()=> Fixed<8>` be sure to use underscore notation when assigning numbers within a NEO-ONE SmartContract

#### Refresher: Underscore notation for Fixed<N> numbers:
Given a `Fixed<8>`
0 is 0
1 is 1_00000000
0.01 would be `0_01000000`
1,000 would be `1_000_00000000`

### Test
```yarn jest TestCrowdsale```
