### PR TITLE
fix(compiler): catch errors properly when using neo-one build --watch

### DIFF
--- a/packages/neo-one-server-plugin-project/src/build/index.ts
+++ b/packages/neo-one-server-plugin-project/src/build/index.ts
@@ -81,9 +81,10 @@ export const build = (
       {
         title: 'Find contracts',
         task: async (ctx) => {
-          ctx.contractPaths = await findContracts(getProjectConfig(ctx));
+          const config = getProjectConfig(ctx);
+          ctx.contractPaths = await findContracts(config);
           if (ctx.contractPaths.length === 0) {
-            throw new Error(`${JSON.stringify(getProjectConfig(ctx))}`);
+            throw new Error(`0 compilable smart contracts found in ${config.paths.contracts}`);
           }
         },
       },

--- a/packages/neo-one-server-plugin-project/src/buildCommand.ts
+++ b/packages/neo-one-server-plugin-project/src/buildCommand.ts
@@ -73,15 +73,22 @@ const doWatch = async (
     let subscription: Subscription | undefined = watchFiles$(projectConfig.paths.contracts)
       .pipe(
         mergeScanLatest(async () => {
+          // tslint:disable-next-line: no-console
+          console.log('Change detected, attempting re-build');
           cancel$ = new ReplaySubject<void>();
-          await build(cli, cancel$, progress, options);
+          try {
+            await build(cli, cancel$, progress, options);
+          } catch (error) {
+            // tslint:disable-next-line: no-console
+            console.error(`Re-build failed with ${error.message}\n`);
+          }
         }),
       )
       .subscribe({
         complete: () => {
           resolve();
         },
-        error: (error: Error) => {
+        error: (error) => {
           reject(error);
         },
       });


### PR DESCRIPTION
### Description of the Change

Catch but don't throw errors when building smart contracts with `--watch` so that it doesn't fail and have to be restarted on TS error or equivalent.

### Test Plan

1. create `./one/contracts/Token.ts` with
```
import { SmartContract } from '@neo-one/smart-contract';

export class Token extends SmartContract {}
```
2. run `yarn watch` in another terminal
3. run
```
node ./dist/neo-one/packages/neo-one-cli/bin/neo-one build --watch
```
4. comment out the `import { SmartContract } from '@neo-one/smart-contract';` line.
5. ??? it doesn't crash out now

### Benefits
here is the old output when you did the above:
```
✔ Load project configuration
 ✖ Find contracts
   → Error: {"paths":{"contracts":"/Users/danielbyrne/neo-one/one/contracts","genera…
   Deploy dev contracts
   Synchronize project
✖ Error: {"paths":{"contracts":"/Users/danielbyrne/neo-one/one/contracts","generated":"/Users/danielbyrne/neo-one/one/generated"},"codegen":{"language":"typescript","framework":"none","browser":false}}
    at Object.task (/Users/danielbyrne/neo-one/dist/neo-one/packages/neo-one-server-plugin-project/build/index.ts:86:19)
Error: Error: {"paths":{"contracts":"/Users/danielbyrne/neo-one/one/contracts","generated":"/Users/danielbyrne/neo-one/one/generated"},"codegen":{"language":"typescript","framework":"none","browser":false}}
    at Object.task (/Users/danielbyrne/neo-one/dist/neo-one/packages/neo-one-server-plugin-project/build/index.ts:86:19)
    at SwitchMapSubscriber.response$.pipe.operators_1.switchMap [as project] (/Users/danielbyrne/neo-one/dist/neo-one/packages/neo-one-server-plugin/handleCLITaskList.ts:123:19)
    at SwitchMapSubscriber._next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/operators/switchMap.ts:123:21)
    at SwitchMapSubscriber.Subscriber.next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subscriber.ts:99:12)
    at MapSubscriber._next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/operators/map.ts:89:22)
    at MapSubscriber.Subscriber.next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subscriber.ts:99:12)
    at RefCountSubscriber.Subscriber._next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subscriber.ts:139:22)
    at RefCountSubscriber.Subscriber.next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subscriber.ts:99:12)
    at ReplaySubject.Subject.next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subject.ts:70:17)
    at ReplaySubject.nextInfiniteTimeWindow (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/ReplaySubject.ts:46:15)
    at ConnectableSubscriber.Subscriber._next (/Users/danielbyrne/neo-one/dist/neo-one/node_modules/rxjs/src/internal/Subscriber.ts:139:22)
```

and the new output:
```
Change detected, attempting re-build
 ✔ Load project configuration
 ✖ Find contracts
   → Error: 0 compilable smart contracts found in /Users/danielbyrne/neo-one/on…
   Deploy dev contracts
   Synchronize project
Re-build failed with Error: 0 compilable smart contracts found in /Users/danielbyrne/neo-one/one/contracts
    at Object.task (/Users/danielbyrne/neo-one/dist/neo-one/packages/neo-one-server-plugin-project/build/index.ts:87:19)

Change detected, attempting re-build
 ✔ Load project configuration
 ✔ Find contracts
 ✔ Deploy dev contracts
 ✔ Synchronize project
```

### Applicable Issues

Fix #1385 
