### PR TITLE
fix(suite): add smart-contract-lib to @neo-one/suite

### DIFF
--- a/packages/neo-one-suite/package.json
+++ b/packages/neo-one-suite/package.json
@@ -6,6 +6,7 @@
     "@neo-one/cli": "^1.3.0",
     "@neo-one/client": "^1.2.4",
     "@neo-one/smart-contract": "^1.1.1",
+    "@neo-one/smart-contract-lib": "^1.5.3",
     "@neo-one/smart-contract-test": "^1.2.1",
     "@neo-one/smart-contract-typescript-plugin": "^1.1.7"
   },


### PR DESCRIPTION
###

Until we remove @neo-one/smart-contract-lib in the future the suite package needs it in its packages so all of the neo-one commands can be run.