### PR TITLE
chore(renovate): change renovate bot schedule to be more ideal

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:daily",
-    ":semanticCommits"
-  ],
+  "extends": ["config:base", ":semanticCommits"],
+  "schedule": ["after 12am and before 5am"],
+  "timezone": ["America/Los_Angeles"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "automerge": true,
   "major": {


### PR DESCRIPTION
### Description of the Change

Changes `renovate` bot config to run in the wee hours of the morning, according to our time zone. This way it won't be making changes while we could be pushing our own changes.

Fixes: #1536 

### Test Plan

After this is merged it should always run between midnight and 5AM.

### Alternate Designs

None.

### Benefits

Less risk for breaking `bors`

### Possible Drawbacks

Slack notifications while we try to sleep.

### Applicable Issues

#1536 