### PR TITLE
fix(server-ver-check): fix server version check

### DIFF
--- a/packages/neo-one-server-client/src/ServerManager.ts
+++ b/packages/neo-one-server-client/src/ServerManager.ts
@@ -107,8 +107,8 @@ export class ServerManager {
     return this.getServerVersion();
   }
 
-  public compareVersions(verA: string, verB: string) {
-    return verA === verB ? 0 : semver.lt(verA, verB) ? -1 : 1;
+  public compareVersions(verA: string, verB: string): 0 | 1 | -1 {
+    return verA === verB ? 0 : semver.lt(verA, verB) ? 1 : -1;
   }
 
   public async getRelativeServerVersion({
@@ -183,13 +183,13 @@ export class ServerManager {
     readonly binary: Binary;
     readonly onStart?: () => void;
   }): Promise<{ readonly pid: number; readonly started: boolean; readonly newerVersion: string | undefined }> {
-    const [version, pid] = await Promise.all([
+    const [npmVersion, pid] = await Promise.all([
       npmCheck('@neo-one/cli', this.checkPath, CHECK_TIMEOUT_MS, CHECK_DELAY_SEC),
       this.checkAlive(port),
     ]);
 
     const newerVersion =
-      version !== undefined && this.compareVersions(this.serverVersion, version) ? version : undefined;
+      npmVersion !== undefined && this.compareVersions(this.serverVersion, npmVersion) > 0 ? npmVersion : undefined;
 
     if (pid !== undefined) {
       return { pid, started: false, newerVersion };


### PR DESCRIPTION
### Requirements
enhanced server version check to report newer version if version difference is ` > 0 `
 
### Description of the Change
Updated variable names to be a bit more reasonable, added missing ` > 0 ` check

### Test Plan
 set NPMVersion to 3.0 & received proper "new version available" 
 otherwise the version in npm `1.1.0` is < `1.2.0`  
### Applicable Issues

fixes #1380