### PR TITLE
pass hash name as ripemd160 instead of rmd160 in Electron

### DIFF
--- a/packages/neo-one-client-common/src/crypto.ts
+++ b/packages/neo-one-client-common/src/crypto.ts
@@ -45,7 +45,7 @@ const sha1 = (value: Buffer): Buffer =>
 const sha256 = sha256In;
 
 const rmd160 = (value: Buffer): Buffer =>
-  createHash('rmd160')
+  createHash(process.versions.hasOwnProperty('electron') ? 'ripemd160' : 'rmd160')
     .update(value)
     .digest();
 


### PR DESCRIPTION


### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change

Changed the call to `createHash` to use the name `ripemd160` instead of `rmd160` when running under Electron. `rmd160` as a hash algorithm name is no longer supported since Electron 4, when the Electron team switched to the BoringSSL library which uses the `ripemd160` name instead of OpenSSL's `rmd160` name.


### Test Plan

Manually tested under Electron v5.0.2 - the Neo-One node would not run under Electron without this change. 

### Alternate Designs

No other designs considered

### Benefits

Neo-One projects requiring RIPEMD160 hashing will be compatible with Electron

### Possible Drawbacks

No drawbacks that I can see

### Applicable Issues

No existing issues known
