### PR TITLE
fix(web build): update preview & testRunner builds to comply with min…

### DIFF
--- a/scripts/website/webpack/preview.ts
+++ b/scripts/website/webpack/preview.ts
@@ -32,7 +32,7 @@ export const preview = ({ stage }: { readonly stage: Stage }): webpack.Configura
             <head>
               <meta charset="UTF-8">
               <title>${title}</title>
-              ${MiniHtmlWebpackPlugin.generateCSSReferences(css, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateCSSReferences({ files: css, publicPath })}
               <style>
                 body {
                   margin: 0;
@@ -43,7 +43,7 @@ export const preview = ({ stage }: { readonly stage: Stage }): webpack.Configura
             </head>
             <body>
               <div id="app"></div>
-              ${MiniHtmlWebpackPlugin.generateJSReferences(js, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateJSReferences({ files: js, publicPath })}
             </body>
           </html>`,
     }),

--- a/scripts/website/webpack/testRunner.ts
+++ b/scripts/website/webpack/testRunner.ts
@@ -32,7 +32,7 @@ export const testRunner = ({ stage }: { readonly stage: Stage }): webpack.Config
             <head>
               <meta charset="UTF-8">
               <title>${title}</title>
-              ${MiniHtmlWebpackPlugin.generateCSSReferences(css, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateCSSReferences({ files: css, publicPath })}
               <style>
                 body {
                   margin: 0;
@@ -43,7 +43,7 @@ export const testRunner = ({ stage }: { readonly stage: Stage }): webpack.Config
             </head>
             <body>
               <div id="app"></div>
-              ${MiniHtmlWebpackPlugin.generateJSReferences(js, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateJSReferences({ files: js, publicPath })}
             </body>
           </html>`,
     }),


### PR DESCRIPTION
…i-html-webpack-plugin update

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change
mini-html-webpack-plugin version update now expects object parameters for `generateCSSReferences` and `generateJSReferences` instead of positional.  Updated to comply.
