### PR TITLE
chore(cli): migrate from winston to pino

### DIFF
--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -13,6 +13,7 @@
     "@neo-one/server-plugin-project": "^1.3.0",
     "@neo-one/server-plugin-wallet": "^1.1.4",
     "@neo-one/utils": "^1.1.2",
+    "@types/pino": "^5.8.8",
     "@types/vorpal": "^1.11.0",
     "cli-table2": "^0.2.0",
     "env-paths": "^2.2.0",
@@ -22,12 +23,12 @@
     "inquirer": "^6.2.2",
     "log-update": "^3.2.0",
     "ora": "^3.4.0",
+    "pino": "^5.12.6",
     "rxjs": "^6.5.2",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.12",
     "tslib": "^1.9.3",
-    "vorpal": "^1.12.0",
-    "winston": "^3.1.0"
+    "vorpal": "^1.12.0"
   },
   "devDependencies": {
     "@types/cli-table2": "0.2.2",

--- a/packages/neo-one-cli/src/InteractiveCLI.ts
+++ b/packages/neo-one-cli/src/InteractiveCLI.ts
@@ -230,8 +230,6 @@ export class InteractiveCLI {
             name: 'interactiveCLI',
             path: logPath,
             level: config.level,
-            maxSize: config.maxSize,
-            maxFiles: config.maxFiles,
           };
         }),
       )

--- a/packages/neo-one-cli/src/commands/common/setupServer.ts
+++ b/packages/neo-one-cli/src/commands/common/setupServer.ts
@@ -28,8 +28,6 @@ export const setupServer = (
         name,
         path,
         level: config.level,
-        maxSize: config.maxSize,
-        maxFiles: config.maxFiles,
       })),
     )
     .subscribe(logConfig$);

--- a/packages/neo-one-cli/src/utils/createClientConfig.ts
+++ b/packages/neo-one-cli/src/utils/createClientConfig.ts
@@ -4,8 +4,6 @@ export interface ClientConfig {
   readonly paths: Paths;
   readonly log: {
     readonly level: string;
-    readonly maxSize: number;
-    readonly maxFiles: number;
   };
 }
 
@@ -17,8 +15,6 @@ export const createClientConfig = ({ paths }: { readonly paths: Paths }): Config
       paths,
       log: {
         level: 'info',
-        maxSize: 10 * 1024 * 1024,
-        maxFiles: 5,
       },
     },
     schema: {
@@ -38,11 +34,9 @@ export const createClientConfig = ({ paths }: { readonly paths: Paths }): Config
         },
         log: {
           type: 'object',
-          required: ['level', 'maxSize', 'maxFiles'],
+          required: ['level'],
           properties: {
             level: { type: 'string' },
-            maxSize: { type: 'number' },
-            maxFiles: { type: 'number' },
           },
         },
       },

--- a/packages/neo-one-client-core/src/provider/JSONRPCHTTPProvider.ts
+++ b/packages/neo-one-client-core/src/provider/JSONRPCHTTPProvider.ts
@@ -89,7 +89,7 @@ const instrumentFetch = async <T extends { readonly status: number }>(
       },
       {
         name: 'http_client_request',
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
         references: monitors.slice(1).map((parent) => monitor.childOf(parent)),
         trace: true,
       },
@@ -283,8 +283,8 @@ export class JSONRPCHTTPProvider extends JSONRPCProvider {
         })
         .captureSpanLog(async (span) => this.requestInternal(req, span), {
           name: 'jsonrpc_client_request',
-          level: { log: 'verbose', span: 'info' },
-          error: { level: 'verbose' },
+          level: { log: 'debug', span: 'info' },
+          error: { level: 'debug' },
           trace: true,
         });
     }

--- a/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
@@ -751,7 +751,7 @@ export class NEOONEDataProvider implements DeveloperProvider {
     /* istanbul ignore next */
     return monitor.at('neo_one_data_provider').captureSpanLog(func, {
       name,
-      level: { log: 'verbose', span: 'info' },
+      level: { log: 'debug', span: 'info' },
       trace: true,
     });
   }

--- a/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
@@ -1560,7 +1560,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore, TProvider exte
       .captureSpanLog(func, {
         name,
         metric,
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
         trace: true,
       });
   }

--- a/packages/neo-one-client-core/src/user/keystore/HDKeyStore.ts
+++ b/packages/neo-one-client-core/src/user/keystore/HDKeyStore.ts
@@ -207,7 +207,7 @@ export class HDKeyStore<Identifier> implements KeyStore {
 
     return monitor.at('hd_key_store').captureSpanLog(func, {
       name,
-      level: { log: 'verbose', span: 'info' },
+      level: { log: 'debug', span: 'info' },
       trace: true,
     });
   }

--- a/packages/neo-one-client-core/src/user/keystore/LocalKeyStore.ts
+++ b/packages/neo-one-client-core/src/user/keystore/LocalKeyStore.ts
@@ -463,7 +463,7 @@ export class LocalKeyStore implements KeyStore {
 
     return monitor.at('local_key_store').captureSpanLog(func, {
       name,
-      level: { log: 'verbose', span: 'info' },
+      level: { log: 'debug', span: 'info' },
       trace: true,
     });
   }

--- a/packages/neo-one-http/src/context.ts
+++ b/packages/neo-one-http/src/context.ts
@@ -43,7 +43,7 @@ export const context = ({ monitor }: { readonly monitor: Monitor }) => async (
     },
     {
       name: 'http_server_request',
-      level: { log: 'verbose', span: 'info' },
+      level: { log: 'debug', span: 'info' },
       metric: {
         total: REQUESTS_HISTOGRAM,
         error: REQUEST_ERRORS_COUNTER,

--- a/packages/neo-one-http/src/createServer$.ts
+++ b/packages/neo-one-http/src/createServer$.ts
@@ -74,7 +74,7 @@ async function handleServer<T extends http.Server | https.Server, TOptions exten
         .log({
           name: 'server_listen',
           message: `Server listening on ${host}:${port}`,
-          level: 'verbose',
+          level: 'debug',
         });
     }
   }

--- a/packages/neo-one-monitor/src/MonitorBase.ts
+++ b/packages/neo-one-monitor/src/MonitorBase.ts
@@ -299,7 +299,8 @@ export class MonitorBase implements Span {
       })
       .filter(utils.notNull);
     if (
-      LogLevelToLevel[fullLevel.span] <= LogLevelToLevel[this.spanLogLevel] &&
+      // tslint:disable-next-line: no-any
+      LogLevelToLevel[fullLevel.span as any] <= LogLevelToLevel[this.spanLogLevel as any] &&
       (trace !== undefined || tracerReferences.length > 0)
     ) {
       span = this.tracer.startSpan(name, {
@@ -576,7 +577,11 @@ export class MonitorBase implements Span {
 
     if (this.span !== undefined) {
       const { span: tracerSpan } = this.span;
-      if (LogLevelToLevel[fullLevel.span] <= LogLevelToLevel[this.spanLogLevel] && tracerSpan !== undefined) {
+      if (
+        // tslint:disable-next-line: no-any
+        LogLevelToLevel[fullLevel.span as any] <= LogLevelToLevel[this.spanLogLevel as any] &&
+        tracerSpan !== undefined
+      ) {
         // tslint:disable-next-line no-any
         let spanLog: { [key: string]: any } = {
           event: name,

--- a/packages/neo-one-monitor/src/__tests__/BrowserMonitor.test.ts
+++ b/packages/neo-one-monitor/src/__tests__/BrowserMonitor.test.ts
@@ -22,7 +22,7 @@ describe('BrowserMonitor', () => {
   (error as any).code = 'red';
   const options2: LoggerLogOptions = {
     name: 'log2',
-    level: 'silly',
+    level: 'trace',
     message: 'test2',
     labels: { label2: 30 },
     data: { data1: '40' },

--- a/packages/neo-one-monitor/src/types.ts
+++ b/packages/neo-one-monitor/src/types.ts
@@ -39,7 +39,7 @@ export interface Labels {
   - Force metrics and spans to be logged by using metricLevel and spanLevel
     respectively at verbose or higher.
 */
-export type LogLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly';
+export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent';
 export type LogLevelOption =
   | LogLevel
   | {

--- a/packages/neo-one-node-bin/package.json
+++ b/packages/neo-one-node-bin/package.json
@@ -17,16 +17,17 @@
     "fs-extra": "^8.0.0",
     "import-local": "^2.0.0",
     "lodash": "^4.17.11",
+    "pino": "^5.12.6",
     "rc": "^1.2.8",
     "rxjs": "^6.5.2",
     "seamless-immutable": "^7.1.4",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.12",
-    "tslib": "^1.9.3",
-    "winston": "^3.1.0"
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@types/fs-extra": "8.0.0",
+    "@types/pino": "^5.8.8",
     "@types/rc": "1.1.0",
     "@types/seamless-immutable": "7.1.10"
   },

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -539,7 +539,7 @@ export class Blockchain {
   ): Promise<readonly ECPoint[]> =>
     this.getMonitor(monitor).captureSpanLog(async () => getValidators(this, transactions), {
       name: 'neo_blockchain_get_validators',
-      level: { log: 'verbose', span: 'info' },
+      level: { log: 'debug', span: 'info' },
     });
 
   public readonly calculateClaimAmount = async (claims: readonly Input[], monitor?: Monitor): Promise<BN> =>
@@ -593,7 +593,7 @@ export class Blockchain {
       },
       {
         name: 'neo_blockchain_calculate_claim_amount',
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
       },
     );
 
@@ -614,7 +614,7 @@ export class Blockchain {
           .withData({ [labels.NEO_BLOCK_INDEX]: entry.block.index })
           .captureSpanLog(async (span) => this.persistBlockInternal(span, entryNonNull.block, entryNonNull.unsafe), {
             name: 'neo_blockchain_persist_block_top_level',
-            level: { log: 'verbose', span: 'info' },
+            level: { log: 'debug', span: 'info' },
             metric: {
               total: NEO_BLOCKCHAIN_PERSIST_BLOCK_DURATION_SECONDS,
               error: NEO_BLOCKCHAIN_PERSIST_BLOCK_FAILURES_TOTAL,

--- a/packages/neo-one-node-consensus/src/Consensus.ts
+++ b/packages/neo-one-node-consensus/src/Consensus.ts
@@ -164,7 +164,7 @@ export class Consensus {
     this.monitor.log({
       name: 'neo_consensus_start',
       message: 'Consensus started.',
-      level: 'verbose',
+      level: 'debug',
     });
 
     const initialResult = await initializeNewConsensus({
@@ -230,7 +230,7 @@ export class Consensus {
     this.monitor.log({
       name: 'neo_consensus_stop',
       message: 'Consensus stopped.',
-      level: 'verbose',
+      level: 'debug',
     });
   }
 

--- a/packages/neo-one-node-http-rpc/src/middleware/checkReady.ts
+++ b/packages/neo-one-node-http-rpc/src/middleware/checkReady.ts
@@ -54,7 +54,7 @@ const fetchCount = async (monitor: Monitor, endpoint: string, timeoutMS: number)
       },
       {
         name: 'neo_rpc_check_ready_client_request',
-        level: { log: 'debug', span: 'debug' },
+        level: { log: 'trace', span: 'trace' },
         trace: true,
       },
     )

--- a/packages/neo-one-node-network/src/Network.ts
+++ b/packages/neo-one-node-network/src/Network.ts
@@ -303,7 +303,7 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
         })
         .log({
           name: 'tcp_server_connect',
-          level: 'verbose',
+          level: 'debug',
           message: `Received socket connection from ${remoteAddress === undefined ? 'unknown' : remoteAddress}`,
         });
 
@@ -421,7 +421,7 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
             .log({
               name: 'neo_network_unhealthy_peer',
               message: `Peer at ${peer.endpoint} is unhealthy.`,
-              level: 'verbose',
+              level: 'debug',
             });
 
           this.blacklistAndClose(peer);
@@ -489,12 +489,12 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
           {
             name: 'neo_network_peer_connect',
             message: `Connecting to peer at ${endpoint}`,
-            level: 'debug',
+            level: 'trace',
             metric: NEO_NETWORK_PEER_CONNECT_TOTAL,
             error: {
               message: `Failed to connect to peer at ${endpoint}.`,
               metric: NEO_NETWORK_PEER_CONNECT_FAILURES_TOTAL,
-              level: 'debug',
+              level: 'trace',
             },
           },
         );
@@ -573,7 +573,7 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
       })
       .log({
         name: 'neo_network_peer_error',
-        level: 'debug',
+        level: 'trace',
         message: `Encountered error with peer at ${peer.endpoint}.`,
         error,
       });
@@ -609,7 +609,7 @@ export class Network<Message, PeerData, PeerHealth extends PeerHealthBase> {
       .log({
         name: 'neo_network_peer_closed',
         message: `Peer closed at ${peer.endpoint}`,
-        level: 'verbose',
+        level: 'debug',
         metric: NEO_NETWORK_PEER_CLOSED_TOTAL,
       });
 

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -317,7 +317,7 @@ export class Node implements INode {
       this.monitor.log({
         name: 'neo_protocol_start',
         message: 'Protocol started.',
-        level: 'verbose',
+        level: 'debug',
       });
     }).pipe(
       neverComplete(),
@@ -326,7 +326,7 @@ export class Node implements INode {
         this.monitor.log({
           name: 'neo_protocol_stop',
           message: 'Protocol stopped.',
-          level: 'verbose',
+          level: 'debug',
         });
       }),
     );
@@ -441,7 +441,7 @@ export class Node implements INode {
             },
             {
               name: 'neo_relay_transaction',
-              level: { log: 'verbose', span: 'info' },
+              level: { log: 'debug', span: 'info' },
               trace: true,
             },
           );
@@ -825,7 +825,7 @@ export class Node implements INode {
         },
         {
           name: 'neo_protocol_message_received',
-          level: 'debug',
+          level: 'trace',
           message: `Received ${message.value.command} from ${peer.endpoint}`,
           metric: NEO_PROTOCOL_MESSAGES_RECEIVED_TOTAL,
           error: {

--- a/packages/neo-one-node-rpc-handler/src/createHandler.ts
+++ b/packages/neo-one-node-rpc-handler/src/createHandler.ts
@@ -174,7 +174,7 @@ const createJSONRPCHandler = (handlers: Handlers) => {
           error: SINGLE_REQUEST_ERRORS_COUNTER,
         },
 
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
       },
     );
 
@@ -191,7 +191,7 @@ const createJSONRPCHandler = (handlers: Handlers) => {
       // tslint:disable-next-line prefer-immediate-return
       const result = await monitor.captureSpanLog(async (span) => handleRequest(span, request), {
         name: 'jsonrpc_server_request',
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
         error: {},
       });
 

--- a/packages/neo-one-node-vm/src/execute.ts
+++ b/packages/neo-one-node-vm/src/execute.ts
@@ -233,8 +233,8 @@ export const executeScript = async ({
 
   return monitor.captureSpanLog(async (span) => run({ monitor: span, context }), {
     name: 'neo_execute_script',
-    level: { log: 'debug', span: 'debug' },
-    error: { level: 'debug' },
+    level: { log: 'trace', span: 'trace' },
+    error: { level: 'trace' },
   });
 };
 
@@ -291,7 +291,7 @@ export const execute = async ({
   let errorMessage;
   const span = monitor.startSpan({
     name: 'neo_execute_scripts',
-    level: 'debug',
+    level: 'trace',
   });
 
   let err;

--- a/packages/neo-one-server-client/src/createServerConfig.ts
+++ b/packages/neo-one-server-client/src/createServerConfig.ts
@@ -11,8 +11,6 @@ export interface ServerConfig {
   };
   readonly log: {
     readonly level: string;
-    readonly maxSize: number;
-    readonly maxFiles: number;
   };
   readonly ports: {
     readonly min: number;
@@ -44,8 +42,6 @@ export const createServerConfig = ({
       },
       log: {
         level: 'info',
-        maxSize: 10 * 1024 * 1024,
-        maxFiles: 5,
       },
       ports: {
         min: minPort === undefined ? 40200 : minPort,
@@ -83,11 +79,9 @@ export const createServerConfig = ({
         },
         log: {
           type: 'object',
-          required: ['level', 'maxSize', 'maxFiles'],
+          required: ['level'],
           properties: {
             level: { type: 'string' },
-            maxSize: { type: 'number' },
-            maxFiles: { type: 'number' },
           },
         },
         ports: {

--- a/packages/neo-one-server-plugin-network/src/commonBackupNode.ts
+++ b/packages/neo-one-server-plugin-network/src/commonBackupNode.ts
@@ -80,8 +80,6 @@ export const processArgs = async (
         name: 'node',
         path: logPath,
         level: config.level,
-        maxSize: config.maxSize,
-        maxFiles: config.maxFiles,
       })),
     )
     .subscribe(logConfig$);

--- a/packages/neo-one-server-plugin-network/src/node/NEOONENodeAdapter.ts
+++ b/packages/neo-one-server-plugin-network/src/node/NEOONENodeAdapter.ts
@@ -14,8 +14,6 @@ import { NodeAdapter, NodeStatus } from './NodeAdapter';
 export interface NodeConfig {
   readonly log: {
     readonly level: string;
-    readonly maxSize: number;
-    readonly maxFiles: number;
   };
 
   readonly settings: {
@@ -57,8 +55,6 @@ const DEFAULT_SEEDS: readonly EndpointConfig[] = [
 const makeDefaultConfig = (dataPath: string): NodeConfig => ({
   log: {
     level: 'info',
-    maxSize: 10 * 1024 * 1024,
-    maxFiles: 5,
   },
   settings: {
     test: false,
@@ -119,11 +115,9 @@ export const createNodeConfig = ({
       properties: {
         log: {
           type: 'object',
-          required: ['level', 'maxSize', 'maxFiles'],
+          required: ['level'],
           properties: {
             level: { type: 'string' },
-            maxSize: { type: 'number' },
-            maxFiles: { type: 'number' },
           },
         },
         settings: {
@@ -419,8 +413,6 @@ export class NEOONENodeAdapter extends NodeAdapter {
     return {
       log: {
         level: 'info',
-        maxSize: 10 * 1024 * 1024,
-        maxFiles: 5,
       },
       settings: {
         test: settings.isTestNet,

--- a/packages/neo-one-server-plugin-network/src/startNode.ts
+++ b/packages/neo-one-server-plugin-network/src/startNode.ts
@@ -23,8 +23,6 @@ export const startNode = ({ vorpal, monitor, shutdown, mutableShutdownFuncs, log
             name: 'node',
             path: logPath,
             level: config.level,
-            maxSize: config.maxSize,
-            maxFiles: config.maxFiles,
           })),
         )
         .subscribe(logConfig$);

--- a/packages/neo-one-server-plugin/src/types.ts
+++ b/packages/neo-one-server-plugin/src/types.ts
@@ -163,8 +163,6 @@ export interface LogConfig {
   readonly name: string;
   readonly path: string;
   readonly level: string;
-  readonly maxSize: number;
-  readonly maxFiles: number;
 }
 
 export interface CLIArgs {

--- a/packages/neo-one-server/src/middleware/context.ts
+++ b/packages/neo-one-server/src/middleware/context.ts
@@ -22,7 +22,7 @@ export const context = ({ monitor }: { readonly monitor: Monitor }) =>
           },
           {
             name: 'grpc_server_request',
-            level: { log: 'verbose', span: 'info' },
+            level: { log: 'debug', span: 'info' },
             trace: true,
           },
         );

--- a/packages/neo-one-server/src/middleware/rpc.ts
+++ b/packages/neo-one-server/src/middleware/rpc.ts
@@ -110,7 +110,7 @@ export const rpc = ({ server }: { readonly server: Server }) => {
           error: SINGLE_REQUEST_ERRORS_COUNTER,
         },
 
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
       },
     );
 
@@ -127,7 +127,7 @@ export const rpc = ({ server }: { readonly server: Server }) => {
       // tslint:disable-next-line prefer-immediate-return
       const result = await monitor.captureSpanLog(async (span) => handleRequest(span, request), {
         name: 'http_rpc_server_request',
-        level: { log: 'verbose', span: 'info' },
+        level: { log: 'debug', span: 'info' },
         error: {},
       });
 

--- a/tslint.json
+++ b/tslint.json
@@ -18,6 +18,7 @@
       "./packages/*/template/**/*.tsx"
     ]
   },
+  "defaultSeverity": "warning",
   "rules": {
     "cyclomatic-complexity": false,
     "no-unused-variable": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,6 +3198,14 @@
   resolved "https://registry.yarnpkg.com/@types/npm-package-arg/-/npm-package-arg-6.1.0.tgz#88bdfce72f6a3d5fa1053c8d44d655e7850642e4"
   integrity sha512-vbt5fb0y1svMhu++1lwtKmZL76d0uPChFlw7kEzyUmTwfmpHRcFb8i0R8ElT69q/L+QLgK2hgECivIAvaEDwag==
 
+"@types/pino@^5.8.8":
+  version "5.8.8"
+  resolved "https://registry.yarnpkg.com/@types/pino/-/pino-5.8.8.tgz#930eb30f1f1eb76b97792647477aab59e5852574"
+  integrity sha512-SxAdLtEpPkVUdnI3iCUjyFC7WVLFiebyzqypvkuJVo7dyK6BPuQ4lTOuZRKpbEdgG386l5HgfqpymL3oWLOUXg==
+  dependencies:
+    "@types/node" "*"
+    "@types/sonic-boom" "*"
+
 "@types/pouchdb-adapter-fruitdown@*":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@types/pouchdb-adapter-fruitdown/-/pouchdb-adapter-fruitdown-6.1.3.tgz#9b140ad9645cc56068728acf08ec19ac0046658e"
@@ -3472,6 +3480,13 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/sonic-boom@*":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@types/sonic-boom/-/sonic-boom-0.6.2.tgz#5f6c7bf6b4a0994f9339d778da6a7adcc3d37080"
+  integrity sha512-vP9Sn1tuz/BTh8L1o776Cbzr+WH4dZGmRXOjQ5L+IVQx40hUmvOS2wfIkqUsID1vL62tThWdlXWIqijwewu3mw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -4541,7 +4556,7 @@ async@^1.4.0, async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.0.1, async@^2.6.1:
+async@^2.0.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -6458,14 +6473,6 @@ color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-color@3.0.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
-  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
-  dependencies:
-    color-convert "^1.9.1"
-    color-string "^1.5.2"
-
 color@^3.0.0, color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
@@ -6474,28 +6481,15 @@ color@^3.0.0, color@^3.1.2:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-colornames@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
-  integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
-
 colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.2.1:
+colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
-
-colorspace@1.1.x:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
-  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
-  dependencies:
-    color "3.0.x"
-    text-hex "1.0.x"
 
 colour@~0.7.1:
   version "0.7.1"
@@ -7934,15 +7928,6 @@ di@0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diagnostics@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.1.tgz#cab6ac33df70c9d9a727490ae43ac995a769b22a"
-  integrity sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==
-  dependencies:
-    colorspace "1.1.x"
-    enabled "1.0.x"
-    kuler "1.0.x"
-
 didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
@@ -8269,13 +8254,6 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
-enabled@1.0.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
-  integrity sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=
-  dependencies:
-    env-variable "0.0.x"
-
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -8384,11 +8362,6 @@ env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
-
-env-variable@0.0.x:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.5.tgz#913dd830bef11e96a039c038d4130604eba37f88"
-  integrity sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -9121,7 +9094,12 @@ fast-plist@^0.1.2:
   resolved "https://registry.yarnpkg.com/fast-plist/-/fast-plist-0.1.2.tgz#a45aff345196006d406ca6cdcd05f69051ef35b8"
   integrity sha1-pFr/NFGWAG1AbKbNzQX2kFHvNbg=
 
-fast-safe-stringify@^2.0.4:
+fast-redact@^1.4.4:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-1.5.0.tgz#302892f566750c4f5eec7b830bfc9bc473484034"
+  integrity sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ==
+
+fast-safe-stringify@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
   integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
@@ -9190,11 +9168,6 @@ feature-policy@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/feature-policy/-/feature-policy-0.3.0.tgz#7430e8e54a40da01156ca30aaec1a381ce536069"
   integrity sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ==
-
-fecha@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
-  integrity sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==
 
 fetch-cookie@0.7.0:
   version "0.7.0"
@@ -9451,6 +9424,11 @@ flat@^4.1.0:
   integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   dependencies:
     is-buffer "~2.0.3"
+
+flatstr@^1.0.9:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
 
 flatted@^2.0.0:
   version "2.0.0"
@@ -13038,13 +13016,6 @@ koa@^2.6.1, koa@^2.7.0:
     type-is "^1.6.16"
     vary "^1.1.2"
 
-kuler@1.0.x:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/kuler/-/kuler-1.0.1.tgz#ef7c784f36c9fb6e16dd3150d152677b2b0228a6"
-  integrity sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==
-  dependencies:
-    colornames "^1.1.1"
-
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
@@ -13820,17 +13791,6 @@ log-update@^3.2.0:
     ansi-escapes "^3.2.0"
     cli-cursor "^2.1.0"
     wrap-ansi "^5.0.0"
-
-logform@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.1.2.tgz#957155ebeb67a13164069825ce67ddb5bb2dd360"
-  integrity sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==
-  dependencies:
-    colors "^1.2.1"
-    fast-safe-stringify "^2.0.4"
-    fecha "^2.3.3"
-    ms "^2.1.1"
-    triple-beam "^1.3.0"
 
 loglevel@^1.6.3:
   version "1.6.3"
@@ -15480,11 +15440,6 @@ once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-one-time@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
-  integrity sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=
-
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
@@ -16236,6 +16191,23 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pino-std-serializers@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz#cb5e3e58c358b26f88969d7e619ae54bdfcc1ae1"
+  integrity sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==
+
+pino@^5.12.6:
+  version "5.12.6"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.12.6.tgz#04a668278d7616db71871f1bd3e26f6918e05feb"
+  integrity sha512-LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==
+  dependencies:
+    fast-redact "^1.4.4"
+    fast-safe-stringify "^2.0.6"
+    flatstr "^1.0.9"
+    pino-std-serializers "^2.3.0"
+    quick-format-unescaped "^3.0.2"
+    sonic-boom "^0.7.3"
 
 pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
@@ -17250,6 +17222,11 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+quick-format-unescaped@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz#0137e94d8fb37ffeb70040535111c378e75396fb"
+  integrity sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -19431,6 +19408,13 @@ socks@~2.3.2:
     ip "^1.1.5"
     smart-buffer "4.0.2"
 
+sonic-boom@^0.7.3:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-0.7.4.tgz#dc1740a900cf8646471f6ac1f4933a5c66c0ca60"
+  integrity sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==
+  dependencies:
+    flatstr "^1.0.9"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -20389,11 +20373,6 @@ text-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-2.0.0.tgz#43eabd1b495482fae4a2bf65e5f56c29f69220f6"
   integrity sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==
 
-text-hex@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
-  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -20773,11 +20752,6 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
-
-triple-beam@^1.2.0, triple-beam@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
-  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 trough@^1.0.0:
   version "1.0.4"
@@ -21990,14 +21964,6 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-winston-transport@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.3.0.tgz#df68c0c202482c448d9b47313c07304c2d7c2c66"
-  integrity sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==
-  dependencies:
-    readable-stream "^2.3.6"
-    triple-beam "^1.2.0"
-
 winston@^2.1.1:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.4.tgz#a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
@@ -22009,21 +21975,6 @@ winston@^2.1.1:
     eyes "0.1.x"
     isstream "0.1.x"
     stack-trace "0.0.x"
-
-winston@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.2.1.tgz#63061377976c73584028be2490a1846055f77f07"
-  integrity sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==
-  dependencies:
-    async "^2.6.1"
-    diagnostics "^1.1.1"
-    is-stream "^1.1.0"
-    logform "^2.1.1"
-    one-time "0.0.4"
-    readable-stream "^3.1.1"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.3.0"
 
 word-wrap@^1.0.3:
   version "1.2.3"


### PR DESCRIPTION
### Description of the Change

Migrate from `winston` logging to `pino`. Still in development, but this is one of two PRs that will completely remove `@neo-one/monitor`.

### Test Plan

```
yarn install
yarn build:node
node ./dist/neo-one/packages/neo-one-node-bin/bin/neo-one-node --environment.monitor=trace
node ./dist/neo-one/packages/neo-one-cli/bin/neo-one
```

you can also pipe the node-bin logs to pino-pretty on the command line (after installing pino-pretty) to see some very nice looking logs :)

### Benefits

Halfway done removing `@neo-one/monitor`.

### Applicable Issues

#1500 
