### PR TITLE
refactor(node-bin image): use github  actions to publish node-bin do…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,8 @@ aliases:
         - staging.tmp
         - trying.tmp
 
-  - &yarn
-    |
-      yarn install --non-interactive --cache-folder ~/.cache/yarn --ignore-engines
+  - &yarn |
+    yarn install --non-interactive --cache-folder ~/.cache/yarn --ignore-engines
 
   - &lint
     working_directory: ~/neo-one

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -1,0 +1,22 @@
+name: DockerHub
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - \@neo-one/node-bin*
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    container:
+      image: neotracker/neo-one-circleci-node:10.16.0-1
+    steps:
+      - uses: actions/checkout@master
+      - uses: ./actions/dockerhub/
+        with:
+          args: -f ./scripts/DockerfileNode .
+        env:
+          DOCKER_NAMESPACE: neoonesuite
+          DOCKER_IMAGE_NAME: node-bin
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/actions/dockerhub/Dockerfile
+++ b/actions/dockerhub/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker:stable
+
+COPY entrypoint.sh /entrypoint.sh
+
+USER root
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/dockerhub/entrypoint.sh
+++ b/actions/dockerhub/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+## mapping of var from user input or default value
+
+USERNAME=${GITHUB_REPOSITORY%%/*}
+REPOSITORY=${GITHUB_REPOSITORY#*/}
+
+ref_tmp=${GITHUB_REF#*/} ## throw away the first part of the ref (GITHUB_REF=refs/heads/master or refs/tags/2019/03/13)
+ref_type=${ref_tmp%%/*} ## extract the second element of the ref (heads or tags)
+ref_value=${ref_tmp#*/} ## extract the third+ elements of the ref (master or 2019/03/13)
+
+IMAGE_TAG=${ref_value//\//-} ## replace `/` with `-` in ref for docker tag requirement (master or 2019-03-13)
+NAMESPACE=${DOCKER_NAMESPACE:-$USERNAME} ## use github username as docker namespace unless specified
+IMAGE_NAME=${DOCKER_IMAGE_NAME:-$REPOSITORY} ## use github repository name as docker image name unless specified
+REGISTRY_IMAGE="$NAMESPACE/$IMAGE_NAME"
+
+## login if needed
+if [ -n "${DOCKER_PASSWORD+set}" ]
+then
+  sh -c "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+fi
+
+## build the image locally
+sh -c "docker build -t $IMAGE_NAME ${*:-.}" ## pass in the build command from user input, otherwise build in default mode
+
+# push all the tags to registry
+sh -c "docker tag $IMAGE_NAME $REGISTRY_IMAGE:latest"
+sh -c "docker push $REGISTRY_IMAGE:latest"
+
+if [ "${ref_type}" = "tags" ]
+then
+  sh -c "docker tag $IMAGE_NAME $REGISTRY_IMAGE:$IMAGE_TAG"
+  sh -c "docker push $REGISTRY_IMAGE:$IMAGE_TAG"
+fi

--- a/packages/neo-one-client-core/package.json
+++ b/packages/neo-one-client-core/package.json
@@ -8,6 +8,7 @@
     "@neo-one/client-switch": "^1.2.2",
     "@neo-one/utils": "^1.1.3",
     "@reactivex/ix-es2015-cjs": "^2.5.3",
+    "@types/debug": "4.1.5",
     "bignumber.js": "^9.0.0",
     "bn.js": "^5.0.0",
     "cross-fetch": "^3.0.4",

--- a/packages/neo-one-node-http-rpc/package.json
+++ b/packages/neo-one-node-http-rpc/package.json
@@ -11,6 +11,7 @@
     "@neo-one/node-core": "^1.1.5",
     "@neo-one/node-rpc-handler": "^1.1.5",
     "@neo-one/utils": "^1.1.3",
+    "@types/koa-compress": "2.0.9",
     "cross-fetch": "^3.0.4",
     "execa": "^2.0.4",
     "koa": "^2.7.0",

--- a/scripts/DockerfileNode
+++ b/scripts/DockerfileNode
@@ -5,10 +5,14 @@ WORKDIR /tmp/neo-one
 COPY package.json tsconfig.json lerna.json gulpfile.js yarn.lock LICENSE README.md ./
 COPY tsconfig/ tsconfig
 COPY types/ types
+COPY packages/neo-one-utils-node/src/ packages/neo-one-utils-node/src
+COPY packages/neo-one-utils-node/package.json packages/neo-one-utils-node/
 COPY packages/neo-one-utils/src/ packages/neo-one-utils/src
 COPY packages/neo-one-utils/package.json packages/neo-one-utils/
 COPY packages/neo-one-logger/src/ packages/neo-one-logger/src
 COPY packages/neo-one-logger/package.json packages/neo-one-logger/
+COPY packages/neo-one-cli-common-node/src/ packages/neo-one-cli-common-node/src
+COPY packages/neo-one-cli-common-node/package.json packages/neo-one-cli-common-node/
 COPY packages/neo-one-client/src/ packages/neo-one-client/src
 COPY packages/neo-one-client/package.json packages/neo-one-client/
 COPY packages/neo-one-client-common/src/ packages/neo-one-client-common/src
@@ -35,8 +39,6 @@ COPY packages/neo-one-node-consensus/src/ packages/neo-one-node-consensus/src
 COPY packages/neo-one-node-consensus/package.json packages/neo-one-node-consensus/
 COPY packages/neo-one-node-core/src/ packages/neo-one-node-core/src
 COPY packages/neo-one-node-core/package.json packages/neo-one-node-core/
-COPY packages/neo-one-node-data-backup/src/ packages/neo-one-node-data-backup/src
-COPY packages/neo-one-node-data-backup/package.json packages/neo-one-node-data-backup/
 COPY packages/neo-one-node-http-rpc/src/ packages/neo-one-node-http-rpc/src
 COPY packages/neo-one-node-http-rpc/package.json packages/neo-one-node-http-rpc/
 COPY packages/neo-one-node-neo-settings/src/ packages/neo-one-node-neo-settings/src
@@ -57,6 +59,10 @@ COPY packages/neo-one-node-vm/src/ packages/neo-one-node-vm/src
 COPY packages/neo-one-node-vm/package.json packages/neo-one-node-vm/
 COPY packages/neo-one-node/src/ packages/neo-one-node/src
 COPY packages/neo-one-node/package.json packages/neo-one-node/
+COPY packages/neo-one-http/src/ packages/neo-one-http/src
+COPY packages/neo-one-http/package.json packages/neo-one-http/
+COPY packages/neo-one-http-context/src/ packages/neo-one-http-context/src
+COPY packages/neo-one-http-context/package.json packages/neo-one-http-context/
 
 RUN sudo yarn install --non-interactive
 RUN yarn build:node

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,7 +2532,7 @@
   dependencies:
     postcss "5 - 7"
 
-"@types/debug@*":
+"@types/debug@*", "@types/debug@4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
@@ -2711,7 +2711,7 @@
   dependencies:
     "@types/koa" "*"
 
-"@types/koa-compress@^2.0.9":
+"@types/koa-compress@2.0.9", "@types/koa-compress@^2.0.9":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@types/koa-compress/-/koa-compress-2.0.9.tgz#5d19f7d928f78b451a9afd148863e2b45f51e541"
   integrity sha512-1Sa9OsbHd2N2N7gLpdIRHe8W99EZbfIR31D7Iisx16XgwZCnWUtGXzXQejhu74Y1pE/wILqBP6VL49ch/MVpZw==


### PR DESCRIPTION
…cker images to docker-hub

##### Description
Adds github actions workflow for building and publishing images of the node-bin to dockerhub.  
What should happen:
- On a merge/push to master, an imagine is built, tagged `latest`, and pushed to `docker.io/neoonesuite/node-bin`
- On a tag push, tags matching `@neo-one/node-bin*` will also trigger an image to be built, tagged `@neo-one/node-bin*`, and pushed to `docker.io/neoonesuite/node-bin`

##### Testing
Tested as much as possible using a `pull_request` event.  
Need to confirm two things once this PR is in:
- merges to master produce a new image as expected
- new node-bin tags produce a new image as expected