### PR TITLE
fix(website): remove html-to-react package

### DIFF
--- a/packages/neo-one-website/package.json
+++ b/packages/neo-one-website/package.json
@@ -33,7 +33,6 @@
     "emotion-theming": "10.0.14",
     "fs-extra": "^8.0.0",
     "gray-matter": "^4.0.2",
-    "html-to-react": "^1.3.4",
     "immer": "^3.1.3",
     "localforage": "^1.7.3",
     "lodash": "^4.17.14",

--- a/packages/neo-one-website/src/components/reference/common/utils.tsx
+++ b/packages/neo-one-website/src/components/reference/common/utils.tsx
@@ -1,11 +1,10 @@
 import { styledOmitProps } from '@neo-one/react-common';
 // @ts-ignore
-import { Parser } from 'html-to-react';
 import * as React from 'react';
 import { ifProp, prop } from 'styled-tools';
 import { Prism } from '../../../common';
 import { StyledRouterLink } from '../../StyledRouterLink';
-import { WordTokens } from '../types';
+import { WordToken, WordTokens } from '../types';
 
 const PUNCTUATION: readonly string[] = ['.', ',', '(', ')', '[', ']', '{', '}', '<', '>', ';', ':'];
 
@@ -33,15 +32,22 @@ const ReferenceLink = ({ to, value, idx, example, code = false, ...props }: Prop
   </StyledReferenceLink>
 );
 
+const getHighlightedHtml = ({
+  idx,
+  example,
+  token,
+}: {
+  readonly idx: number;
+  readonly example: WordTokens;
+  readonly token: WordToken;
+}): { readonly __html: string } => ({
+  __html: Prism.highlight(checkPunctuation(idx, example, token.value), Prism.languages.typescript, 'typescript'),
+});
+
 export const buildExample = (example: WordTokens) =>
   example.map((token, idx) =>
     token.slug === undefined ? (
-      <span key={idx}>
-        {new Parser().parse(
-          Prism.highlight(checkPunctuation(idx, example, token.value), Prism.languages.typescript, 'typescript'),
-          'text/xml',
-        )}
-      </span>
+      <span key={idx} dangerouslySetInnerHTML={getHighlightedHtml({ idx, example, token })}></span>
     ) : (
       <ReferenceLink key={idx} to={token.slug} code idx={idx} value={token.value} example={example} />
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8082,7 +8082,7 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-domhandler@^2.3.0, domhandler@^2.4.2:
+domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
@@ -10878,17 +10878,6 @@ html-tags@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.0.0.tgz#41f57708c9e6b7b46a00a22317d614c4a2bab166"
   integrity sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==
-
-html-to-react@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.3.4.tgz#647b3a54fdec73a6461864b129fb0d1eec7d4589"
-  integrity sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==
-  dependencies:
-    domhandler "^2.4.2"
-    escape-string-regexp "^1.0.5"
-    htmlparser2 "^3.10.0"
-    lodash.camelcase "^4.3.0"
-    ramda "^0.26"
 
 html-tokenize@^2.0.0:
   version "2.0.0"
@@ -17306,11 +17295,6 @@ ramda@0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
   integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
-
-ramda@^0.26:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randomatic@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
### Description of the Change

Removes the `html-to-react` package, which was used in the website. It was used to convert Prism.js-highlighted HTML to React code. `Prism.highlight()` returned a string which was then passed to `html-to-react`. I simply removed the `html-to-react` package and instead of passing the string of highlighted HTML code to `html-to-react` I passed it to `dangerouslySetInnerHtml` in its parent `<span>` element.

Fixes #748 

### Test Plan

Run `yarn website:start:dev-builds` and `yarn website:start:dev` and go to the *Resources* page and click on any of the references to see the syntax highlighting in the code examples, complete with links to other source code definitions

### Alternate Designs

It's possible I'm not understanding what we want from this issue. I looked into how to use hooks with Prism.js in order to override how it handles links, but the way we currently handle that seems to work very nicely.

### Benefits

Removes `html-to-react` dependency.

### Possible Drawbacks

Possibly introduces a XSS vulnerability? We use `dangerouslySetInnerHtml` in three other places. Someone could theoretically commit malicious code to our type definition files which would then be directly injected to our website.

### Applicable Issues

#748 