### PR TITLE
feat(e2e): add init e2e tests

### DIFF
--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -145,7 +145,7 @@ const getProjectFramework = async (rootDir: string): Promise<CodegenFramework> =
   // tslint:disable-next-line no-any
   let pkg: any;
   try {
-    pkg = await fs.readFile(nodePath.resolve(rootDir, 'package.json'), 'utf8');
+    pkg = await fs.readJSON(nodePath.resolve(rootDir, 'package.json'));
   } catch (err) {
     if (err.code === 'ENOENT') {
       return 'none';

--- a/packages/neo-one-cli/src/__e2e__/cmd/init.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/init.test.ts
@@ -1,0 +1,144 @@
+import fs from 'fs-extra';
+import nodePath from 'path';
+
+const getPackage = (dependency: string) => ({
+  name: 'test-project',
+  version: '0.0.0',
+  dependencies: {
+    [dependency]: '0.0.0',
+  },
+});
+
+const getTSConfig = () => ({
+  compilerOptions: {
+    module: 'commonjs',
+    noImplicitAny: true,
+    removeComments: true,
+    preserveConstEnums: true,
+    sourceMap: true,
+  },
+  exclude: [],
+});
+
+const setupAndInitDirectory = async ({
+  dependency = 'none',
+  js = false,
+}: {
+  readonly dependency?: string;
+  readonly js?: boolean;
+} = {}) => {
+  const { exec: execAsync, env } = one.createCLIProject('init');
+
+  const tmpDir = env.NEO_ONE_TMP_DIR === undefined ? process.cwd() : env.NEO_ONE_TMP_DIR;
+
+  await fs.writeJSON(nodePath.join(tmpDir, 'package.json'), getPackage(dependency));
+  if (!js) {
+    await fs.writeJSON(nodePath.join(tmpDir, 'tsconfig.json'), getTSConfig());
+  }
+
+  await execAsync('init');
+
+  await Promise.all([
+    expect(fs.pathExists(nodePath.join(tmpDir, js ? '.neo-one.config.js' : '.neo-one.config.ts'))).resolves.toEqual(
+      true,
+    ),
+    expect(fs.pathExists(nodePath.join(tmpDir, 'contracts'))).resolves.toEqual(true),
+  ]);
+
+  const [neoConfig, tsConfig] = await Promise.all([
+    import(nodePath.join(tmpDir, js ? '.neo-one.config.js' : '.neo-one.config.ts')),
+    fs.readJSON(nodePath.join(tmpDir, 'tsconfig.json')).catch(() => undefined),
+  ]);
+
+  if (!js) {
+    expect(tsConfig.exclude).toEqual(['contracts/*.ts']);
+  }
+
+  return neoConfig;
+};
+
+describe('init command - no framework', () => {
+  it('does not set framework if not implied', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory();
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'none',
+      browserify: false,
+    });
+
+    expect(contracts).toEqual({
+      path: 'contracts',
+    });
+  });
+});
+
+describe('init command - js', () => {
+  it('creates a .js config when no tsconfig', async () => {
+    await setupAndInitDirectory({
+      js: true,
+    });
+  });
+});
+
+describe('init command - react', () => {
+  it('sets framework to react if package.json has react dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: 'react',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'react',
+      browserify: false,
+    });
+
+    expect(contracts).toEqual({
+      path: 'contracts',
+    });
+  });
+});
+
+describe('init command - vue', () => {
+  it('sets framework to vue if package.json has vue dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: 'vue',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'vue',
+      browserify: false,
+    });
+
+    expect(contracts).toEqual({
+      path: 'contracts',
+    });
+  });
+});
+
+describe('init command - angular', () => {
+  it('sets framework to angular if package.json has angular dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: '@angular/core',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'angular',
+      browserify: false,
+    });
+
+    expect(contracts).toEqual({
+      path: 'contracts',
+    });
+  });
+});

--- a/types/e2e.d.ts
+++ b/types/e2e.d.ts
@@ -3,14 +3,21 @@ declare interface NodeProject {
   readonly env: any;
 }
 
+declare interface CLIProject {
+  readonly exec: (command: string, options?: object) => Promise<void>;
+  readonly env: any;
+}
+
 declare interface One {
   readonly addCleanup: (callback: () => Promise<void> | void) => void;
   readonly cleanupTest: () => Promise<void>;
   readonly createExec: (project: string) => (command: string, options?: object) => Promise<string>;
   readonly createExecAsync: (project: string) => (command: string, options?: object) => void;
   readonly createNodeProject: (project: string) => NodeProject;
+  readonly createCLIProject: (project: string) => CLIProject;
   readonly until: (func: () => Promise<void>) => Promise<void>;
   readonly measureRequire: (mod: string) => Promise<number>;
   readonly getProjectConfig: (project: string) => any;
+  readonly getProjectDir: (project: string) => string;
 }
 declare const one: One;


### PR DESCRIPTION
## Description

adds e2e tests for the `neo-one init` command. 5 tests total, I can add more if needed. I put them all in 1 file but nested in describe blocks so they don't try to run asynchronously (it works out ~2x faster).

Also it seemed weird to me that we were using `fs.readFile` instead of `fs.readJSON` for package.jsons, was this intentional?