### PR TITLE
fix(core): fix arg assertions in client smart contract APIs

### DIFF
--- a/packages/neo-one-client-core/src/Client.ts
+++ b/packages/neo-one-client-core/src/Client.ts
@@ -332,8 +332,8 @@ export class Client<
    *
    * @param networkIn `NetworkType` to select.
    */
-  public async selectNetwork(networkIn: NetworkType): Promise<void> {
-    const network = args.assertString('network', networkIn);
+  public async selectNetwork(network: NetworkType): Promise<void> {
+    args.assertString('network', network);
     const provider = this.getNetworkProvider(network);
     const account = provider.getCurrentUserAccount();
     if (account === undefined) {
@@ -468,14 +468,18 @@ export class Client<
   /**
    * @returns `Promise` which resolves to an `Account` object for the provided `UserAccountID`.
    */
-  public async getAccount(id: UserAccountID): Promise<Account> {
+  public async getAccount(idIn: UserAccountID): Promise<Account> {
+    const id = args.assertUserAccountID('id', idIn);
+
     return this.getNetworkProvider(id.network).getAccount(id.network, id.address);
   }
 
   /**
    * @internal
    */
-  public __iterActionsRaw(network: NetworkType, options?: IterOptions): AsyncIterable<RawAction> {
+  public __iterActionsRaw(network: NetworkType, optionsIn?: IterOptions): AsyncIterable<RawAction> {
+    args.assertString('network', network);
+    const options = args.assertNullableIterOptions('iterOptions', optionsIn);
     const provider = this.getNetworkProvider(network);
     if (provider.iterActionsRaw !== undefined) {
       return provider.iterActionsRaw(network, options);
@@ -510,7 +514,17 @@ export class Client<
     optionsIn?: InvokeSendUnsafeReceiveTransactionOptions,
     sourceMaps: SourceMaps = {},
   ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
-    const options = optionsIn === undefined ? {} : optionsIn;
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    args.assertArray('paramsZipped', paramsZipped);
+    args.assertBoolean('verify', verify);
+    const options = args.assertInvokeSendUnsafeReceiveTransactionOptions('options', optionsIn);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
     await this.applyBeforeRelayHook(options);
 
     return this.addTransactionHooks(
@@ -530,7 +544,16 @@ export class Client<
     optionsIn?: TransactionOptions,
     sourceMaps: SourceMaps = {},
   ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
-    const options = optionsIn === undefined ? {} : optionsIn;
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    const options = args.assertTransactionOptions('options', optionsIn);
+    args.assertTransfer('transfer', transfer);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
     await this.applyBeforeRelayHook(options);
 
     return this.addTransactionHooks(
@@ -550,7 +573,16 @@ export class Client<
     optionsIn?: TransactionOptions,
     sourceMaps: SourceMaps = {},
   ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
-    const options = optionsIn === undefined ? {} : optionsIn;
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    args.assertHash256('hash', hash);
+    const options = args.assertTransactionOptions('options', optionsIn);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
     await this.applyBeforeRelayHook(options);
 
     return this.addTransactionHooks(
@@ -570,7 +602,16 @@ export class Client<
     optionsIn?: TransactionOptions,
     sourceMaps: SourceMaps = {},
   ): Promise<TransactionResult<RawInvokeReceipt, InvocationTransaction>> {
-    const options = optionsIn === undefined ? {} : optionsIn;
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    args.assertHash256('hash', hash);
+    const options = args.assertTransactionOptions('options', optionsIn);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
     await this.applyBeforeRelayHook(options);
 
     return this.addTransactionHooks(
@@ -589,7 +630,15 @@ export class Client<
     optionsIn?: TransactionOptions,
     sourceMaps: SourceMaps = {},
   ): Promise<TransactionResult<TransactionReceipt, ClaimTransaction>> {
-    const options = optionsIn === undefined ? {} : optionsIn;
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    const options = args.assertTransactionOptions('options', optionsIn);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
     await this.applyBeforeRelayHook(options);
 
     return this.addTransactionHooks(
@@ -607,6 +656,12 @@ export class Client<
     params: ReadonlyArray<ScriptBuilderParam | undefined>,
   ): Promise<RawCallReceipt> {
     try {
+      args.assertString('network', network);
+      args.assertAddress('contract', contract);
+      args.assertString('method', method);
+      args
+        .assertArray('params', params)
+        .forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
       const receipt = await this.getNetworkProvider(network).call(network, contract, method, params);
       await this.hooks.afterCall.promise(receipt);
 
@@ -626,7 +681,7 @@ export class Client<
   }
 
   protected getProvider(options: TransactionOptions = {}): TUserAccountProvider {
-    const { from } = options;
+    const { from } = args.assertTransactionOptions('options', options);
     if (from === undefined) {
       return this.selectedProvider$.getValue();
     }
@@ -646,6 +701,7 @@ export class Client<
   }
 
   protected getNetworkProvider(network: NetworkType): TUserAccountProvider {
+    args.assertString('network', network);
     const providers = Object.values(this.providers);
     const accountProvider = providers.find((provider) =>
       provider.getNetworks().some((providerNetwork) => providerNetwork === network),

--- a/packages/neo-one-client-core/src/__data__/data.ts
+++ b/packages/neo-one-client-core/src/__data__/data.ts
@@ -210,6 +210,24 @@ const transactionOptions = {
   },
 };
 
+const iterOptions = {
+  notDefined: undefined,
+  empty: {},
+  notObject: 'notObject',
+  onlyIndexStart: blockFilters.onlyStart,
+  onlyIndexStop: blockFilters.onlyStop,
+  validBlockFilter: blockFilters.valid,
+  invalidStart: {
+    indexStart: 'one',
+    indexStop: 20,
+  },
+  invalidStop: {
+    indexStart: 1,
+    indexStop: 'twenty',
+  },
+  invalidBlockFilter: blockFilters.invalid,
+};
+
 const simpleReturnType = (returnType: ABIReturn) => ({
   functions: [
     {
@@ -361,6 +379,25 @@ const timestamps = {
   past: 1534365211,
 };
 
+const invokeSendUnsafeReceiveTransactionOptions = {
+  notDefined: undefined,
+  ...transactionOptions,
+  onlySendTo: {
+    sendTo: [
+      {
+        amount: transfer.a.amount,
+        asset: transfer.a.asset,
+      },
+    ],
+  },
+  onlySendFromsInvalid: {
+    sendFrom: transfers.invalidTransfer,
+  },
+  onlySendFromValid: {
+    sendFrom: transfers.valid,
+  },
+};
+
 export const data = {
   transactions,
   attributes,
@@ -373,6 +410,8 @@ export const data = {
   blockFilters,
   getOptions,
   transactionOptions,
+  iterOptions,
+  invokeSendUnsafeReceiveTransactionOptions,
   contractRegisters,
   abi,
   smartContractDefinition,

--- a/packages/neo-one-client-core/src/__tests__/__snapshots__/args.test.ts.snap
+++ b/packages/neo-one-client-core/src/__tests__/__snapshots__/args.test.ts.snap
@@ -56,9 +56,29 @@ exports[`arg assertions assertHash256 - non-string 1`] = `"Expected string for v
 
 exports[`arg assertions assertHash256 - undefined 1`] = `"Expected string for value, found undefined"`;
 
+exports[`arg assertions assertInvokeSendUnsafeReceiveTransactionOptions - invalidAttributes 1`] = `"Expected Array for InvokeSendUnsafeReceiveTransactionOptions.attributes, found [object Object]"`;
+
+exports[`arg assertions assertInvokeSendUnsafeReceiveTransactionOptions - invalidFrom 1`] = `"Expected string for UserAccountID.network, found undefined"`;
+
+exports[`arg assertions assertInvokeSendUnsafeReceiveTransactionOptions - invalidNetworkFee 1`] = `"Expected Array for InvokeSendUnsafeReceiveTransactionOptions.attributes, found [object Object]"`;
+
+exports[`arg assertions assertInvokeSendUnsafeReceiveTransactionOptions - non object 1`] = `"Expected InvokeSendUnsafeReceiveTransactionOptions for value, found true"`;
+
+exports[`arg assertions assertInvokeSendUnsafeReceiveTransactionOptions - onlySendFromsValid 1`] = `"Expected Transfer for InvokeSendUnsafeReceiveTransactionOptions.sendFrom, found Foo"`;
+
 exports[`arg assertions assertNullableArray - non array 1`] = `"Expected Array for value, found true"`;
 
 exports[`arg assertions assertNullableBoolean - non boolean 1`] = `"Expected boolean for value, found 0"`;
+
+exports[`arg assertions assertNullableIterOptions - invalidBlockFilter 1`] = `"Expected IterOptions for value, found [object Object]"`;
+
+exports[`arg assertions assertNullableIterOptions - invalidStart 1`] = `"Expected number for IterOptions.indexStart, found one"`;
+
+exports[`arg assertions assertNullableIterOptions - invalidStop 1`] = `"Expected number for IterOptions.indexStop, found twenty"`;
+
+exports[`arg assertions assertNullableIterOptions - notObject 1`] = `"Expected IterOptions for value, found notObject"`;
+
+exports[`arg assertions assertNullableNumber - non number 1`] = `"Expected number for value, found true"`;
 
 exports[`arg assertions assertNumber - non number 1`] = `"Expected number for value, found true"`;
 

--- a/packages/neo-one-client-core/src/__tests__/args.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/args.test.ts
@@ -193,6 +193,24 @@ describe('arg assertions', () => {
     expect(() => args.assertNumber('value', value)).toThrowErrorMatchingSnapshot();
   });
 
+  test('assertNullableNumber - number', () => {
+    const value = data.numbers.a;
+
+    expect(args.assertNullableNumber('value', value)).toEqual(value);
+  });
+
+  test('assertNullableNumber - undefined', () => {
+    const value = undefined;
+
+    expect(args.assertNullableNumber('value', value)).toEqual(value);
+  });
+
+  test('assertNullableNumber - non number', () => {
+    const value = true;
+
+    expect(() => args.assertNullableNumber('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
   test('assertArray - array', () => {
     const value = [data.numbers.a];
 
@@ -620,5 +638,163 @@ describe('arg assertions', () => {
     const value = data.transactionOptions.invalidNetworkFee;
 
     expect(() => args.assertTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - notDefined', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.notDefined;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({});
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - valid', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.valid;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual(value);
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlyFrom', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlyFrom;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({ ...value, attributes: [] });
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlyFromScriptHash', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlyFromScriptHash;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({
+      ...data.invokeSendUnsafeReceiveTransactionOptions.onlyFrom,
+      attributes: [],
+    });
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlyAttributes', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlyAttributes;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual(value);
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlyAttributesScriptHash', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlyAttributesScriptHash;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual(
+      data.invokeSendUnsafeReceiveTransactionOptions.onlyAttributes,
+    );
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlyNetworkFee', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlyNetworkFee;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({ ...value, attributes: [] });
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - empty', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.empty;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({ attributes: [] });
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - undefined', () => {
+    const value = undefined;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({});
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - non object', () => {
+    const value = true;
+
+    expect(() => args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - invalidFrom', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.invalidFrom;
+
+    expect(() => args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - invalidAttributes', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.invalidAttributes;
+
+    expect(() => args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - invalidNetworkFee', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.invalidNetworkFee;
+
+    expect(() => args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlySendTo', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlySendTo;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({
+      ...value,
+      attributes: [],
+    });
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlySendFromsValid', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlySendFromsInvalid;
+
+    expect(() => args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertInvokeSendUnsafeReceiveTransactionOptions - onlySendFromValid', () => {
+    const value = data.invokeSendUnsafeReceiveTransactionOptions.onlySendFromValid;
+
+    expect(args.assertInvokeSendUnsafeReceiveTransactionOptions('value', value)).toEqual({ ...value, attributes: [] });
+  });
+
+  test('assertNullableIterOptions - notDefined', () => {
+    const value = data.iterOptions.notDefined;
+
+    expect(args.assertNullableIterOptions('value', value)).toEqual(undefined);
+  });
+
+  test('assertNullableIterOptions - empty', () => {
+    const value = data.iterOptions.empty;
+
+    expect(args.assertNullableIterOptions('value', value)).toEqual(value);
+  });
+
+  test('assertNullableIterOptions - notObject', () => {
+    const value = data.iterOptions.notObject;
+
+    expect(() => args.assertNullableIterOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertNullableIterOptions - onlyIndexStart', () => {
+    const value = data.iterOptions.onlyIndexStart;
+
+    expect(args.assertNullableIterOptions('value', value)).toEqual(value);
+  });
+
+  test('assertNullableIterOptions - onlyIndexStop', () => {
+    const value = data.iterOptions.onlyIndexStop;
+
+    expect(args.assertNullableIterOptions('value', value)).toEqual(value);
+  });
+
+  test('assertNullableIterOptions - validBlockFilter', () => {
+    const value = data.iterOptions.validBlockFilter;
+
+    expect(args.assertNullableIterOptions('value', value)).toEqual(value);
+  });
+
+  test('assertNullableIterOptions - invalidStart', () => {
+    const value = data.iterOptions.invalidStart;
+
+    expect(() => args.assertNullableIterOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertNullableIterOptions - invalidStop', () => {
+    const value = data.iterOptions.invalidStop;
+
+    expect(() => args.assertNullableIterOptions('value', value)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('assertNullableIterOptions - invalidBlockFilter', () => {
+    const value = data.iterOptions.invalidBlockFilter;
+
+    expect(() => args.assertNullableIterOptions('value', value)).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Add arg assertions to the client smart contract APIs in `neo-one-client-core/src/Client.ts`. I added two arg assertion methods in `neo-one-client-core/src/args.ts` and added tests for those new methods in `neo-one-client-core/src/__tests__/args.test.ts`. The two new methods in `args.ts` are:
- `assertNullableIterOptions` for asserting `IterOptions` parameters
- `assertNullableNumber` for asserting a number which could also be undefined
- `assertInvokeSendUnsafeReceiveTransactionOptions` for asserting `InvokeSendUnsafeReceiveTransactionOptions` type
- `assertNullableSendTo` for ^
- `assertNullableSendFrom` for ^^


Fixes: #722 

### Test Plan

To run tests for all of `neo-one-client-core`:
`yarn jest packages/neo-one-client-core/src/**/*`

Run tests just for the changed files:
`yarn jest packages/neo-one-client-core/src/__tests__/args.test.ts`
`yarn jest packages/neo-one-client-core/src/__tests__/Client.test.ts`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None.

### Benefits

<!-- What benefits will be realized by the code change? -->
Smart contract APIs will throw errors if arguments are incorrect.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None that I can see.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#722 