### PR TITLE
chore(client): add node version switch to DeveloperClient consensus

### DIFF
--- a/packages/neo-one-client-core/package.json
+++ b/packages/neo-one-client-core/package.json
@@ -19,6 +19,7 @@
     "lodash": "^4.17.14",
     "rxjs": "^6.5.2",
     "safe-stable-stringify": "^1.1.0",
+    "semver": "^6.3.0",
     "tapable": "^1.1.3",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-node-consensus/package.json
+++ b/packages/neo-one-node-consensus/package.json
@@ -14,6 +14,7 @@
     "bn.js": "^4.11.8",
     "lodash": "^4.17.14",
     "rxjs": "^6.5.2",
+    "semver": "^6.3.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description of the Change

e2e8 CI check was failing consistently because of some changes made to DeveloperClient's `runConsensusNow` method. This reverts the changes _only_ for node 8.

### Test Plan

```
yarn build
yarn e2e DeveloperClient
```

### Alternate Designs

It is not clear to me how to implement this without a version switch s.t it works on all node versions. This is more of a hotfix than anything.

### Benefits

Tests pass!

### Possible Drawbacks

?? I don't think my semver check is good practice in the long run, but this is a blocking issue for CI runs.
