### PR TITLE
fix(renovate): tell renovate to run on weekends as well

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":semanticCommits"],
-  "schedule": ["after 12am and before 5am"],
+  "schedule": ["after 1am and before 5am on every weekday", "every weekend"],
   "timezone": "America/Los_Angeles",
   "updateNotScheduled": false,
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
### Description of the Change

Renovate seems confused and submits PRs in the middle of the day still, clogging our CI jobs. It's possible that it is misinterpreting 12am as 12pm, so I changed it to be after 1am. I also added on weekends so it runs anytime during the weekends. The submitted change is almost directly from the renovate docs, so this *should* work: https://renovatebot.com/docs/configuration-options/#schedule

### Test Plan

Watch for when renovate makes PRs and updates.

### Alternate Designs

None.

### Benefits

Better schedule.

### Possible Drawbacks

None.

### Applicable Issues

#1536 
