### PR TITLE
feat(contract-test-name): provide smartContractName hints

### DIFF
--- a/packages/neo-one-smart-contract-lib/src/__data__/tokenUtils.ts
+++ b/packages/neo-one-smart-contract-lib/src/__data__/tokenUtils.ts
@@ -9,7 +9,7 @@ import {
   UserAccountID,
 } from '@neo-one/client-common';
 import { SmartContractAny } from '@neo-one/client-core';
-import { withContracts } from '@neo-one/smart-contract-test';
+import { getContractFromOptions, withContracts } from '@neo-one/smart-contract-test';
 import BigNumber from 'bignumber.js';
 
 export interface DeployOptions {
@@ -41,7 +41,7 @@ const ZERO = {
   PUBLIC_KEY: '027f73dbc47133b08a4bc0fc04589fc76525baaf3bebe71bdd78053d559c41db70',
 };
 
-export const testToken = async ({
+export const tokenTester = async ({
   name,
   filePath,
   symbol,
@@ -65,8 +65,10 @@ export const testToken = async ({
     ],
     async (options) => {
       const { client, networkName, masterAccountID, masterPrivateKey } = options;
-      // tslint:disable-next-line no-any
-      const smartContract: SmartContractAny = (options as any)[smartContractName];
+
+      const smartContract = getContractFromOptions(options, smartContractName);
+      expect(smartContract).toBeDefined();
+
       let event: Event;
       if (deploy !== undefined) {
         const deployResult = await deploy({

--- a/packages/neo-one-smart-contract-lib/src/__tests__/RedToken.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/RedToken.test.ts
@@ -1,12 +1,12 @@
 import BigNumber from 'bignumber.js';
 import * as path from 'path';
-import { testToken } from '../__data__';
+import { tokenTester } from '../__data__';
 
 const issueValue = new BigNumber('1000000');
 
 describe('RedToken', () => {
   test('properties + issue + balanceOf + totalSupply + transfer', async () => {
-    await testToken({
+    await tokenTester({
       name: 'RedToken',
       filePath: path.resolve(__dirname, '..', '__data__', 'contracts', 'RedToken.ts'),
       smartContractName: 'redToken',

--- a/packages/neo-one-smart-contract-lib/src/__tests__/TestToken.test.ts
+++ b/packages/neo-one-smart-contract-lib/src/__tests__/TestToken.test.ts
@@ -1,11 +1,11 @@
 import { InvokeReceipt, TransactionResult } from '@neo-one/client-common';
 import BigNumber from 'bignumber.js';
 import * as path from 'path';
-import { testToken } from '../__data__';
+import { tokenTester } from '../__data__';
 
 describe('TestToken', () => {
   test('properties + issue + balanceOf + totalSupply + transfer', async () => {
-    await testToken({
+    await tokenTester({
       name: 'TestToken',
       filePath: path.resolve(__dirname, '..', '__data__', 'contracts', 'TestToken.ts'),
       smartContractName: 'testToken',

--- a/packages/neo-one-smart-contract-test/src/__e2e__/index.test.ts
+++ b/packages/neo-one-smart-contract-test/src/__e2e__/index.test.ts
@@ -2,7 +2,7 @@
 import * as api from '@neo-one/smart-contract-test';
 
 describe('@neo-one/smart-contract-test', () => {
-  const EXPECTED = ['withContracts'];
+  const EXPECTED = ['getContractFromOptions', 'withContracts'];
 
   test('has expected exports', () => {
     // tslint:disable-next-line no-array-mutation no-misleading-array-reverse

--- a/packages/neo-one-smart-contract-test/src/withContracts.ts
+++ b/packages/neo-one-smart-contract-test/src/withContracts.ts
@@ -1,4 +1,4 @@
-import { NEOONEDataProvider } from '@neo-one/client-core';
+import { NEOONEDataProvider, SmartContractAny } from '@neo-one/client-core';
 import { createCompilerHost } from '@neo-one/smart-contract-compiler-node';
 import {
   Contract,
@@ -9,6 +9,39 @@ import {
 import { createNode } from './createNode';
 
 export { Contract, WithContractsOptions, TestOptions };
+
+// tslint:disable-next-line no-any
+export const getContractFromOptions = (options: any, smartContractName: string): SmartContractAny => {
+  const smartContract: SmartContractAny = options[smartContractName];
+
+  // tslint:disable-next-line: strict-type-predicates
+  if (smartContract === undefined) {
+    const re = new RegExp(smartContractName.toLowerCase(), 'g');
+    const matches = Object.keys(options).filter((key) => key.toLowerCase().match(re));
+    if (matches.length) {
+      // tslint:disable-next-line: no-console
+      console.error(
+        `\n\nCould not find smartContractName: "${smartContractName}", did you mean: ${matches.join(', ')}\n\n`,
+      );
+    } else {
+      const reserved = [
+        'client',
+        'developerClient',
+        'masterAccountID',
+        'masterPrivateKey',
+        'networkName',
+        'accountIDs',
+      ];
+      const otherNames = Object.keys(options).filter((key) => reserved.indexOf(key) === -1);
+      // tslint:disable-next-line: no-console
+      console.error(
+        `\n\nCould not find smartContractName: "${smartContractName}", did you mean: ${otherNames.join(', ')}\n\n`,
+      );
+    }
+  }
+
+  return smartContract;
+};
 
 export const withContracts = async <T>(
   contracts: ReadonlyArray<Contract>,


### PR DESCRIPTION
withContracts:
1.) Added a companion utility function to `withContracts` to test if the supplied `smartContractName` is available in the list of contracts.
2.) Rename `testToken` to `tokenTester` this seems like a reasonable rename to avoid confusing with the actual `TestToken`

If it is just an issue with matching the case of letters:
![image](https://user-images.githubusercontent.com/39564353/57030067-6f9afb00-6bf8-11e9-9713-0c10a283f3ad.png)

If the provided smart contract name is just wrong:
![image](https://user-images.githubusercontent.com/39564353/57030150-b557c380-6bf8-11e9-8330-ee77bf0465a5.png)


fixes #1399
