### PR TITLE
fix(web): fix logging / opencensus imports for website

### DIFF
--- a/packages/neo-one-client-switch/src/node/tracing.ts
+++ b/packages/neo-one-client-switch/src/node/tracing.ts
@@ -31,6 +31,8 @@ const startTracing = (config: Config) => {
   };
 };
 
+const getNewPropagation = () => new TraceContextFormat();
+
 export {
   AggregationType,
   Config as TracingConfig,
@@ -46,6 +48,6 @@ export {
   SpanKind,
   startTracing,
   TagMap,
-  TraceContextFormat,
+  getNewPropagation,
   tracer,
 };

--- a/packages/neo-one-logger/src/loggers.ts
+++ b/packages/neo-one-logger/src/loggers.ts
@@ -3,18 +3,23 @@ import { getPretty } from '@neo-one/logger-config';
 import pino from 'pino';
 
 const createLogger = (name: string, options: pino.LoggerOptions = {}) =>
-  pino(
-    { ...options, name, prettyPrint: getPretty() },
-    process.env.NODE_ENV === 'production' ? pino.extreme(1) : pino.destination(2),
-  );
+  options.browser !== undefined
+    ? pino({ ...options, name, prettyPrint: getPretty() })
+    : pino(
+        { ...options, name, prettyPrint: getPretty() },
+        process.env.NODE_ENV === 'production' ? pino.extreme(1) : pino.destination(2),
+      );
 
-export const editorLogger = createLogger('editor-server');
-export const serverLogger = createLogger('server');
-export const nodeLogger = createLogger('node');
-export const rpcLogger = createLogger('rpc');
-export const cliLogger = createLogger('cli');
-export const httpLogger = createLogger('http');
-export const testLogger = createLogger('test');
+// tslint:disable-next-line: strict-type-predicates
+const browserOptions = typeof window !== 'undefined' ? { browser: { asObject: true } } : {};
+
+export const editorLogger = createLogger('editor-server', browserOptions);
+export const serverLogger = createLogger('server', browserOptions);
+export const nodeLogger = createLogger('node', browserOptions);
+export const rpcLogger = createLogger('rpc', browserOptions);
+export const cliLogger = createLogger('cli', browserOptions);
+export const httpLogger = createLogger('http', browserOptions);
+export const testLogger = createLogger('test', browserOptions);
 export const loggers: readonly pino.Logger[] = [
   editorLogger,
   serverLogger,

--- a/packages/neo-one-node/src/startFullNode.ts
+++ b/packages/neo-one-node/src/startFullNode.ts
@@ -1,11 +1,11 @@
 import {
+  getNewPropagation,
   globalStats,
   JaegerTraceExporter,
   JaegerTraceExporterOptions,
   PrometheusExporterOptions,
   PrometheusStatsExporter,
   startTracing,
-  TraceContextFormat,
   TracingConfig,
 } from '@neo-one/client-switch';
 import { setGlobalLogLevel } from '@neo-one/logger';
@@ -94,7 +94,7 @@ export const startFullNode = async ({
 
         const stopTracing = startTracing({
           ...telemetry.tracing,
-          propagation: new TraceContextFormat(),
+          propagation: getNewPropagation(),
           exporter,
         });
 

--- a/scripts/website/webpack/preview.ts
+++ b/scripts/website/webpack/preview.ts
@@ -32,7 +32,7 @@ export const preview = ({ stage }: { readonly stage: Stage }): webpack.Configura
             <head>
               <meta charset="UTF-8">
               <title>${title}</title>
-              ${MiniHtmlWebpackPlugin.generateCSSReferences(css, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateCSSReferences({ files: css, publicPath })}
               <style>
                 body {
                   margin: 0;
@@ -43,7 +43,7 @@ export const preview = ({ stage }: { readonly stage: Stage }): webpack.Configura
             </head>
             <body>
               <div id="app"></div>
-              ${MiniHtmlWebpackPlugin.generateJSReferences(js, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateJSReferences({ files: js, publicPath })}
             </body>
           </html>`,
     }),

--- a/scripts/website/webpack/testRunner.ts
+++ b/scripts/website/webpack/testRunner.ts
@@ -32,7 +32,7 @@ export const testRunner = ({ stage }: { readonly stage: Stage }): webpack.Config
             <head>
               <meta charset="UTF-8">
               <title>${title}</title>
-              ${MiniHtmlWebpackPlugin.generateCSSReferences(css, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateCSSReferences({ files: css, publicPath })}
               <style>
                 body {
                   margin: 0;
@@ -43,7 +43,7 @@ export const testRunner = ({ stage }: { readonly stage: Stage }): webpack.Config
             </head>
             <body>
               <div id="app"></div>
-              ${MiniHtmlWebpackPlugin.generateJSReferences(js, publicPath)}
+              ${MiniHtmlWebpackPlugin.generateJSReferences({ files: js, publicPath })}
             </body>
           </html>`,
     }),


### PR DESCRIPTION
Fixes the website build. 

For now we add some more cache-loading to `@neo-one/client-switch/browser/tracing.ts` because importing `@opencensus/web-core` causes a tracer to start even though we don't want it to (yet). 

I think once we hook up the inital trace/spans described here https://github.com/census-instrumentation/opencensus-web this won't be necessary anymore.

Also adds a browser switch to `createLogger` options since we don't want to enable a `pino.destination` in the browser (it fails load the definition entirely when in browser)