### PR TITLE
feat(cli): 'yarn neo-one init' finds framework, warns otherwise

### DIFF
--- a/packages/neo-one-server-plugin-project/src/initCommand.ts
+++ b/packages/neo-one-server-plugin-project/src/initCommand.ts
@@ -65,16 +65,20 @@ export const initCommand = ({ cli }: InteractiveCLIArgs) =>
       initDataFile({ folder: cwd, name: '.onerc', data: JSON.stringify(relativeConfig), cli }),
     ]);
 
+    if (projectConfig.codegen.framework === 'none') {
+      cli.print('Unable to determine project framework, please specify it in .onerc');
+    }
+
     const rootTsConfigPath = path.resolve(cwd, 'tsconfig.json');
     const exists = await fs.pathExists(rootTsConfigPath);
     if (exists) {
       const file = await jsonFile(rootTsConfigPath);
       const currentExcludeIn = await file.get('exclude');
-      const currentExclude = currentExcludeIn === undefined ? [] : currentExcludeIn;
+      const currentExclude = new Set<string>(currentExcludeIn);
       file.set({
-        exclude: currentExclude.concat([
-          normalizePath(path.relative(cwd, path.join(projectConfig.paths.contracts, '*.ts'))),
-        ]),
+        exclude: [
+          ...currentExclude.add(normalizePath(path.relative(cwd, path.join(projectConfig.paths.contracts, '*.ts')))),
+        ],
       });
       await file.save();
       cli.print('Added contracts directory to root tsconfig exclude.');

--- a/packages/neo-one-server-plugin-project/src/utils/loadProjectConfig.ts
+++ b/packages/neo-one-server-plugin-project/src/utils/loadProjectConfig.ts
@@ -1,17 +1,27 @@
+import { CodegenFramework } from '@neo-one/smart-contract-codegen';
 import convict from 'convict';
 import cosmiconfig from 'cosmiconfig';
-import * as path from 'path';
+import fs from 'fs-extra';
+import path from 'path';
 import { ProjectConfig, projectConfigSchema } from '../types';
 
-const validateConfig = (rootDir: string, configIn: cosmiconfig.Config): ProjectConfig => {
+const validateConfig = async (rootDir: string, configIn: cosmiconfig.Config): Promise<ProjectConfig> => {
   const config = convict<ProjectConfig>(projectConfigSchema);
   config.load(configIn);
   config.validate({ allowed: 'warn' });
 
   const validatedConfig = config.getProperties();
 
+  let newFramework: CodegenFramework | undefined;
+  if (Object.entries(configIn).length === 0) {
+    newFramework = await getProjectFramework(rootDir);
+  }
+
   return {
-    ...validatedConfig,
+    codegen: {
+      ...validatedConfig.codegen,
+      framework: newFramework ? newFramework : validatedConfig.codegen.framework,
+    },
     paths: {
       contracts: path.resolve(rootDir, validatedConfig.paths.contracts),
       generated: path.resolve(rootDir, validatedConfig.paths.generated),
@@ -25,4 +35,36 @@ export const loadProjectConfig = async (rootDir: string): Promise<ProjectConfig>
   const result = await explorer.search(rootDir);
 
   return validateConfig(rootDir, result === null ? {} : result.config);
+};
+
+// tslint:disable-next-line: no-any
+const getPkgDependencies = (pkg: any): Set<string> => {
+  const dependencies = pkg.dependencies === undefined ? [] : Object.keys(pkg.dependencies);
+  const devDependencies = pkg.devDependencies === undefined ? [] : Object.keys(pkg.devDependencies);
+
+  return new Set(dependencies.concat(devDependencies));
+};
+
+const getProjectFramework = async (rootDir: string): Promise<CodegenFramework> => {
+  const pkgPath = path.resolve(rootDir, 'package.json');
+  const pkgExists = await fs.pathExists(pkgPath);
+  if (!pkgExists) {
+    return 'none';
+  }
+  const pkg = await fs.readJSON(path.resolve(rootDir, 'package.json'));
+  const dependencies = getPkgDependencies(pkg);
+
+  if (dependencies.has('react') || dependencies.has('react-dom')) {
+    return 'react';
+  }
+
+  if (dependencies.has('@angular/core') || dependencies.has('@angular/cli')) {
+    return 'angular';
+  }
+
+  if (dependencies.has('vue') || dependencies.has('@vue/cli-service')) {
+    return 'vue';
+  }
+
+  return 'none';
 };


### PR DESCRIPTION
### Description of the Change

Check the package.json of the current working directory for key dependencies in order to deduce the project framework.

Additional do some `Set` wrapping for the tsconfig.exclude overrides we do. Previously if someone did `yarn neo-one init` multiple times it would keep adding the same file to the end of the exclude. Fixed now :)

### Test Plan

kind of complicated but if you do the various `create-x-app`s you can see that the dependencies I check for are the ones generated by the frameworks. You can quickly test it works for react using
```
yarn build
node ./dist/neo-one/packages/neo-one-cli/bin/neo-one init
```
and see that the `.onerc` has "react" as its framework.

### Alternate Designs

It looks like only angular sets up additional `.json` files that could be used to identify it as angular, but it also looks like that name can be variable. I'm open to other suggestions of checking the framework.

### Benefits

quicker to hit the ground running with `@neo-one`

### Applicable Issues

fix #1382 