### PR TITLE
feat(build): fix bin package.jsons

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags:
-      - \@neo-one/node-bin*
+      - '*neo-one/node-bin*'
 jobs:
   push:
     runs-on: ubuntu-18.04

--- a/actions/dockerhub/entrypoint.sh
+++ b/actions/dockerhub/entrypoint.sh
@@ -10,11 +10,14 @@ REPOSITORY=${GITHUB_REPOSITORY#*/}
 ref_tmp=${GITHUB_REF#*/} ## throw away the first part of the ref (GITHUB_REF=refs/heads/master or refs/tags/2019/03/13)
 ref_type=${ref_tmp%%/*} ## extract the second element of the ref (heads or tags)
 ref_value=${ref_tmp#*/} ## extract the third+ elements of the ref (master or 2019/03/13)
-
+echo ref_tmp
+echo ref_type
+echo ref_value
 IMAGE_TAG=${ref_value//\//-} ## replace `/` with `-` in ref for docker tag requirement (master or 2019-03-13)
 NAMESPACE=${DOCKER_NAMESPACE:-$USERNAME} ## use github username as docker namespace unless specified
 IMAGE_NAME=${DOCKER_IMAGE_NAME:-$REPOSITORY} ## use github repository name as docker image name unless specified
 REGISTRY_IMAGE="$NAMESPACE/$IMAGE_NAME"
+echo IMAGE_TAG
 
 ## login if needed
 if [ -n "${DOCKER_PASSWORD+set}" ]

--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -22,6 +22,7 @@
     "cross-fetch": "^3.0.4",
     "execa": "^2.0.4",
     "fs-extra": "^8.1.0",
+    "import-local": "^3.0.2",
     "listr": "^0.14.3",
     "source-map": "^0.7.3",
     "typescript": "^3.5.3",

--- a/packages/neo-one-client-switch/package.json
+++ b/packages/neo-one-client-switch/package.json
@@ -19,6 +19,7 @@
     "@opencensus/web-propagation-tracecontext": "^0.0.5",
     "@opencensus/web-types": "^0.0.5",
     "lodash": "^4.17.15",
+    "regenerator-runtime": "^0.13.3",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0"
   },

--- a/packages/neo-one-node-bin/package.json
+++ b/packages/neo-one-node-bin/package.json
@@ -10,6 +10,7 @@
     "@neo-one/utils": "^1.2.0",
     "@neo-one/utils-node": "^1.1.4",
     "env-paths": "^2.2.0",
+    "import-local": "^3.0.2",
     "rc": "^1.2.8",
     "tslib": "^1.10.0",
     "yargs": "^14.0.0"


### PR DESCRIPTION
Files that build a bin need to have `import-local` in their package.json.

Also add `regenerator-runtime` as a dep in `@neo-one/client-switch`, I think it was implicit before.

All of these were an issue when I made a tmp-project and ran:
```
yarn add @neo-one/suite
yarn neo-one init
```

and installing them myself fixed the issue.

## Additional information

also adding some echos for the docker file entrypoint so we can debug the tag actions, will revert.