### PR TITLE
fix(core, protocol): describe InvalidFormat errors

### DIFF
--- a/packages/neo-one-node-core/src/BlockBase.ts
+++ b/packages/neo-one-node-core/src/BlockBase.ts
@@ -46,7 +46,7 @@ export abstract class BlockBase implements EquatableKey {
     const consensusData = reader.readUInt64LE();
     const nextConsensus = reader.readUInt160();
     if (reader.readUInt8() !== 1) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected BinaryReader\'s readUInt8(0) to be 1. Received: ${reader.readUInt8()}`);
     }
     const script = Witness.deserializeWireBase(options);
 

--- a/packages/neo-one-node-core/src/Header.ts
+++ b/packages/neo-one-node-core/src/Header.ts
@@ -19,7 +19,9 @@ export class Header extends BlockBase implements SerializableWire<Header>, Seria
     const { reader } = options;
     const blockBase = super.deserializeBlockBaseWireBase(options);
     if (reader.readUInt8() !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(
+        `Expected Header BinaryReader readUInt8(0) to be 0. Received: ${reader.readUInt8()}`,
+      );
     }
 
     return new this({

--- a/packages/neo-one-node-core/src/invocationResult/InvocationResultError.ts
+++ b/packages/neo-one-node-core/src/invocationResult/InvocationResultError.ts
@@ -27,7 +27,7 @@ export class InvocationResultError extends InvocationResultBase<VMState.Fault>
     const { reader } = options;
     const { state, gasConsumed, gasCost, stack } = super.deserializeInvocationResultWireBase(options);
     if (state !== VMState.Fault) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected VMState to be: ${VMState.Fault}. Received: ${state}`);
     }
     const message = reader.readVarString(MAX_SIZE);
 

--- a/packages/neo-one-node-core/src/invocationResult/InvocationResultSuccess.ts
+++ b/packages/neo-one-node-core/src/invocationResult/InvocationResultSuccess.ts
@@ -15,7 +15,7 @@ export class InvocationResultSuccess extends InvocationResultBase<VMState.Halt>
   public static deserializeWireBase(options: DeserializeWireBaseOptions): InvocationResultSuccess {
     const { state, gasConsumed, gasCost, stack } = super.deserializeInvocationResultWireBase(options);
     if (state !== VMState.Halt) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected VMState state to be ${VMState.Halt}. Received: ${state}.`);
     }
 
     return new this({ gasConsumed, gasCost, stack });

--- a/packages/neo-one-node-core/src/payload/ConsensusPayload.ts
+++ b/packages/neo-one-node-core/src/payload/ConsensusPayload.ts
@@ -56,7 +56,7 @@ export class ConsensusPayload extends UnsignedConsensusPayload
       consensusMessage,
     } = super.deserializeUnsignedConsensusPayloadWireBase(options);
     if (reader.readUInt8() !== 1) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected BinaryReader\'s readUInt8(0) to be 1. Received: ${reader.readUInt8()}`);
     }
     const script = Witness.deserializeWireBase(options);
 

--- a/packages/neo-one-node-core/src/payload/message/ChangeViewConsensusMessage.ts
+++ b/packages/neo-one-node-core/src/payload/message/ChangeViewConsensusMessage.ts
@@ -16,7 +16,7 @@ export class ChangeViewConsensusMessage extends ConsensusMessageBase<
     const message = super.deserializeConsensusMessageBaseWireBase(options);
     const newViewNumber = reader.readUInt8();
     if (newViewNumber === 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected BinaryReader\'s readUInt8(0) to be 0. Received: ${newViewNumber}`);
     }
 
     return new this({

--- a/packages/neo-one-node-core/src/payload/message/PrepareRequestConsensusMessage.ts
+++ b/packages/neo-one-node-core/src/payload/message/PrepareRequestConsensusMessage.ts
@@ -32,7 +32,9 @@ export class PrepareRequestConsensusMessage extends ConsensusMessageBase<
     }
     const minerTransaction = MinerTransaction.deserializeWireBase(options);
     if (!common.uInt256Equal(minerTransaction.hash, transactionHashes[0])) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(
+        `Expected minerTransaction hash (${minerTransaction.hash}) to equal first transaction hash (${transactionHashes[0]})`,
+      );
     }
     const signature = reader.readBytes(64);
 

--- a/packages/neo-one-node-core/src/storageChange/StorageChangeAdd.ts
+++ b/packages/neo-one-node-core/src/storageChange/StorageChangeAdd.ts
@@ -14,7 +14,7 @@ export class StorageChangeAdd extends StorageChangeAddModifyBase<StorageChangeTy
   public static deserializeWireBase(options: DeserializeWireBaseOptions): StorageChangeAdd {
     const { type, hash, key, value } = super.deserializeStorageChangeAddModifyWireBase(options);
     if (type !== StorageChangeType.Add) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected storage change type to be ${StorageChangeType.Add}. Received: ${type}`);
     }
 
     return new this({ hash, key, value });

--- a/packages/neo-one-node-core/src/storageChange/StorageChangeDelete.ts
+++ b/packages/neo-one-node-core/src/storageChange/StorageChangeDelete.ts
@@ -13,7 +13,7 @@ export class StorageChangeDelete extends StorageChangeBase<StorageChangeType.Del
   public static deserializeWireBase(options: DeserializeWireBaseOptions): StorageChangeDelete {
     const { type, hash, key } = super.deserializeStorageChangeWireBase(options);
     if (type !== StorageChangeType.Delete) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected storage change type to be ${StorageChangeType.Delete}. Received: ${type}`);
     }
 
     return new this({ hash, key });

--- a/packages/neo-one-node-core/src/storageChange/StorageChangeModify.ts
+++ b/packages/neo-one-node-core/src/storageChange/StorageChangeModify.ts
@@ -14,7 +14,7 @@ export class StorageChangeModify extends StorageChangeAddModifyBase<StorageChang
   public static deserializeWireBase(options: DeserializeWireBaseOptions): StorageChangeModify {
     const { type, hash, key, value } = super.deserializeStorageChangeAddModifyWireBase(options);
     if (type !== StorageChangeType.Modify) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected storage change type to be ${StorageChangeType.Modify}. Received: ${type}`);
     }
 
     return new this({ hash, key, value });

--- a/packages/neo-one-node-core/src/transaction/ClaimTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/ClaimTransaction.ts
@@ -40,7 +40,7 @@ export class ClaimTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Claim) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type to be ${TransactionType.Claim}. Received: ${type}`);
     }
 
     const claims = reader.readArray(() => Input.deserializeWireBase(options));

--- a/packages/neo-one-node-core/src/transaction/ContractTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/ContractTransaction.ts
@@ -21,7 +21,7 @@ export class ContractTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Contract) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type to be ${TransactionType.Contract}. Received: ${type}`);
     }
 
     const { attributes, inputs, outputs, scripts } = super.deserializeTransactionBaseEndWireBase(options);
@@ -49,7 +49,7 @@ export class ContractTransaction extends TransactionBase<
     });
 
     if (this.version !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be 0. Received: ${this.version}`);
     }
   }
 

--- a/packages/neo-one-node-core/src/transaction/EnrollmentTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/EnrollmentTransaction.ts
@@ -43,7 +43,7 @@ export class EnrollmentTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Enrollment) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type ${TransactionType.Enrollment}. Received: ${type}`);
     }
 
     const publicKey = reader.readECPoint();
@@ -82,7 +82,7 @@ export class EnrollmentTransaction extends TransactionBase<
     this.publicKey = publicKey;
 
     if (this.version !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be 0. Received: ${this.version}`);
     }
 
     const getScriptHashesForVerifying = super.getScriptHashesForVerifying.bind(this);

--- a/packages/neo-one-node-core/src/transaction/InvocationTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/InvocationTransaction.ts
@@ -37,12 +37,12 @@ export class InvocationTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Invocation) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type to be ${TransactionType.Invocation}. Received: ${type}`);
     }
 
     const script = reader.readVarBytesLE(MAX_SCRIPT_SIZE);
     if (script.length === 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError('Expected invocation script length to not be 0');
     }
 
     let gas = utils.ZERO;

--- a/packages/neo-one-node-core/src/transaction/IssueTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/IssueTransaction.ts
@@ -31,7 +31,7 @@ export class IssueTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Issue) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type to be ${TransactionType.Issue}. Received: ${type}`);
     }
 
     const { attributes, inputs, outputs, scripts } = super.deserializeTransactionBaseEndWireBase(options);

--- a/packages/neo-one-node-core/src/transaction/MinerTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/MinerTransaction.ts
@@ -34,7 +34,7 @@ export class MinerTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Miner) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type ${TransactionType.Miner}. Received: ${type}`);
     }
 
     const nonce = reader.readUInt32LE();
@@ -68,7 +68,7 @@ export class MinerTransaction extends TransactionBase<
     this.nonce = nonce;
 
     if (this.version !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be 0. Received: ${this.version}`);
     }
   }
 

--- a/packages/neo-one-node-core/src/transaction/PublishTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/PublishTransaction.ts
@@ -33,7 +33,7 @@ export class PublishTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Publish) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type to be ${TransactionType.Publish}. Received: ${type}`);
     }
 
     const contract = deserializeContractWireBase({
@@ -83,7 +83,7 @@ export class PublishTransaction extends TransactionBase<
     this.contract = contract;
 
     if (this.version > 1) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be greater than 1. Received: ${this.version}`);
     }
   }
 

--- a/packages/neo-one-node-core/src/transaction/RegisterTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/RegisterTransaction.ts
@@ -56,7 +56,7 @@ export class RegisterTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.Register) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type ${TransactionType.Register}. Received: ${type}`);
     }
 
     const assetType = assertAssetType(reader.readUInt8());
@@ -114,7 +114,7 @@ export class RegisterTransaction extends TransactionBase<
     this.asset = asset;
 
     if (this.version !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be 0. Received: ${this.version}`);
     }
 
     if (
@@ -122,7 +122,7 @@ export class RegisterTransaction extends TransactionBase<
       asset.type !== AssetType.GoverningToken &&
       asset.type !== AssetType.UtilityToken
     ) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`AssetType and asset owner are invalid`);
     }
 
     const getScriptHashesForVerifying = super.getScriptHashesForVerifying.bind(this);

--- a/packages/neo-one-node-core/src/transaction/StateTransaction.ts
+++ b/packages/neo-one-node-core/src/transaction/StateTransaction.ts
@@ -40,7 +40,7 @@ export class StateTransaction extends TransactionBase<
     const { type, version } = super.deserializeTransactionBaseStartWireBase(options);
 
     if (type !== TransactionType.State) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected transaction type ${TransactionType.State}. Received: ${type}`);
     }
 
     const descriptors = reader.readArray(() => StateDescriptor.deserializeWireBase(options));
@@ -79,7 +79,7 @@ export class StateTransaction extends TransactionBase<
     this.descriptors = descriptors;
 
     if (this.version !== 0) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected version to be 0. Received: ${this.version}`);
     }
 
     const getScriptHashesForVerifying = super.getScriptHashesForVerifying.bind(this);

--- a/packages/neo-one-node-core/src/transaction/attribute/BufferAttribute.ts
+++ b/packages/neo-one-node-core/src/transaction/attribute/BufferAttribute.ts
@@ -40,7 +40,7 @@ export class BufferAttribute extends AttributeBase(BufferAttributeModel) {
         usage === AttributeUsage.Remark15
       )
     ) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Invalid AttributeUsageModel. Received: ${usage}`);
     }
     const value =
       usage === AttributeUsage.DescriptionUrl ? reader.readBytes(reader.readUInt8()) : reader.readVarBytesLE();

--- a/packages/neo-one-node-core/src/transaction/attribute/ECPointAttribute.ts
+++ b/packages/neo-one-node-core/src/transaction/attribute/ECPointAttribute.ts
@@ -20,7 +20,9 @@ export class ECPointAttribute extends AttributeBase(ECPointAttributeModel) {
     const { reader } = options;
     const { usage } = super.deserializeAttributeWireBase(options);
     if (!(usage === AttributeUsage.ECDH02 || usage === AttributeUsage.ECDH03)) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(
+        `Expected attribute usage to be ${AttributeUsage.ECDH02} or ${AttributeUsage.ECDH03}. Received: ${usage}`,
+      );
     }
     const value = common.bufferToECPoint(Buffer.concat([Buffer.from([usage]), reader.readBytes(32)]));
 

--- a/packages/neo-one-node-core/src/transaction/attribute/UInt160Attribute.ts
+++ b/packages/neo-one-node-core/src/transaction/attribute/UInt160Attribute.ts
@@ -20,7 +20,7 @@ export class UInt160Attribute extends AttributeBase(UInt160AttributeModel) {
     const { reader } = options;
     const { usage } = super.deserializeAttributeWireBase(options);
     if (usage !== AttributeUsage.Script) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected attribute usage to be ${AttributeUsage.Script}. Received: ${usage}`);
     }
     const value = reader.readUInt160();
 

--- a/packages/neo-one-node-core/src/transaction/attribute/UInt256Attribute.ts
+++ b/packages/neo-one-node-core/src/transaction/attribute/UInt256Attribute.ts
@@ -39,7 +39,7 @@ export class UInt256Attribute extends AttributeBase(UInt256AttributeModel) {
         usage === AttributeUsage.Hash15
       )
     ) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Invalid AttributeUsageModel. Received: ${usage}`);
     }
     const value = reader.readUInt256();
 

--- a/packages/neo-one-node-core/src/transaction/state/StateDescriptor.ts
+++ b/packages/neo-one-node-core/src/transaction/state/StateDescriptor.ts
@@ -47,18 +47,24 @@ export class StateDescriptor implements SerializableWire<StateDescriptor>, Seria
     switch (type) {
       case StateDescriptorType.Account:
         if (key.length !== 20) {
-          throw new InvalidFormatError();
+          throw new InvalidFormatError(
+            `Expected StateDescriptor account key length to equal 20. Received: ${key.length}`,
+          );
         }
         if (field !== VOTES) {
-          throw new InvalidFormatError();
+          throw new InvalidFormatError(`Expected StateDescriptor account field to equal ${VOTES}. Received: ${field}`);
         }
         break;
       case StateDescriptorType.Validator:
         if (key.length !== 33) {
-          throw new InvalidFormatError();
+          throw new InvalidFormatError(
+            `Expected StateDescriptor validator key length to equal 33. Received: ${key.length}`,
+          );
         }
         if (field !== REGISTERED) {
-          throw new InvalidFormatError();
+          throw new InvalidFormatError(
+            `Expected StateDescriptor validator field to equal ${REGISTERED}. Received: ${field}`,
+          );
         }
         break;
       default:

--- a/packages/neo-one-node-protocol/src/payload/FilterLoadPayload.ts
+++ b/packages/neo-one-node-protocol/src/payload/FilterLoadPayload.ts
@@ -18,7 +18,7 @@ export class FilterLoadPayload implements SerializableWire<FilterLoadPayload> {
     const k = reader.readUInt8();
     const tweak = reader.readUInt32LE();
     if (k > 50) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError(`Expected BinaryReader\'s readUInt8(0) to be less than 50. Received: ${k}`);
     }
 
     return new this({ filter, k, tweak });

--- a/packages/neo-one-node-protocol/src/payload/NetworkAddress.ts
+++ b/packages/neo-one-node-protocol/src/payload/NetworkAddress.ts
@@ -79,7 +79,7 @@ export class NetworkAddress implements SerializableWire<NetworkAddress> {
   public serializeWireBase(writer: BinaryWriter): void {
     const address = NetworkAddress.getAddress6(this.host);
     if (address == undefined) {
-      throw new InvalidFormatError();
+      throw new InvalidFormatError('Network IP address undefined');
     }
     writer.writeUInt32LE(this.timestamp);
     writer.writeUInt64LE(this.services);


### PR DESCRIPTION
### Description of the Change

About half of the time that an `InvalidFormatError` was thrown it didn't have a message along with it, making debugging harder. This adds descriptive messages to those remaining times that `InvalidFormatError` is thrown.

Fixes: #675 

### Test Plan

None.

### Alternate Designs

I think I described the errors well but someone with knowledge of the architecture may want to glance at them to be sure the messages are accurate.

### Benefits

More descriptive errors when `InvalidFormatError`s are thrown.

### Possible Drawbacks

None.

### Applicable Issues

Fixes: #675 
