### PR TITLE
fix(build): fix import transformations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -453,6 +453,8 @@ const compileTypescript = ((cache) =>
             `${RXJS_IMPORT}/${format.module === 'esm' ? '_esm2015/' : ''}internal`,
           ),
         )
+        .pipe(gulpReplace(/import\("(?:..\/)*neo-one-([^\)]*)\/src"\)/g, 'import("@neo-one/$1")'))
+        .pipe(gulpReplace(/import\("(?:..\/)*types\/bn.js"\).BN/g, 'import("bn.js")'))
         .pipe(gulpReplace("import { BN } from 'bn.js';", "import BN from 'bn.js';"))
         .pipe(
           gulpRename((name) => {


### PR DESCRIPTION
### Description of the Change

Big surprise the build was still broken. This adds regex transformations to the `gulpfile` that SHOULD be the final fix that is needed. I did an full audit of the `dist` today so this was the only red-flag I saw.

### Test Plan

```
yarn build
```

the imports aren't jank relative paths with a bunch of `../../../`s

### Applicable Issues

fix #1509 
