### PR TITLE
docs(polyfill): document polyfill requirements + fix incorrect line

### DIFF
--- a/packages/neo-one-website/docs/0-installation/1-environment-setup.md
+++ b/packages/neo-one-website/docs/0-installation/1-environment-setup.md
@@ -82,3 +82,18 @@ Configure your IDE to use your local TypeScript installation and the `@neo-one/s
   3. Open a TypeScript file, then click the TypeScript version number in the lower right hand side of your editor and choose "Use Workspace Version"
 
 That's it! Enjoy inline smart contract compiler diagnostics.
+
+## Javascript Environment Requirements
+
+NEO•ONE depends on several types which older browser may not support.  NEO•ONE requires the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) as well as [Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator). If you support older browsers and devices which may not yet provide these natively, consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js) or [babel-polyfill](https://babeljs.io/docs/en/babel-polyfill/).
+
+To polyfill an environment for NEO•ONE using core-js, include the following lines at the top of your entry point.
+
+```typescript
+import 'core-js/es/map';
+import 'core-js/es/set';
+import 'core-js/es/symbol/async-iterator';
+```
+
+
+

--- a/packages/neo-one-website/tutorial/tutorial.md
+++ b/packages/neo-one-website/tutorial/tutorial.md
@@ -251,7 +251,7 @@ await withContracts(async ({ token, accountIDs }) => {
 });
 ```
 
-Notice how the methods correspond 1:1 to what's been declared in the smart contract. We're also making use of one of the automatically generated `UserAccountID`s as the `balanceOf` `Address` argument.
+Notice how the methods correspond 1:1 to what's been declared in the smart contract. We're also making use of one of the automatically generated `UserAccountID`s as the `balanceOf` `Address` argument. You can find the full list of automatically generated `UserAccountID`s in the [testing](/docs/testing) section of the docs.
 
 ### Constructors
 
@@ -366,8 +366,8 @@ Now that we can mint tokens, let's see how we can test both `transfer` and `mint
 
 ```typescript
 await withContracts(async ({ token, accountIDs }) => {
-  // We'll use this account for minting
-  const accountID = accountIDs[0];
+  // We'll use this account for minting because it starts with 10 NEO in it
+  const accountID = accountIDs[2];
   const amount = new BigNumber(10);
 
   // Mint the tokens and verify the transaction succeeds


### PR DESCRIPTION
### Description of the Change
Documented polyfill requirements and fixed a mistake in the tutorial - accountIDs[0] has no NEO and will fail to mintTokens. 

### Applicable Issues
#783, #1341