### PR TITLE
chore(node): remove 'https' option from RPC Server

### DIFF
--- a/packages/neo-one-node-bin/src/utils/extractConfigurations.ts
+++ b/packages/neo-one-node-bin/src/utils/extractConfigurations.ts
@@ -5,7 +5,7 @@ import { NodeEnvironment, NodeOptions } from '@neo-one/node-protocol';
 import _ from 'lodash';
 
 const envKeys = {
-  rpc: ['http', 'https', 'splashScreen'],
+  rpc: ['http', 'splashScreen'],
   backup: ['tmpPath', 'readyPath'],
   node: ['externalPort'],
   network: ['listenTCP'],

--- a/packages/neo-one-node-http-rpc/src/rpcServer$.ts
+++ b/packages/neo-one-node-http-rpc/src/rpcServer$.ts
@@ -2,7 +2,6 @@ import { context, cors, createServer$, onError as appOnError } from '@neo-one/ht
 import { Monitor } from '@neo-one/monitor';
 import { Blockchain, Node } from '@neo-one/node-core';
 import * as http from 'http';
-import * as https from 'https';
 import Application from 'koa';
 import rateLimit from 'koa-ratelimit-lru';
 import Router from 'koa-router';
@@ -23,13 +22,6 @@ export interface ServerOptions {
 }
 export interface Environment {
   readonly http?: {
-    readonly port: number;
-    readonly host: string;
-  };
-
-  readonly https?: {
-    readonly key: string;
-    readonly cert: string;
     readonly port: number;
     readonly host: string;
   };
@@ -141,17 +133,7 @@ export const rpcServer$ = ({
     map((options) => (options.server === undefined ? undefined : options.server.keepAliveTimeout)),
   );
 
-  return combineLatest([
-    environment.http === undefined
-      ? _of(undefined)
-      : createServer$(monitor, app$, keepAliveTimeout$, environment.http, () => http.createServer()),
-    environment.https === undefined
-      ? _of(undefined)
-      : createServer$(monitor, app$, keepAliveTimeout$, environment.https, (options) =>
-          https.createServer({
-            cert: options.cert,
-            key: options.key,
-          }),
-        ),
-  ]);
+  return environment.http === undefined
+    ? _of(undefined)
+    : createServer$(monitor, app$, keepAliveTimeout$, environment.http, () => http.createServer());
 };

--- a/packages/neo-one-node/src/FullNode.ts
+++ b/packages/neo-one-node/src/FullNode.ts
@@ -122,11 +122,7 @@ export class FullNode {
   private getRPCPort(): number {
     const rpcOptions = this.options.environment.rpc;
 
-    return rpcOptions.http !== undefined
-      ? rpcOptions.http.port
-      : rpcOptions.https !== undefined
-      ? rpcOptions.https.port
-      : 8080;
+    return rpcOptions.http !== undefined ? rpcOptions.http.port : 8080;
   }
 
   private getBackupEnvironment(): BackupRestoreEnvironment {

--- a/packages/neo-one-website/docs/4-node/1-docker.md
+++ b/packages/neo-one-website/docs/4-node/1-docker.md
@@ -16,13 +16,13 @@ If you are unfamiliar with Docker or do not have a version installed locally vis
 ## Requirements
 
 - [Docker](https://www.docker.com/get-started)
-  - Minimum: ***at least*** 2GB Memory, 1cpu, and 50GB Storage allocated
+  - Minimum: **_at least_** 2GB Memory, 1cpu, and 50GB Storage allocated
   - Recommended: 4GB Memory, 2cpu, and 60GB+ Storage allocated
-  (if you plan to deploy to a cluster you will need this for *each* pod/container)
+    (if you plan to deploy to a cluster you will need this for _each_ pod/container)
 
 ## Getting Started
 
-[![Docker Repository on Quay](https://quay.io/repository/neoone/node/status "Docker Repository on Quay")](https://quay.io/repository/neoone/node)
+[![Docker Repository on Quay](https://quay.io/repository/neoone/node/status 'Docker Repository on Quay')](https://quay.io/repository/neoone/node)
 
 NEO•ONE uses [quay](https://quay.io/) to automatically build the docker image every time a new version is published.
 
@@ -37,7 +37,7 @@ Voila! You should now be running the most recent NEO•ONE Node in a local docke
 
 ## Configuring
 
-There are __several__ ways to configure the node; any [rc](https://github.com/dominictarr/rc#rc) type configuration is accepted. as an example we can set the `monitor` level of the node to *verbose* using either:
+There are **several** ways to configure the node; any [rc](https://github.com/dominictarr/rc#rc) type configuration is accepted. as an example we can set the `monitor` level of the node to _verbose_ using either:
 
 ```bash
 docker run quay.io/neoone/node --environment.monitor=verbose
@@ -98,7 +98,7 @@ Upon visiting `localhost:8001/metrics` you should now see the node-metrics page.
 
 Note
 
-By default metrics are **disabled** so you *must* include the `--environment.telemetry.port=8001` argument or provide a telemetry port through other means of configuration (see above).
+By default metrics are **disabled** so you _must_ include the `--environment.telemetry.port=8001` argument or provide a telemetry port through other means of configuration (see above).
 
 :::
 
@@ -138,7 +138,7 @@ Upon successfully starting the node, you should begin to see `relay_block` event
 
 Note
 
-Its worth mentioning that syncing the entire blockchain can take a **very** long time. We recommend `restoring` to a recent backup (described below) and *then* syncing.
+Its worth mentioning that syncing the entire blockchain can take a **very** long time. We recommend `restoring` to a recent backup (described below) and _then_ syncing.
 
 :::
 
@@ -165,4 +165,4 @@ To download a backup of the most recent blockchain data and extract it you can c
 
 This tells the node where we want to restore from. Assuming there is an available google-cloud bucket to restore from (there will be for our example) it will download and extract the blockchain data to our defined `node-data` folder. This process can take multiple hours depending on network speeds as a fully synced backup is ~16GB in size.
 
-To restore ***and*** sync simply combine the above configurations.
+To restore **_and_** sync simply combine the above configurations.

--- a/packages/neo-one-website/docs/4-node/6-configuration.md
+++ b/packages/neo-one-website/docs/4-node/6-configuration.md
@@ -33,7 +33,7 @@ This section will serve as a reference for the NEO•ONE Node's many configurati
 
 ### dataPath
 
-*defaults to the data path supplied by [env-paths](https://www.npmjs.com/package/env-paths)*
+_defaults to the data path supplied by [env-paths](https://www.npmjs.com/package/env-paths)_
 
 `environment.dataPath` is the path used for storing blockchain data.
 
@@ -41,7 +41,7 @@ In the [local docker](/docs/node-docker#Examples) example we could store blockch
 
 ### chainFile
 
-*disabled by default*
+_disabled by default_
 
 Optional path for syncing from a local `chainFile`. A chainfile is a full binary of blockchain data that can be used to **hard** re-sync the chain. As opposed to a normal backup this is used to re-sync instead of restore. This is useful in extreme situations like a fork.
 
@@ -55,22 +55,23 @@ Syncing from a chainfile can take a **very** long time. Upwards of 30 hours.
 
 ### dumpChainFile
 
-*disabled by default*
+_disabled by default_
 
 Optional path for outputting a `chainFile`.
 
 ### monitor
 
-*defaults to **'info'***
+\*defaults to **'info'\***
 
 Desired logging level of the node monitor, options are
+
 ```
 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly'
 ```
 
 ### haltOnSync
 
-*defaults to **false***
+\*defaults to **false\***
 
 `haltOnSync` enables a watcher which will halt the node when the rpc server's `readyHealthCheck` passes and begin a backup if a location is specified which you are authorized to push to.
 
@@ -84,11 +85,11 @@ To properly halt and backup, you must also provide `backup` and `rpc.readyHealth
 
 ### levelDownOptions
 
-*see the [leveldown documentation](https://github.com/Level/leveldown#options)*
+_see the [leveldown documentation](https://github.com/Level/leveldown#options)_
 
 ### telemetry
 
-*disabled by default*
+_disabled by default_
 
 `environment.telemetry.port` specifies the port to use when serving node-metrics. When enabled, you can visit `localhost:<port>/metrics` to view metrics.
 
@@ -107,19 +108,19 @@ To properly halt and backup, you must also provide `backup` and `rpc.readyHealth
 
 ### type
 
-*defaults to 'main'*
+_defaults to 'main'_
 
 `settings.type` specifies which NEO network we are connecting to.
 
 ### privateNet
 
-*defaults to **false***
+\*defaults to **false\***
 
 `settings.privateNet` specifies whether or not the node is connecting to a private network.
 
 ### address
 
-*defaults to '5fa99d93303775fe50ca119c327759313eccfa1c'*
+_defaults to '5fa99d93303775fe50ca119c327759313eccfa1c'_
 
 `settings.address` sets the initial address we send tokens to on private net.
 
@@ -136,12 +137,6 @@ List of consensus nodes.
     "http?": {
       "port": number,
       "host": string
-    },
-    "https?": {
-      "port": number,
-      "host": string,
-      "cert": string,
-      "key": string
     },
     "server?": {
       "keepAliveTimeout": number,
@@ -177,24 +172,26 @@ List of consensus nodes.
 
 ---
 
-*by default only http is enabled on `localhost:8080` OR `localhost:$PORT` if you have set the `PORT` environment variable*
+_by default only http is enabled on `localhost:8080` OR `localhost:$PORT` if you have set the `PORT` environment variable_
 
-`rpc.http` or `rpc.https` are used to configure the rpc server’s host options. You do not need to specify both http and https options.
+`rpc.http` is used to configure the rpc server’s host options. It is important in a kubernetes setup that `containerPort` matches `rpc.http.port`.
 
 ### Hot Options
-*these options can be changed without restarting the node*
 
-`server.keepAliveTimeout`: if you would like your server to close after *x* seconds without activity set a timeout here (in milliseconds).
+_these options can be changed without restarting the node_
 
-`liveHealthCheck` *&* `readyHealthCheck` share the same configuration.
+`server.keepAliveTimeout`: if you would like your server to close after _x_ seconds without activity set a timeout here (in milliseconds).
+
+`liveHealthCheck` _&_ `readyHealthCheck` share the same configuration.
+
 - `rpcURLs`: a list of RPC URLs to compare our node to
 - `offset`: the acceptable difference of blocks ahead/behind to count as `live` or `ready`
 - `timeoutMS`: timeout for RPC connections
 - `checkEndpoints`: the number of different endpoints to check against before passing `true`/`false`.
 
-`tooBusyCheck` (*experimental*): enable the tooBusy middleware which throttles requests to the node when under significant load. Currently an experimental feature, see [toobusy-js](https://github.com/strml/node-toobusy) for more. Set `tooBusyCheck.enabled` to **true** if you would like to try it.
+`tooBusyCheck` (_experimental_): enable the tooBusy middleware which throttles requests to the node when under significant load. Currently an experimental feature, see [toobusy-js](https://github.com/strml/node-toobusy) for more. Set `tooBusyCheck.enabled` to **true** if you would like to try it.
 
-`rateLimit` (*experimental*): enable the rateLimiter middleware which throttles requests to the node when too many have been made from the same address over a period of time. Currently an experimental feature, see [koa-ratelimit-lru](https://github.com/Dreamacro/koa-ratelimit-lru) for more. Set `rateLimit.enabled` to **true** to experiment with it.
+`rateLimit` (_experimental_): enable the rateLimiter middleware which throttles requests to the node when too many have been made from the same address over a period of time. Currently an experimental feature, see [koa-ratelimit-lru](https://github.com/Dreamacro/koa-ratelimit-lru) for more. Set `rateLimit.enabled` to **true** to experiment with it.
 
 ## Node
 
@@ -221,7 +218,8 @@ List of consensus nodes.
 `externalPort` specifies the external port of the node, useful for a deployment when the container ports are different from the cluster port.
 
 ### Hot Options
-*these options can be changed without restarting the node*
+
+_these options can be changed without restarting the node_
 
 `rpcURLs` specifies a list of known node RPC URLs you would like to try and connect to. A list of public mainnet hosts can be found at http://monitor.cityofzion.io/.
 
@@ -229,9 +227,9 @@ List of consensus nodes.
 
 `consensus` sets the consensus options for the node, requires a privateNet setup.
 
-  - `enabled` enables consensus
-  - `privateKey` the key for the network
-  - `privateNet` true/false
+- `enabled` enables consensus
+- `privateKey` the key for the network
+- `privateNet` true/false
 
 ## Network
 
@@ -261,7 +259,8 @@ List of consensus nodes.
 `listenTCP` when provided at least a port this allows other nodes to create TCP connections with this one over that port. `host` is optional and defaults to 'localhost'.
 
 ### Hot Options
-*these options can be changed without restarting the node*
+
+_these options can be changed without restarting the node_
 
 `seeds` specifies external seeds you would like to connect to.
 
@@ -276,6 +275,7 @@ List of consensus nodes.
 `socketTimeoutMS` sets the timeout of peer requests (in milliseconds). Defaults to 1 minute.
 
 ## backup
+
 ```bash
 ...
 {
@@ -316,12 +316,13 @@ List of consensus nodes.
 
 ---
 
-`tmpPath` *(defaults to ${environment.dataPath}/tmp)* specifies the file path to use for downloading backup files before extraction.
+`tmpPath` _(defaults to \${environment.dataPath}/tmp)_ specifies the file path to use for downloading backup files before extraction.
 
-`readyPath` *(defaults to ${environment.dataPath}/ready)* specifies the file path to use when flagging the restore as 'ready'.
+`readyPath` _(defaults to \${environment.dataPath}/ready)_ specifies the file path to use when flagging the restore as 'ready'.
 
 ### Hot Options
-*these options can be changed without restarting the node*
+
+_these options can be changed without restarting the node_
 
 `restore`: set to **true** to attempt and pull the latest backup from your provider on starting the node, **false** to ignore restoring and only backup.
 


### PR DESCRIPTION
Remove the `https` option from the node. We never used it and don't plan to support it.

### Applicable Issues

Fixes #1609 
