### PR TITLE
fix(tslint): re-enable auto fixing lint errors on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,14 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "tslint.autoFixOnSave": true,
   "typescript.format.insertSpaceBeforeFunctionParenthesis": false,
   "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
   "typescript.format.enable": false,
   "javascript.format.enable": false,
   "typescript.preferences.quoteStyle": "single",
   "javascript.preferences.quoteStyle": "single",
-  "typescript.autoImportSuggestions.enabled": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.tslint": true
+  },
   "editor.formatOnPaste": false,
   "editor.formatOnSave": true,
   "cSpell.language": "en",


### PR DESCRIPTION
title,

also remove some other deprecated settings we had laying around.