### PR TITLE
fix(website): fix the scroll sync issue

### DIFF
--- a/packages/neo-one-website/src/components/content/MainContent.tsx
+++ b/packages/neo-one-website/src/components/content/MainContent.tsx
@@ -171,7 +171,7 @@ export const MainContent = ({ content, title, date, link, author, ...props }: Pr
     {date === undefined || author === undefined ? null : <DateAndAuthor date={date} author={author} />}
     {content.type === 'markdown' ? (
       <>
-        <StyledMarkdown source={content.value} linkColor="accent" light anchors />
+        <StyledMarkdown source={content.value} linkColor="accent" light anchors resetScroll />
         <EditPageLink link={link} />
       </>
     ) : (

--- a/packages/neo-one-website/src/elements/Markdown.tsx
+++ b/packages/neo-one-website/src/elements/Markdown.tsx
@@ -265,16 +265,15 @@ export class Markdown extends React.Component<Props> {
 
   public componentDidMount(): void {
     this.handleUpdate();
+    if (this.props.resetScroll) {
+      window.scrollTo(0, 0);
+    }
   }
 
   public componentDidUpdate(prevProps: Props): void {
     this.handleUpdate();
-    const current = this.ref.current;
-    if (current && this.props.resetScroll && this.props.source !== prevProps.source) {
-      // tslint:disable-next-line no-object-mutation
-      current.scrollTop = 0;
-      // tslint:disable-next-line no-object-mutation
-      current.scrollLeft = 0;
+    if (this.props.resetScroll && this.props.source !== prevProps.source) {
+      window.scrollTo(0, 0);
     }
   }
 


### PR DESCRIPTION
### Description of the Change

Update our scroll-sync method to match what React-Router recommends now. https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md

### Test Plan

start the website with:
```
yarn website:start:dev-builds
```
and in a seperate terminal
```
yarn website:start:dev
```

Click a really long article, like in `/Docs`, and then click other links. You'll see you are brought to the top of the page again now.

### Benefits

It was really annoying before.

### Applicable Issues

#1340 
