### PR TITLE
fix(renovate): fix broken renovate schedule/timezone

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": ["config:base", ":semanticCommits"],
   "schedule": ["after 12am and before 5am"],
-  "timezone": ["America/Los_Angeles"],
+  "timezone": "America/Los_Angeles",
+  "updateNotScheduled": false,
   "postUpdateOptions": ["yarnDedupeHighest"],
   "automerge": true,
   "major": {


### PR DESCRIPTION
### Description of the Change

Renovate doesn't seem to be running when we want it to. This is a second attempt to fix that and make it run in the middle of the night.

### Test Plan

After the merge watch that Renovate only opens PRs after 12am midnight and before 5am

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits

<!-- What benefits will be realized by the code change? -->
No Renovate commits during the day

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

### Applicable Issues

<!-- Enter any applicable Issues here -->
#1536 
