### PR TITLE
fix(web): fix website build by using client-switch

### DIFF
--- a/packages/neo-one-client-switch/package.json
+++ b/packages/neo-one-client-switch/package.json
@@ -25,6 +25,8 @@
     "@types/lodash": "4.14.136"
   },
   "optionalDependencies": {
+    "@opencensus/exporter-prometheus": "^0.0.16",
+    "@opencensus/exporter-jaeger": "^0.0.16",
     "@ledgerhq/hw-transport-node-hid": "4.68.2",
     "@opencensus/core": "^0.0.16",
     "@opencensus/nodejs-base": "^0.0.16",

--- a/packages/neo-one-client-switch/src/browser/tracing.ts
+++ b/packages/neo-one-client-switch/src/browser/tracing.ts
@@ -39,16 +39,26 @@ const globalStats: Stats = {
   getCurrentTagContext: noOp,
 };
 
+const PrometheusStatsExporter = {
+  onRegisterView: noOp,
+  onRecord: noOp,
+  start: noOp,
+  stop: noOp,
+};
+const JaegerTraceExporter = NoopExporter;
+
 export {
-  TraceContextFormat,
-  Span,
-  SpanKind,
   AggregationType,
+  globalStats,
+  JaegerTraceExporter,
   Measure,
   MeasureUnit,
-  TagMap,
   NoopExporter,
-  tracer,
+  PrometheusStatsExporter,
+  Span,
+  SpanKind,
   startTracing,
-  globalStats,
+  TagMap,
+  TraceContextFormat,
+  tracer,
 };

--- a/packages/neo-one-client-switch/src/node/tracing.ts
+++ b/packages/neo-one-client-switch/src/node/tracing.ts
@@ -11,6 +11,8 @@ import {
   SpanKind,
   TagMap,
 } from '@opencensus/core';
+import { JaegerTraceExporter } from '@opencensus/exporter-jaeger';
+import { PrometheusStatsExporter } from '@opencensus/exporter-prometheus';
 import { TracingBase } from '@opencensus/nodejs-base';
 import { TraceContextFormat } from '@opencensus/propagation-tracecontext';
 
@@ -30,15 +32,17 @@ const startTracing = (exporter: Exporter) => {
 };
 
 export {
-  startTracing,
-  TraceContextFormat,
-  tracer,
   AggregationType,
   globalStats,
+  JaegerTraceExporter,
   Measure,
   MeasureUnit,
+  NoopExporter,
+  PrometheusStatsExporter,
   Span,
   SpanKind,
+  startTracing,
   TagMap,
-  NoopExporter,
+  TraceContextFormat,
+  tracer,
 };

--- a/packages/neo-one-node-blockchain/package.json
+++ b/packages/neo-one-node-blockchain/package.json
@@ -5,10 +5,10 @@
   "main": "./src/index",
   "dependencies": {
     "@neo-one/client-common": "^1.3.0",
+    "@neo-one/client-switch": "^1.2.2",
     "@neo-one/logger": "^1.0.0",
     "@neo-one/node-core": "^1.1.5",
     "@neo-one/utils": "^1.1.3",
-    "@opencensus/core": "^0.0.16",
     "@types/bn.js": "^4.11.5",
     "bn.js": "^4.11.8",
     "js-priority-queue": "^0.1.5",

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -1,4 +1,5 @@
 import { common, crypto, ECPoint, ScriptBuilder, UInt160, VMState } from '@neo-one/client-common';
+import { AggregationType, globalStats, MeasureUnit } from '@neo-one/client-switch';
 import { nodeLogger } from '@neo-one/logger';
 import {
   Action,
@@ -29,7 +30,6 @@ import {
   VM,
 } from '@neo-one/node-core';
 import { Labels, utils as commonUtils } from '@neo-one/utils';
-import { AggregationType, globalStats, MeasureUnit } from '@opencensus/core';
 import { BN } from 'bn.js';
 import PriorityQueue from 'js-priority-queue';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';

--- a/packages/neo-one-node-network/package.json
+++ b/packages/neo-one-node-network/package.json
@@ -4,10 +4,10 @@
   "description": "NEO•ONE NEO network protocol.",
   "main": "./src/index",
   "dependencies": {
+    "@neo-one/client-switch": "^1.2.2",
     "@neo-one/logger": "^1.0.0",
     "@neo-one/node-core": "^1.1.5",
     "@neo-one/utils": "^1.1.3",
-    "@opencensus/core": "^0.0.16",
     "lodash": "^4.17.14",
     "rxjs": "^6.5.2",
     "tslib": "^1.9.3"

--- a/packages/neo-one-node-network/src/Network.ts
+++ b/packages/neo-one-node-network/src/Network.ts
@@ -1,3 +1,4 @@
+import { AggregationType, globalStats, MeasureUnit } from '@neo-one/client-switch';
 import { nodeLogger } from '@neo-one/logger';
 import {
   ConnectedPeer,
@@ -11,7 +12,6 @@ import {
   PeerHealthBase,
 } from '@neo-one/node-core';
 import { Labels, utils } from '@neo-one/utils';
-import { AggregationType, globalStats, MeasureUnit } from '@opencensus/core';
 import _ from 'lodash';
 import * as net from 'net';
 import { Observable, Subscription } from 'rxjs';

--- a/packages/neo-one-node-protocol/package.json
+++ b/packages/neo-one-node-protocol/package.json
@@ -5,12 +5,12 @@
   "main": "./src/index",
   "dependencies": {
     "@neo-one/client-common": "^1.3.0",
+    "@neo-one/client-switch": "^1.2.2",
     "@neo-one/logger": "^1.0.0",
     "@neo-one/monitor": "^1.1.4",
     "@neo-one/node-consensus": "^1.1.5",
     "@neo-one/node-core": "^1.1.5",
     "@neo-one/utils": "^1.1.3",
-    "@opencensus/core": "^0.0.16",
     "@types/bloom-filter": "^0.2.0",
     "@types/bn.js": "^4.11.5",
     "@types/ip-address": "^5.8.2",

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -1,4 +1,5 @@
 import { common, crypto, UInt256Hex, utils } from '@neo-one/client-common';
+import { AggregationType, globalStats, MeasureUnit } from '@neo-one/client-switch';
 import { nodeLogger } from '@neo-one/logger';
 import { Consensus, ConsensusOptions } from '@neo-one/node-consensus';
 import {
@@ -24,7 +25,6 @@ import {
   VerifyTransactionResult,
 } from '@neo-one/node-core';
 import { finalize, Labels, labelToTag, neverComplete, utils as commonUtils } from '@neo-one/utils';
-import { AggregationType, globalStats, MeasureUnit } from '@opencensus/core';
 import { ScalingBloem } from 'bloem';
 // tslint:disable-next-line:match-default-export-name
 import BloomFilter from 'bloom-filter';

--- a/packages/neo-one-node-rpc-handler/package.json
+++ b/packages/neo-one-node-rpc-handler/package.json
@@ -5,10 +5,10 @@
   "main": "./src/index",
   "dependencies": {
     "@neo-one/client-common": "^1.3.0",
+    "@neo-one/client-switch": "^1.2.2",
     "@neo-one/logger": "^1.0.0",
     "@neo-one/node-core": "^1.1.5",
     "@neo-one/utils": "^1.1.2",
-    "@opencensus/core": "^0.0.16",
     "rxjs": "^6.5.2",
     "tslib": "^1.9.3"
   },

--- a/packages/neo-one-node-rpc-handler/src/createHandler.ts
+++ b/packages/neo-one-node-rpc-handler/src/createHandler.ts
@@ -1,4 +1,5 @@
 import { common, crypto, JSONHelper, RelayTransactionResultJSON, TransactionJSON, utils } from '@neo-one/client-common';
+import { AggregationType, globalStats, MeasureUnit, TagMap } from '@neo-one/client-switch';
 import { nodeLogger } from '@neo-one/logger';
 import {
   Account,
@@ -14,7 +15,6 @@ import {
   TransactionType,
 } from '@neo-one/node-core';
 import { Labels, labelToTag } from '@neo-one/utils';
-import { AggregationType, globalStats, MeasureUnit, TagMap } from '@opencensus/core';
 import { filter, switchMap, take, timeout, toArray } from 'rxjs/operators';
 
 const logger = nodeLogger.child({ component: 'rpc-handler' });
@@ -584,7 +584,7 @@ export const createHandler = ({
               timeout(new Date(Date.now() + watchTimeoutMS)),
             )
             .toPromise();
-        } catch (error) {
+        } catch {
           throw new JSONRPCError(-100, 'Unknown transaction');
         }
       } else {


### PR DESCRIPTION
### Description of the Change

As spencer quickly found out the `opencensus` modules _all_ need to come from `@neo-one/client-switch` to allow the website to build properly. This addresses that.
