### PR TITLE
feat(rpc): Re-enable rateLimit middleware on the rpc server

### DIFF
--- a/packages/neo-one-server-plugin-network/src/node/NEOONENodeAdapter.ts
+++ b/packages/neo-one-server-plugin-network/src/node/NEOONENodeAdapter.ts
@@ -94,6 +94,11 @@ const makeDefaultConfig = (dataPath: string): NodeConfig => ({
         offset: 1,
         timeoutMS: 5000,
       },
+      rateLimit: {
+        enabled: true,
+        duration: 60000,
+        rate: 6000000,
+      },
     },
   },
 });

--- a/packages/neo-one-server-plugin-wallet/src/__data__/bootstrapTestUtils.ts
+++ b/packages/neo-one-server-plugin-wallet/src/__data__/bootstrapTestUtils.ts
@@ -19,7 +19,7 @@ interface Tokens {
   readonly [key: string]: string;
 }
 
-export async function getNetworkInfo(
+async function getNetworkInfo(
   network: string,
 ): Promise<{
   readonly height: number;
@@ -298,7 +298,7 @@ interface Options {
   readonly rpcURL: string;
 }
 
-export async function getDefaultInfo({ network }: Options): Promise<Info> {
+async function getDefaultInfo({ network }: Options): Promise<Info> {
   const outputs = await one.execute(`get wallet --network ${network} --json`);
   const wallets: ReadonlyArray<Info> = one
     .parseJSON(outputs)
@@ -317,7 +317,7 @@ export async function getDefaultInfo({ network }: Options): Promise<Info> {
   return { wallets };
 }
 
-export async function testBootstrap(
+async function testBootstrap(
   getCommand: (options: Options) => Promise<string>,
   numWallets: number,
   network: string,
@@ -380,3 +380,9 @@ export async function testBootstrap(
     testContracts({ readClient, tokens }),
   ]);
 }
+
+export const bootstrapTestUtils = {
+  testBootstrap,
+  getNetworkInfo,
+  getDefaultInfo,
+};

--- a/packages/neo-one-server-plugin-wallet/src/__e2e__/bootstrap20Wallets.test.ts
+++ b/packages/neo-one-server-plugin-wallet/src/__e2e__/bootstrap20Wallets.test.ts
@@ -1,4 +1,4 @@
-import * as bootstrapTestUtils from '../__data__/bootstrapTestUtils';
+import { bootstrapTestUtils } from '../__data__/bootstrapTestUtils';
 
 describe('bootstrap 20 wallets', () => {
   test('bootstrap - 20 wallets', async () => {

--- a/packages/neo-one-server-plugin-wallet/src/__e2e__/bootstrapRPC.test.ts
+++ b/packages/neo-one-server-plugin-wallet/src/__e2e__/bootstrapRPC.test.ts
@@ -1,6 +1,6 @@
 import { Asset, privateKeyToAddress } from '@neo-one/client-common';
 import { NEOONEProvider } from '@neo-one/client-core';
-import * as bootstrapTestUtils from '../__data__/bootstrapTestUtils';
+import { bootstrapTestUtils } from '../__data__/bootstrapTestUtils';
 import { ASSET_INFO, DEFAULT_PRIVATE_KEYS, TOKEN_INFO } from '../bootstrap';
 
 describe('bootstrap with rpc', () => {


### PR DESCRIPTION
Re-enable the RPC RateLimiter middleware with appropriate defaults that allow it to pass tests but also still be a failsafe if someone messed up and had a client send a TON of requests at once.