### PR TITLE
feat(premixed-individually-capped): add IndividuallyCappedCrowdsale+

### DIFF
--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/TestCrowdsaleContract.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/TestCrowdsaleContract.ts
@@ -1,0 +1,18 @@
+import { Address, Deploy, Fixed } from '@neo-one/smart-contract';
+// tslint:disable-next-line:no-implicit-dependencies
+import { CrowdsaleContract } from '@neo-one/smart-contract-lib';
+
+export class TestCrowdsaleContract extends CrowdsaleContract() {
+  public constructor(protected initialOwner: Address = Deploy.senderAddress) {
+    super();
+  }
+  protected initialCrowdsaleWallet(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleRate(): Fixed<8> {
+    return 1_20000000;
+  }
+  protected initialCrowdsaleToken(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/validation/TestIndividuallyCappedCrowdsale.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/validation/TestIndividuallyCappedCrowdsale.ts
@@ -1,0 +1,21 @@
+import { Address, Deploy, Fixed } from '@neo-one/smart-contract';
+// tslint:disable-next-line:no-implicit-dependencies
+import { IndividuallyCappedCrowdsale } from '@neo-one/smart-contract-lib';
+
+export class TestIndividuallyCappedCrowdsale extends IndividuallyCappedCrowdsale {
+  public constructor(protected initialOwner: Address = Deploy.senderAddress) {
+    super();
+  }
+  protected initialCrowdsaleCap(): Fixed<8> {
+    return 0;
+  }
+  protected initialCrowdsaleWallet(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleToken(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleRate(): Fixed<8> {
+    return 1_20000000;
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/withAccessRoles/TestCrowdsaleWithCapperRole.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/contracts/crowdsale/withAccessRoles/TestCrowdsaleWithCapperRole.ts
@@ -1,0 +1,22 @@
+import { Address, Deploy, Fixed } from '@neo-one/smart-contract';
+// tslint:disable-next-line:no-implicit-dependencies
+import { CrowdsaleWithCapperRole } from '@neo-one/smart-contract-lib';
+
+export class TestCrowdsaleWithCapperRole extends CrowdsaleWithCapperRole {
+  public constructor(protected initialOwner: Address = Deploy.senderAddress) {
+    super();
+    this.initialCapper(initialOwner);
+  }
+  protected initialCrowdsaleCap(): Fixed<8> {
+    return 100_000_000_00000000;
+  }
+  protected initialCrowdsaleWallet(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleToken(): Address {
+    return Address.from('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+  }
+  protected initialCrowdsaleRate(): Fixed<8> {
+    return 1_20000000;
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/__data__/keys.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/keys.ts
@@ -1,0 +1,85 @@
+import { common, crypto, ECPoint, PrivateKey, PublicKeyString, UInt160 } from '@neo-one/client-common';
+
+export const keys: ReadonlyArray<{
+  readonly name: string;
+  readonly address: string;
+  readonly privateKey: PrivateKey;
+  readonly privateKeyString: string;
+  readonly publicKey: ECPoint;
+  readonly publicKeyString: PublicKeyString;
+  readonly wif: string;
+  readonly password: string;
+  readonly encryptedWIF: string;
+  readonly scriptHash: UInt160;
+  readonly scriptHashString: string;
+}> = [
+  {
+    name: 'first',
+    address: 'ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW',
+    privateKey: common.bufferToPrivateKey(
+      Buffer.from('7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344', 'hex'),
+    ),
+    privateKeyString: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+    publicKey: common.bufferToECPoint(
+      Buffer.from('02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef', 'hex'),
+    ),
+    publicKeyString: common.ecPointToString(
+      common.bufferToECPoint(Buffer.from('02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef', 'hex')),
+    ),
+    wif: 'L1QqQJnpBwbsPGAuutuzPTac8piqvbR1HRjrY5qHup48TBCBFe4g',
+    password: 'city of zion',
+    encryptedWIF: '6PYLHmDf6AjF4AsVtosmxHuPYeuyJL3SLuw7J1U8i7HxKAnYNsp61HYRfF',
+    scriptHash: common.bufferToUInt160(Buffer.from('3775292229eccdf904f16fff8e83e7cffdc0f0ce', 'hex')),
+    scriptHashString: common.uInt160ToString(
+      common.bufferToUInt160(Buffer.from('3775292229eccdf904f16fff8e83e7cffdc0f0ce', 'hex')),
+    ),
+  },
+  {
+    name: 'second',
+    address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s',
+    privateKey: common.bufferToPrivateKey(
+      Buffer.from('9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69', 'hex'),
+    ),
+    privateKeyString: '9ab7e154840daca3a2efadaf0df93cd3a5b51768c632f5433f86909d9b994a69',
+    publicKey: common.bufferToECPoint(
+      Buffer.from('031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9', 'hex'),
+    ),
+    publicKeyString: common.ecPointToString(
+      common.bufferToECPoint(Buffer.from('031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9', 'hex')),
+    ),
+    wif: 'L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG',
+    password: '我的密码',
+    encryptedWIF: '6PYWVp3xfgvnuNKP7ZavSViYvvim2zuzx9Q33vuWZr8aURiKeJ6Zm7BfPQ',
+    scriptHash: common.bufferToUInt160(Buffer.from('35b20010db73bf86371075ddfba4e6596f1ff35d', 'hex')),
+    scriptHashString: common.uInt160ToString(
+      common.bufferToUInt160(Buffer.from('35b20010db73bf86371075ddfba4e6596f1ff35d', 'hex')),
+    ),
+  },
+  {
+    name: 'third',
+    address: 'AVf4UGKevVrMR1j3UkPsuoYKSC4ocoAkKx',
+    privateKey: common.bufferToPrivateKey(
+      Buffer.from('3edee7036b8fd9cef91de47386b191dd76db2888a553e7736bb02808932a915b', 'hex'),
+    ),
+    privateKeyString: '3edee7036b8fd9cef91de47386b191dd76db2888a553e7736bb02808932a915b',
+    publicKey: common.bufferToECPoint(
+      Buffer.from('02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa', 'hex'),
+    ),
+    publicKeyString: common.ecPointToString(
+      common.bufferToECPoint(Buffer.from('02232ce8d2e2063dce0451131851d47421bfc4fc1da4db116fca5302c0756462fa', 'hex')),
+    ),
+    wif: 'KyKvWLZsNwBJx5j9nurHYRwhYfdQUu9tTEDsLCUHDbYBL8cHxMiG',
+    password: 'MyL33tP@33w0rd',
+    encryptedWIF: '6PYNoc1EG5J38MTqGN9Anphfdd6UwbS4cpFCzHhrkSKBBbV1qkbJJZQnkn',
+    scriptHash: common.bufferToUInt160(Buffer.from('9847e26135152874355e324afd5cc99f002acb33', 'hex')),
+    scriptHashString: common.uInt160ToString(
+      common.bufferToUInt160(Buffer.from('9847e26135152874355e324afd5cc99f002acb33', 'hex')),
+    ),
+  },
+];
+
+export const addKeysToCrypto = () => {
+  keys.forEach(({ privateKey, publicKey }) => {
+    crypto.addPublicKey(privateKey, publicKey);
+  });
+};

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;
+exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.825"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/RedToken.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.499"`;
+exports[`RedToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.153"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.413"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.825"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/__snapshots__/TestToken.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.087"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy cost 1`] = `"3.153"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"0"`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.499"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer cost 1`] = `"3.565"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/TestCrowdsaleContract.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/TestCrowdsaleContract.test.ts
@@ -1,0 +1,60 @@
+import { common, crypto } from '@neo-one/client-common';
+import { SmartContractAny } from '@neo-one/client-core';
+import { withContracts } from '@neo-one/smart-contract-test';
+import * as path from 'path';
+
+const RECIPIENT = {
+  PRIVATE_KEY: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+  PUBLIC_KEY: '02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef',
+};
+
+describe('Crowdsale', () => {
+  test('deploy + transfer', async () => {
+    await withContracts<{ testCrowdsaleContract: SmartContractAny }>(
+      [
+        {
+          filePath: path.resolve(
+            __dirname,
+            '..',
+            '..',
+            '__data__',
+            'contracts',
+            'crowdsale',
+            'TestCrowdsaleContract.ts',
+          ),
+          name: 'TestCrowdsaleContract',
+        },
+      ],
+      async ({ testCrowdsaleContract: smartContract, masterAccountID }) => {
+        crypto.addPublicKey(
+          common.stringToPrivateKey(RECIPIENT.PRIVATE_KEY),
+          common.stringToECPoint(RECIPIENT.PUBLIC_KEY),
+        );
+
+        const deployResult = await smartContract.deploy(masterAccountID.address, { from: masterAccountID });
+
+        const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
+        if (deployReceipt.result.state !== 'HALT') {
+          throw new Error(deployReceipt.result.message);
+        }
+
+        expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
+        expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
+        expect(deployReceipt.result.value).toBeTruthy();
+
+        const [initialOwner, initialRate, token, wallet] = await Promise.all([
+          smartContract.owner.confirmed(),
+          smartContract.rate(),
+          smartContract.token(),
+          smartContract.wallet(),
+        ]);
+
+        expect(initialOwner.result.value).toEqual(masterAccountID.address);
+        expect(initialRate.toNumber()).toEqual(1.2);
+        expect(wallet.toString()).toEqual('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+        expect(token.toString()).toEqual('ALq7AWrhAueN6mJNqk6FHJjnsEoPRytLdW');
+      },
+      { deploy: false },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Crowdsale deploy + transfer: deploy consumed 1`] = `"0"`;
+
+exports[`Crowdsale deploy + transfer: deploy cost 1`] = `"1.398"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/__snapshots__/TestCrowdsaleContract.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Crowdsale deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Crowdsale deploy + transfer: deploy cost 1`] = `"1.398"`;
+exports[`Crowdsale deploy + transfer: deploy cost 1`] = `"1.64"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/validation/TestIndividuallyCappedCrowdsale.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/validation/TestIndividuallyCappedCrowdsale.test.ts
@@ -1,0 +1,216 @@
+import { common, crypto } from '@neo-one/client-common';
+import { Hash256, SmartContractAny } from '@neo-one/client-core';
+import { withContracts } from '@neo-one/smart-contract-test';
+import BigNumber from 'bignumber.js';
+import * as path from 'path';
+import { keys } from '../../../__data__/keys';
+
+const RECIPIENT = {
+  PRIVATE_KEY: '7d128a6d096f0c14c3a25a2b0c41cf79661bfcb4a8cc95aaaea28bde4d732344',
+  PUBLIC_KEY: '02028a99826edc0c97d18e22b6932373d908d323aa7f92656a77ec26e8861699ef',
+};
+
+describe('IndividuallyCappedCrowdsale', () => {
+  test('deploy + transfer', async () => {
+    await withContracts<{ testIndividuallyCappedCrowdsale: SmartContractAny }>(
+      [
+        {
+          filePath: path.resolve(
+            __dirname,
+            '..',
+            '..',
+            '..',
+            '__data__',
+            'contracts',
+            'crowdsale',
+            'validation',
+            'TestIndividuallyCappedCrowdsale.ts',
+          ),
+          name: 'TestIndividuallyCappedCrowdsale',
+        },
+      ],
+      async ({ client, networkName, accountIDs, testIndividuallyCappedCrowdsale: smartContract, masterAccountID }) => {
+        crypto.addPublicKey(
+          common.stringToPrivateKey(RECIPIENT.PRIVATE_KEY),
+          common.stringToECPoint(RECIPIENT.PUBLIC_KEY),
+        );
+
+        const deployResult = await smartContract.deploy(masterAccountID.address, { from: masterAccountID });
+
+        const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
+        if (deployReceipt.result.state !== 'HALT') {
+          throw new Error(deployReceipt.result.message);
+        }
+
+        expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
+        expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
+        expect(deployReceipt.result.value).toBeTruthy();
+        const [accountOne, accountTwo] = await Promise.all([
+          client.providers.memory.keystore.addUserAccount({
+            network: networkName,
+            name: 'accountOne',
+            privateKey: keys[1].privateKeyString,
+          }),
+          client.providers.memory.keystore.addUserAccount({
+            network: networkName,
+            name: 'accountTwo',
+            privateKey: keys[2].privateKeyString,
+          }),
+        ]);
+
+        expect(accountOne.userAccount.id.address).toBe(keys[1].address);
+
+        const [initialOwner, initialRate, token, wallet] = await Promise.all([
+          smartContract.owner.confirmed({ from: accountOne.userAccount.id }),
+          smartContract.rate({ from: accountOne.userAccount.id }),
+          smartContract.token({ from: accountTwo.userAccount.id }),
+          smartContract.wallet({ from: masterAccountID }),
+        ]);
+
+        const masterAccountAddress = keys[0].address;
+
+        expect(initialOwner.result.value).toEqual(masterAccountID.address);
+        expect(initialRate.toNumber()).toEqual(1.2);
+        expect(wallet.toString()).toEqual(masterAccountAddress);
+        expect(token.toString()).toEqual(masterAccountAddress);
+
+        // ### ASSIGN ADDRESSES
+        const accountAAddress = accountIDs[2].address;
+        const accountBAddress = accountIDs[3].address;
+        const accountCAddress = accountIDs[5].address;
+
+        //  GET CURRENT CAPS
+        const [cap0a, cap0b, cap0c] = await Promise.all([
+          smartContract.getCap(accountAAddress, { from: masterAccountID }),
+          smartContract.getCap(accountBAddress, { from: masterAccountID }),
+          smartContract.getCap(accountCAddress, { from: masterAccountID }),
+        ]);
+
+        expect(cap0a.toNumber()).toEqual(0);
+        expect(cap0b.toNumber()).toEqual(0);
+        expect(cap0c.toNumber()).toEqual(0);
+
+        // ### SET CAPS to 100, 1000, 10000
+        await Promise.all([
+          smartContract.setCap.confirmed(accountAAddress, new BigNumber(9), masterAccountID.address, {
+            from: masterAccountID,
+          }),
+          smartContract.setCap.confirmed(accountBAddress, new BigNumber(99), masterAccountID.address, {
+            from: masterAccountID,
+          }),
+          smartContract.setCap.confirmed(accountCAddress, new BigNumber(9999), masterAccountID.address, {
+            from: masterAccountID,
+          }),
+        ]);
+
+        // VERIFY CAP WAS SET PROPERLY
+        const [capA, capB, capC] = await Promise.all([
+          smartContract.getCap(accountAAddress, { from: masterAccountID }),
+          smartContract.getCap(accountBAddress, { from: masterAccountID }),
+          smartContract.getCap(accountCAddress, { from: masterAccountID }),
+        ]);
+
+        // verify each account has expected remainders
+        expect(capA.toNumber()).toEqual(9);
+        expect(capB.toNumber()).toEqual(99);
+        expect(capC.toNumber()).toEqual(9999);
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 2500));
+        const firstPurchaseAResult = await smartContract.mintTokens({
+          sendTo: [
+            {
+              amount: new BigNumber(8),
+              asset: Hash256.NEO,
+            },
+          ],
+          from: accountIDs[2],
+        });
+
+        const firstPurchaseA = await firstPurchaseAResult.confirmed();
+        const firstPurchaseB = await smartContract.mintTokens.confirmed({
+          sendTo: [
+            {
+              amount: new BigNumber(88),
+              asset: Hash256.NEO,
+            },
+          ],
+          from: accountIDs[3],
+        });
+
+        const firstPurchaseC = await smartContract.mintTokens.confirmed({
+          sendTo: [
+            {
+              amount: new BigNumber(8888.0),
+              asset: Hash256.NEO,
+            },
+          ],
+          from: accountIDs[5],
+        });
+
+        expect(firstPurchaseA.result.state).toBe('HALT');
+        expect(firstPurchaseB.result.state).toBe('HALT');
+        expect(firstPurchaseC.result.state).toBe('HALT');
+
+        const [firstContribA, firstContribB, firstContribC] = await Promise.all([
+          smartContract.getContributions(accountAAddress, { from: masterAccountID }),
+          smartContract.getContributions(accountBAddress, { from: masterAccountID }),
+          smartContract.getContributions(accountCAddress, { from: masterAccountID }),
+        ]);
+
+        expect(firstContribA.toNumber()).toEqual(8);
+        expect(firstContribB.toNumber()).toEqual(88);
+        expect(firstContribC.toNumber()).toEqual(8888);
+
+        const Fixed8 = (num: number): number => Math.round(num * 100000000) / 100000000;
+
+        const finalDepositA = Fixed8(capA - firstContribA.toNumber());
+
+        const secondPurchaseA = await smartContract.mintTokens.confirmed({
+          sendTo: [
+            {
+              amount: new BigNumber(finalDepositA),
+              asset: Hash256.NEO,
+            },
+          ],
+          from: accountIDs[2],
+        });
+
+        const finalDepositB = Fixed8(capB - firstContribB.toNumber());
+
+        let secondPurchaseB;
+        try {
+          secondPurchaseB = await smartContract.mintTokens.confirmed({
+            sendTo: [
+              {
+                amount: new BigNumber(finalDepositB + 1),
+                asset: Hash256.NEO,
+              },
+            ],
+            from: accountIDs[3],
+          });
+        } catch {
+          secondPurchaseB = -1;
+        }
+
+        let secondPurchaseC;
+        try {
+          secondPurchaseC = await smartContract.mintTokens.confirmed(
+            masterAccountID.address,
+            accountCAddress,
+            new BigNumber(-10),
+            {
+              from: masterAccountID,
+            },
+          );
+        } catch {
+          secondPurchaseC = -1;
+        }
+
+        expect(secondPurchaseA.result.state).toBe('HALT');
+        expect(secondPurchaseB).toBe(-1);
+        expect(secondPurchaseC).toBe(-1);
+      },
+      { deploy: false },
+    );
+  });
+});

--- a/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/validation/__snapshots__/TestIndividuallyCappedCrowdsale.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/crowdsale/validation/__snapshots__/TestIndividuallyCappedCrowdsale.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IndividuallyCappedCrowdsale deploy + transfer: deploy consumed 1`] = `"0"`;
+
+exports[`IndividuallyCappedCrowdsale deploy + transfer: deploy cost 1`] = `"1.662"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/TestOwnableContract.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/TestOwnableContract.test.ts
@@ -31,7 +31,7 @@ describe('Ownable', () => {
 
         expect(deployReceipt.result.gasConsumed.toString()).toMatchSnapshot('deploy consumed');
         expect(deployReceipt.result.gasCost.toString()).toMatchSnapshot('deploy cost');
-        expect(deployReceipt.result.value).toBeTruthy();
+        expect(deployReceipt.result.value).toEqual(true);
 
         const [initialOwner, recipient] = await Promise.all([
           smartContract.owner.confirmed(),

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Ownable deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.332"`;
+exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.574"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestOwnableContract.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Ownable deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.272"`;
+exports[`Ownable deploy + transfer: deploy cost 1`] = `"1.332"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Secondary deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.326"`;
+exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.568"`;

--- a/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/ownership/__snapshots__/TestSecondary.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Secondary deploy + transfer: deploy consumed 1`] = `"0"`;
 
-exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.266"`;
+exports[`Secondary deploy + transfer: deploy cost 1`] = `"1.326"`;

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/CrowdsaleContract.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/CrowdsaleContract.ts
@@ -1,0 +1,105 @@
+import {
+  Address,
+  Blockchain,
+  constant,
+  createEventNotifier,
+  Fixed,
+  Hash256,
+  receive,
+  SmartContract,
+} from '@neo-one/smart-contract';
+import { Ownable } from '../ownership/Ownable';
+
+const notifyTokensPurchased = createEventNotifier<Address, Fixed<8>, Fixed<8>>(
+  'tokens_purchased',
+  'account',
+  'NEO',
+  'qty tokens',
+);
+
+export function CrowdsaleContract() {
+  abstract class CrowdsaleContractClass extends Ownable(SmartContract) {
+    public readonly token: Address = this.initialCrowdsaleToken();
+    public readonly rate: Fixed<8> = this.initialCrowdsaleRate();
+    public readonly wallet: Address = this.initialCrowdsaleWallet();
+    protected mutableNeoRaised: Fixed<8> = 0;
+
+    @constant
+    public get neoRaised(): Fixed<8> {
+      return this.mutableNeoRaised;
+    }
+
+    @receive
+    public mintTokens(): boolean {
+      const { references } = Blockchain.currentTransaction;
+      if (references.length === 0) {
+        return false;
+      }
+      const sender = references[0].address;
+
+      let amountNeo = 0;
+      // tslint:disable-next-line no-loop-statement
+      for (const output of Blockchain.currentTransaction.outputs) {
+        if (output.address.equals(this.address)) {
+          if (!output.asset.equals(Hash256.NEO)) {
+            return false;
+          }
+
+          amountNeo += output.value;
+        }
+      }
+
+      this.issue(sender, amountNeo);
+
+      return true;
+    }
+
+    protected issue(account: Address, amountNeo: Fixed<8>): boolean {
+      this.preValidatePurchase(account, amountNeo);
+      const tokens = this.getTokenAmount(amountNeo);
+      this.mutableNeoRaised += amountNeo;
+      this.processPurchase(account, tokens);
+      notifyTokensPurchased(account, amountNeo, tokens);
+      this.updatePurchasingState(account, amountNeo);
+      this.forwardFunds(amountNeo, account);
+      this.postValidatePurchase(account, amountNeo);
+
+      return true;
+    }
+
+    // Override these functions with your configuration.
+    protected abstract initialCrowdsaleWallet(): Address;
+    protected abstract initialCrowdsaleRate(): Fixed<8>;
+    protected abstract initialCrowdsaleToken(): Address;
+
+    // PITFALL: Remember, when layering functionality in different classes, remember to
+    // call the corresponding super._fnx() to ensure the chain of checks is maintained.
+
+    /* tslint:disable: no-unused no-empty */
+    protected preValidatePurchase(purchaser: Address, amount: Fixed<8>) {
+      // override with any pre-purchase checks
+    }
+
+    protected processPurchase(purchaser: Address, tokens: Fixed<8>) {
+      // override with any purchase-process
+    }
+
+    protected updatePurchasingState(purchaser: Address, amount: Fixed<8>) {
+      // override with any state updates required
+    }
+
+    protected forwardFunds(amount: Fixed<8>, account: Address) {
+      // override with your method of forwarding funds
+    }
+
+    protected postValidatePurchase(purchaser: Address, amount: Fixed<8>) {
+      // override with any post purchase validation checks
+    }
+
+    protected getTokenAmount(amountNeo: Fixed<8>) {
+      return amountNeo * this.rate;
+    }
+  }
+
+  return CrowdsaleContractClass;
+}

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
@@ -1,2 +1,3 @@
-// tslint:disable-next-line:export-name
 export { CrowdsaleContract } from './CrowdsaleContract';
+export { CrowdsaleWithCapperRole } from './withAccessRoles';
+export { IndividuallyCappedCrowdsale } from './validation';

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/index.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:export-name
+export { CrowdsaleContract } from './CrowdsaleContract';

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/validation/IndividuallyCappedCrowdsale.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/validation/IndividuallyCappedCrowdsale.ts
@@ -1,0 +1,67 @@
+import { Address, constant, createEventNotifier, Fixed, MapStorage } from '@neo-one/smart-contract';
+import { CrowdsaleWithCapperRole } from '../withAccessRoles';
+
+const notifySetCap = createEventNotifier<Address, Fixed<8>, Address>('cap set', 'account', 'amount', 'by');
+
+export abstract class IndividuallyCappedCrowdsale extends CrowdsaleWithCapperRole {
+  protected readonly contributions = MapStorage.for<Address, Fixed<8>>();
+  protected readonly individualCaps = MapStorage.for<Address, Fixed<8>>();
+
+  public setCap(account: Address, amount: Fixed<8>, requestedBy: Address): boolean {
+    this.positiveOnly(amount);
+    this.onlyCappers(requestedBy);
+    notifySetCap(account, amount, requestedBy);
+    this.individualCaps.set(account, amount);
+
+    return true;
+  }
+
+  @constant
+  public getContributions(account: Address): Fixed<8> {
+    const contribs = this.contributions.get(account);
+
+    if (contribs === undefined) {
+      return 0;
+    }
+
+    return contribs;
+  }
+
+  @constant
+  public getCap(account: Address): Fixed<8> {
+    const cap = this.individualCaps.get(account);
+    if (cap === undefined) {
+      return 0;
+    }
+
+    return cap;
+  }
+
+  protected positiveOnly(num: Fixed<8>) {
+    if (num < 0) {
+      throw new Error('no negative purchase');
+    }
+  }
+
+  protected preValidatePurchase(account: Address, amount: Fixed<8>) {
+    this.positiveOnly(amount);
+    super.preValidatePurchase(account, amount);
+    const accountCap = this.getCap(account);
+    const curBalance = this.getContributions(account);
+    const newBalance = curBalance + amount;
+    if (newBalance > accountCap) {
+      throw new Error(
+        `Adding ${amount} to the current balance of ${curBalance} will exceed the allowed cap of ${accountCap}`,
+      );
+    }
+  }
+
+  protected updatePurchasingState(account: Address, amount: Fixed<8>, announce?: boolean) {
+    super.updatePurchasingState(account, amount);
+    this.contributions.set(account, this.getContributions(account) + amount);
+
+    if (announce) {
+      throw new Error(`adding ${amount} to ${account}'s contributions`);
+    }
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/validation/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/validation/index.ts
@@ -1,0 +1,2 @@
+// tslint:disable:export-name
+export { IndividuallyCappedCrowdsale } from './IndividuallyCappedCrowdsale';

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/withAccessRoles/CrowdsaleWithCapperRole.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/withAccessRoles/CrowdsaleWithCapperRole.ts
@@ -1,0 +1,47 @@
+import { Address, constant, MapStorage, createEventNotifier } from '@neo-one/smart-contract';
+import { AccessRoleHandler } from '../../utils';
+import { CrowdsaleContract } from '../CrowdsaleContract';
+
+const notifyAddCapper = createEventNotifier<Address, Address>('add_minter', 'address', 'requested by');
+const notifyRemoveCapper = createEventNotifier<Address, Address>('remove_minter', 'address', 'requested by');
+
+export abstract class CrowdsaleWithCapperRole extends CrowdsaleContract() {
+  private readonly capperList = MapStorage.for<Address, boolean>();
+
+  @constant
+  public isCapper(address: Address): boolean {
+    return AccessRoleHandler.isMember(this.capperList, address);
+  }
+
+  @constant
+  public onlyCappers(address: Address) {
+    if (!Address.isCaller(address) && this.isCapper(address)) {
+      throw new Error('not a capper');
+    }
+  }
+
+  public addCapper(address: Address, requestedBy: Address): boolean {
+    this.onlyCappers(requestedBy);
+    if (!AccessRoleHandler.isMember(this.capperList, address) && AccessRoleHandler.add(this.capperList, address)) {
+      notifyAddCapper(address, requestedBy);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  public removeCapper(address: Address, requestedBy: Address): boolean {
+    this.onlyCappers(requestedBy);
+    if (AccessRoleHandler.isMember(this.capperList, address) && AccessRoleHandler.remove(this.capperList, address)) {
+      notifyRemoveCapper(address, requestedBy);
+
+      return true;
+    }
+
+    return false;
+  }
+  protected initialCapper(account: Address) {
+    this.capperList.set(account, true);
+  }
+}

--- a/packages/neo-one-smart-contract-lib/src/crowdsale/withAccessRoles/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/crowdsale/withAccessRoles/index.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:export-name
+export { CrowdsaleWithCapperRole } from './CrowdsaleWithCapperRole';

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,2 +1,3 @@
 export { NEP5Token } from './NEP5Token';
 export { Ownable, Secondary } from './ownership';
+export { CrowdsaleContract } from './crowdsale';

--- a/packages/neo-one-smart-contract-lib/src/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/index.ts
@@ -1,3 +1,3 @@
 export { NEP5Token } from './NEP5Token';
 export { Ownable, Secondary } from './ownership';
-export { CrowdsaleContract } from './crowdsale';
+export { CrowdsaleContract, IndividuallyCappedCrowdsale, CrowdsaleWithCapperRole } from './crowdsale';

--- a/packages/neo-one-smart-contract-lib/src/utils/AccessRoles.ts
+++ b/packages/neo-one-smart-contract-lib/src/utils/AccessRoles.ts
@@ -1,0 +1,29 @@
+import { Address, MapStorage } from '@neo-one/smart-contract';
+
+export type AccessRoleMemberList = MapStorage<Address, boolean>;
+
+const isMember = (list: AccessRoleMemberList, member: Address): boolean =>
+  list.has(member) && list.get(member) === true;
+
+export const AccessRoleHandler = {
+  isMember,
+
+  add: (list: AccessRoleMemberList, member: Address): boolean => {
+    if (!isMember(list, member)) {
+      list.set(member, true);
+
+      return true;
+    }
+
+    return false;
+  },
+  remove: (list: AccessRoleMemberList, member: Address): boolean => {
+    if (isMember(list, member)) {
+      list.delete(member);
+
+      return true;
+    }
+
+    return false;
+  },
+};

--- a/packages/neo-one-smart-contract-lib/src/utils/index.ts
+++ b/packages/neo-one-smart-contract-lib/src/utils/index.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:export-name
+export { AccessRoleHandler } from './AccessRoles';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "packages/neo-one-smart-contract-lib/src/index.ts",
     "packages/neo-one-smart-contract-lib/src/ownership/*.ts",
     "packages/neo-one-smart-contract-lib/src/crowdsale/**/*.ts",
+    "packages/neo-one-smart-contract-lib/src/utils/**/*.ts",
     "packages/neo-one-smart-contract-lib/src/ICO.ts",
     "packages/neo-one-smart-contract-lib/src/NEP5Token.ts",
     "packages/neo-one-smart-contract-compiler/src/__data__/snippets/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
     "packages/neo-one-smart-contract/src/*.d.ts",
     "packages/neo-one-smart-contract-lib/src/index.ts",
     "packages/neo-one-smart-contract-lib/src/ownership/*.ts",
+    "packages/neo-one-smart-contract-lib/src/crowdsale/**/*.ts",
     "packages/neo-one-smart-contract-lib/src/ICO.ts",
     "packages/neo-one-smart-contract-lib/src/NEP5Token.ts",
     "packages/neo-one-smart-contract-compiler/src/__data__/snippets/**/*.ts",


### PR DESCRIPTION
Add a pre-mixed the which adds a list to track addresses allowed to modify caps.  This contract is then extended with to be `IndividuallyCapped` by adding `MapStorage`s that track `contributions` and `individualCaps`.

 `CrowdsaleWithCapperRole`
the ability to add and 

Testing: 

     yarn jest individually
