### PR TITLE
feat(renovate): seperate misc major/minor and add update schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     "group:definitelyTyped",
+    "schedule:daily",
     ":semanticCommits"
   ],
   "packageRules": [
@@ -9,8 +10,7 @@
       "packagePatterns": ["*"],
       "excludePackagePatterns": ["^react*", "^webpack*", "^rollup*", "^style*", "typescript", "^@types/*"],
       "groupName": "misc dependencies",
-      "groupSlug": "misc",
-      "separateMajorMinor": false
+      "groupSlug": "misc"
     },
     {
       "packagePatterns": ["^react*", "^webpack*", "^rollup*", "^style*"],


### PR DESCRIPTION
title, putting it on a schedule allows us to "kick out" failing dependency updates without them immediately coming back. 

Also I think we can comfortably separate the misc major/minor updates.

(by default it will update its branches on 2am every day)