### PR TITLE
test(exchange): add exchange contract based on Switcheo for testing

### DIFF
--- a/packages/neo-one-cli/src/__data__/projects/ico/contracts/Coin.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/contracts/Coin.ts
@@ -1,0 +1,174 @@
+import {
+  Address,
+  constant,
+  Contract,
+  createEventNotifier,
+  Fixed,
+  ForwardValue,
+  MapStorage,
+  SmartContract,
+} from '@neo-one/smart-contract';
+
+const notifyTransfer = createEventNotifier<Address | undefined, Address | undefined, Fixed<8>>(
+  'transfer',
+  'from',
+  'to',
+  'amount',
+);
+const notifyApproveSendTransfer = createEventNotifier<Address, Address, Fixed<8>>(
+  'approveSendTransfer',
+  'from',
+  'to',
+  'amount',
+);
+const notifyRevokeSendTransfer = createEventNotifier<Address, Address, Fixed<8>>(
+  'revokeSendTransfer',
+  'from',
+  'to',
+  'amount',
+);
+
+interface CoinPayableContract {
+  readonly approveReceiveTransfer: (
+    from: Address,
+    amount: Fixed<8>,
+    asset: Address,
+    // tslint:disable-next-line readonly-array
+    ...args: ForwardValue[]
+  ) => boolean;
+  readonly onRevokeSendTransfer: (from: Address, amount: Fixed<8>, asset: Address) => void;
+}
+
+export class Coin extends SmartContract {
+  public readonly properties = {
+    codeVersion: '1.0',
+    author: 'dicarlo2',
+    email: 'alex.dicarlo@neotracker.io',
+    description: 'NEO•ONE Coin',
+  };
+  public readonly name = 'Two';
+  public readonly symbol = 'TWO';
+  public readonly decimals = 8;
+  private readonly balances = MapStorage.for<Address, Fixed<8>>();
+  private readonly approvedTransfers = MapStorage.for<[Address, Address], Fixed<8>>();
+  private mutableSupply: Fixed<8> = 0;
+
+  @constant
+  public get totalSupply(): Fixed<8> {
+    return this.mutableSupply;
+  }
+
+  @constant
+  public balanceOf(address: Address): Fixed<8> {
+    const balance = this.balances.get(address);
+
+    return balance === undefined ? 0 : balance;
+  }
+
+  @constant
+  public approvedTransfer(from: Address, to: Address): Fixed<8> {
+    const approved = this.approvedTransfers.get([from, to]);
+
+    return approved === undefined ? 0 : approved;
+  }
+
+  // tslint:disable-next-line readonly-array
+  public transfer(from: Address, to: Address, amount: Fixed<8>, ...approveArgs: ForwardValue[]): boolean {
+    if (amount < 0) {
+      throw new Error(`Amount must be greater than 0: ${amount}`);
+    }
+
+    const fromBalance = this.balanceOf(from);
+    if (fromBalance < amount) {
+      return false;
+    }
+
+    const approved = this.approvedTransfer(from, to);
+    const reduceApproved = approved >= amount && Address.isCaller(to);
+    if (!reduceApproved && !Address.isCaller(from)) {
+      return false;
+    }
+
+    const contract = Contract.for(to);
+    if (contract !== undefined && !Address.isCaller(to)) {
+      const smartContract = SmartContract.for<CoinPayableContract>(to);
+      if (!smartContract.approveReceiveTransfer(from, amount, this.address, ...approveArgs)) {
+        return false;
+      }
+    }
+
+    const toBalance = this.balanceOf(to);
+    this.balances.set(from, fromBalance - amount);
+    this.balances.set(to, toBalance + amount);
+    notifyTransfer(from, to, amount);
+
+    if (reduceApproved) {
+      this.approvedTransfers.set([from, to], approved - amount);
+    }
+
+    return true;
+  }
+
+  public approveSendTransfer(from: Address, to: Address, amount: Fixed<0>): boolean {
+    if (amount < 0) {
+      throw new Error(`Amount must be greater than 0: ${amount}`);
+    }
+
+    if (!Address.isCaller(from)) {
+      return false;
+    }
+
+    this.approvedTransfers.set([from, to], this.approvedTransfer(from, to) + amount);
+    notifyApproveSendTransfer(from, to, amount);
+
+    return true;
+  }
+
+  public approveReceiveTransfer(_from: Address, _amount: Fixed<8>, _asset: Address): boolean {
+    return false;
+  }
+
+  public revokeSendTransfer(from: Address, to: Address, amount: Fixed<8>): boolean {
+    if (amount < 0) {
+      throw new Error(`Amount must be greater than 0: ${amount}`);
+    }
+
+    if (!Address.isCaller(from)) {
+      return false;
+    }
+
+    const approved = this.approvedTransfer(from, to);
+    if (approved < amount) {
+      return false;
+    }
+
+    this.approvedTransfers.set([from, to], approved - amount);
+    notifyRevokeSendTransfer(from, to, amount);
+
+    const contract = Contract.for(to);
+    if (contract !== undefined) {
+      const smartContract = SmartContract.for<CoinPayableContract>(to);
+      // NOTE: This should catch errors once we have stack isolation
+      smartContract.onRevokeSendTransfer(from, amount, this.address);
+    }
+
+    return true;
+  }
+
+  public onRevokeSendTransfer(_from: Address, _amount: Fixed<8>, _asset: Address): void {
+    // do nothing
+  }
+
+  public issue(to: Address, amount: Fixed<8>): boolean {
+    if (amount < 0) {
+      throw new Error(`Amount must be greater than 0: ${amount}`);
+    }
+
+    const toBalance = this.balanceOf(to);
+    this.balances.set(to, toBalance + amount);
+    notifyTransfer(undefined, to, amount);
+    this.mutableSupply += amount;
+
+    return true;
+  }
+}

--- a/packages/neo-one-cli/src/__data__/projects/ico/contracts/CoinICO.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/contracts/CoinICO.ts
@@ -1,0 +1,87 @@
+import {
+  Address,
+  Blockchain,
+  constant,
+  Deploy,
+  Fixed,
+  Hash256,
+  Integer,
+  LinkedSmartContract,
+  receive,
+  SmartContract,
+} from '@neo-one/smart-contract';
+import { Coin } from './Coin';
+
+export class CoinICO extends SmartContract {
+  public readonly properties = {
+    codeVersion: '1.0',
+    author: 'dicarlo2',
+    email: 'alex.dicarlo@neotracker.io',
+    description: 'NEO•ONE Coin ICO',
+  };
+  public readonly amountPerNEO = 10;
+  private mutableRemaining: Fixed<8> = 10_000_000_000_00000000;
+
+  public constructor(
+    public readonly owner: Address = Deploy.senderAddress,
+    public readonly startTimeSeconds: Integer = Blockchain.currentBlockTime,
+    public readonly icoDurationSeconds: Integer = 157700000,
+  ) {
+    super();
+    if (!Address.isCaller(owner)) {
+      throw new Error('Sender was not the owner.');
+    }
+  }
+
+  @constant
+  public get remaining(): Fixed<8> {
+    return this.mutableRemaining;
+  }
+
+  @receive
+  public mintTokens(): void {
+    if (!this.hasStarted() || this.hasEnded()) {
+      throw new Error('Invalid mintTokens');
+    }
+
+    const { references } = Blockchain.currentTransaction;
+    if (references.length === 0) {
+      throw new Error('Invalid mintTokens');
+    }
+    const sender = references[0].address;
+
+    let amount = 0;
+    // tslint:disable-next-line no-loop-statement
+    for (const output of Blockchain.currentTransaction.outputs) {
+      if (output.address.equals(this.address)) {
+        if (!output.asset.equals(Hash256.NEO)) {
+          throw new Error('Invalid mintTokens');
+        }
+
+        amount += output.value * this.amountPerNEO;
+      }
+    }
+
+    if (amount > this.remaining) {
+      throw new Error('Invalid mintTokens');
+    }
+
+    if (amount === 0) {
+      throw new Error('Invalid mintTokens');
+    }
+
+    const coin = LinkedSmartContract.for<Coin>();
+    if (!coin.issue(sender, amount)) {
+      throw new Error('Invalid mintTokens');
+    }
+    this.mutableRemaining -= amount;
+  }
+
+  private hasStarted(): boolean {
+    return Blockchain.currentBlockTime >= this.startTimeSeconds;
+  }
+
+  private hasEnded(): boolean {
+    return Blockchain.currentBlockTime > this.startTimeSeconds + this.icoDurationSeconds;
+  }
+}

--- a/packages/neo-one-cli/src/__data__/projects/ico/contracts/Exchange.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/contracts/Exchange.ts
@@ -1,0 +1,347 @@
+import {
+  Address,
+  constant,
+  MapStorage,
+  crypto,
+  Integer,
+  createEventNotifier,
+  SmartContract,
+} from '@neo-one/smart-contract';
+
+const notifyDeposited = createEventNotifier<Address, Address, Integer>('deposited', 'address', 'assetID', 'amount');
+const notifyWithdrawn = createEventNotifier<Address, Address, Integer>('withdrawn', 'address', 'assetID', 'amount');
+const notifyOfferCreated = createEventNotifier<Address, Address, Integer, Address, Integer, Buffer>(
+  'offerCreated',
+  'makerAddress',
+  'offerAssetID',
+  'offerAmount',
+  'wantAssetID',
+  'wantAmount',
+  'offerHash',
+);
+const notifyOfferCancelled = createEventNotifier<Buffer>('offerCancelled', 'offerHash');
+// const notifyBurnt = createEventNotifier<Address, Address, Integer>(
+//   'burnt',
+//   'filler',
+//   'takerFeeAssetID',
+//   'takerFeeAmount',
+// );
+const notifyFilled = createEventNotifier<Address, Buffer, Integer, Address, Integer, Address, Integer, Integer>(
+  'offerFilled',
+  'filler',
+  'offerHash',
+  'amountToFill',
+  'offerAssetID',
+  'offerAmount',
+  'wantAssetID',
+  'wantAmount',
+  'amountToTake',
+);
+
+interface NEP5 {
+  readonly transfer: (from: Address, to: Address, amount: Integer) => boolean;
+}
+
+type Offer = {
+  readonly maker: Address;
+  readonly offerAssetID: Address;
+  readonly offerAmount: Integer;
+  readonly wantAssetID: Address;
+  readonly wantAmount: Integer;
+  // readonly makerFeeAssetID: Address;
+  // readonly makerFeeAvailableAmount: Integer;
+  readonly nonce: string;
+};
+
+const STATE_PENDING = 0x00;
+const STATE_ACTIVE = 0x01;
+const STATE_INACTIVE = 0x02;
+
+// Based on the Switcheo BrokerContract: https://github.com/Switcheo/switcheo-neo
+export class Exchange extends SmartContract {
+  public readonly properties = {
+    codeVersion: '1.0',
+    author: 'dicarlo2',
+    email: 'alex.dicarlo@neotracker.io',
+    description: 'Exchange',
+  };
+  private mutableInitState: typeof STATE_PENDING | typeof STATE_ACTIVE | typeof STATE_INACTIVE = STATE_PENDING;
+  // private mutableFeeAddress: Address | undefined;
+  private readonly balances = MapStorage.for<[Address, Address], Integer>();
+  private readonly offers = MapStorage.for<Buffer, Offer>();
+
+  public initialize(): boolean {
+    if (this.mutableInitState !== STATE_PENDING) return false;
+
+    // this.mutableFeeAddress = feeAddress;
+    this.mutableInitState = STATE_ACTIVE;
+
+    return true;
+  }
+
+  @constant
+  public balanceOf(address: Address, assetID: Address): Integer {
+    const balance = this.balances.get([address, assetID]);
+
+    return balance === undefined ? 0 : balance;
+  }
+
+  @constant
+  public getOffer(offerHash: Buffer): Offer | undefined {
+    return this.offers.get(offerHash);
+  }
+
+  public deposit(originator: Address, assetID: Address, amount: Integer): boolean {
+    if (this.receivedNEP5(originator, assetID, amount)) {
+      return this.transferNEP5(originator, this.address, assetID, amount);
+    }
+
+    return false;
+  }
+
+  public withdraw(originator: Address, assetID: Address, amount: Integer): boolean {
+    if (this.mutableInitState !== STATE_ACTIVE) return false;
+    if (amount < 0) throw new Error(`Amount must be greater than 0: ${amount}`);
+    if (!this.checkBalance(originator, assetID, amount)) throw new Error(`Insufficient balance to withdraw ${amount}`);
+    if (!Address.isCaller(originator)) return false;
+
+    this.changeBalance(originator, assetID, amount, 'decrease');
+    notifyWithdrawn(originator, assetID, amount);
+
+    return this.transferNEP5(this.address, originator, assetID, amount);
+  }
+
+  public makeOffer(
+    maker: Address,
+    offerAssetID: Address,
+    offerAmount: Integer,
+    wantAssetID: Address,
+    wantAmount: Integer,
+    // makerFeeAssetID: Address,
+    // makerFeeAvailableAmount: Integer,
+    nonce: string,
+  ): boolean {
+    // Check that transaction is called/signed by the maker
+    if (!Address.isCaller(maker)) return false;
+    // Check that the offer does not already exist
+    const offerHash = this.getOfferHash(
+      maker,
+      offerAssetID,
+      offerAmount,
+      wantAssetID,
+      wantAmount,
+      // makerFeeAssetID,
+      // makerFeeAvailableAmount,
+      nonce,
+    );
+    if (this.getOffer(offerHash) !== undefined) return false;
+    // Check that amounts > 0
+    if (offerAmount <= 0 || wantAmount <= 0) return false;
+    // Check that the trade is across different assets
+    if (offerAssetID === wantAssetID) return false;
+    // Check fees
+    // if (makerFeeAvailableAmount < 0) return false;
+    // Reduce available balance for the offered asset and amount
+    this.changeBalance(maker, offerAssetID, offerAmount, 'decrease');
+    // Reserve fees from the maker fee asset only if it is different from want asset
+    // if (makerFeeAssetID !== wantAssetID && makerFeeAvailableAmount > 0) {
+    //   // Reduce fees here separately as it is a different asset type
+    //   this.changeBalance(maker, makerFeeAssetID, makerFeeAvailableAmount, 'decrease');
+    // }
+    // Add the offer to storage
+    this.offers.set(offerHash, {
+      maker,
+      offerAssetID,
+      offerAmount,
+      wantAssetID,
+      wantAmount,
+      // makerFeeAssetID,
+      // makerFeeAvailableAmount,
+      nonce,
+    });
+    notifyOfferCreated(maker, offerAssetID, offerAmount, wantAssetID, wantAmount, offerHash);
+
+    return true;
+  }
+
+  public fillOffer(
+    filler: Address,
+    offerHash: Buffer,
+    amountToTake: Integer,
+    // takerFeeAssetID: Address,
+    // takerFeeAmount: Integer,
+    // burnTakerFee: boolean,
+    // makerFeeAmount: Integer,
+    // burnMakerFee: boolean,
+  ): boolean {
+    // Check that transaction is called/signed by the filler
+    if (!Address.isCaller(filler)) return false;
+    // Check fees
+    // if (takerFeeAmount < 0) return false;
+    // if (makerFeeAmount < 0) return false;
+    // Check that the offer still exists
+    const offer = this.getOffer(offerHash);
+    if (offer === undefined) return false;
+    // Check that the filler is different from the maker
+    if (filler === offer.maker) return false;
+    // Check that the amount that will be taken is at least 1
+    if (amountToTake < 1) return false;
+    // Check that you cannot take more than available
+    if (amountToTake > offer.offerAmount) return false;
+    // Calculate amount we have to give the offerer (what the offerer wants)
+    const amountToFill = (amountToTake * offer.wantAmount) / offer.offerAmount;
+    if (amountToFill < 1) return false;
+    // Check that there is enough balance to reduce for filler
+    const wantAssetBalance = this.balanceOf(filler, offer.wantAssetID);
+    if (wantAssetBalance < amountToFill) return false;
+    // Check if we should deduct fees separately from the taker amount & there is enough balance in native fees if using native fees
+    // const deductTakerFeesSeparately = takerFeeAssetID !== offer.offerAssetID;
+    // const feeAssetBalance = this.balanceOf(filler, takerFeeAssetID);
+    // if (deductTakerFeesSeparately && takerFeeAmount > 0 && feeAssetBalance <= takerFeeAmount) return false;
+    // Check that maker fee does not exceed remaining amount that can be deducted as maker fees
+    // if (offer.makerFeeAvailableAmount < makerFeeAmount) return false;
+    // Check if we should deduct fees separately from the maker receiving amount
+    // const deductMakerFeesSeparately = offer.makerFeeAssetID !== offer.wantAssetID;
+
+    // Reduce balance from filler
+    this.changeBalance(filler, offer.wantAssetID, amountToFill, 'decrease');
+    // Move filled asset to the maker balance (reduce fees if needed)
+    // const amountForMakerAfterFees = deductMakerFeesSeparately ? amountToFill : amountToFill - makerFeeAmount;
+    this.changeBalance(offer.maker, offer.wantAssetID, amountToFill, 'increase');
+    // Move taken asset to the taker balance
+    // const amountToTakeAfterFees = deductTakerFeesSeparately ? amountToTake : amountToTake - takerFeeAmount;
+    this.changeBalance(filler, offer.offerAssetID, amountToTake, 'increase');
+
+    // Move fees
+    // if (takerFeeAmount > 0) {
+    // if (deductTakerFeesSeparately) {
+    //   // Reduce fees here from contract balance separately as it is a different asset type
+    //   this.changeBalance(filler, takerFeeAssetID, takerFeeAmount, 'decrease');
+    // }
+    // if (burnTakerFee) {
+    //   // Emit burnt event for easier client tracking
+    //   // notifyBurnt(filler, takerFeeAssetID, takerFeeAmount);
+    // } else {
+    // Only increase fee address balance if not burning
+    // this.changeBalance(this.getFeeAddress(), takerFeeAssetID, takerFeeAmount, 'increase');
+    // }
+    // }
+    // if (makerFeeAmount > 0) {
+    //   // Reduce from available maker fees here
+    //   const makerFeeAvailableAmount = offer.makerFeeAvailableAmount - makerFeeAmount;
+    //   this.offers.set(offerHash, { ...offer, makerFeeAvailableAmount });
+
+    //   if (burnMakerFee) {
+    //     // Emit burnt event for easier client tracking
+    //     notifyBurnt(filler, offer.makerFeeAssetID, makerFeeAmount);
+    //   } else {
+    //     // Only increase fee address balance if not burning
+    //     this.changeBalance(this.getFeeAddress(), offer.makerFeeAssetID, makerFeeAmount, 'increase');
+    //   }
+    // }
+    const offerAmount = offer.offerAmount - amountToTake;
+    const wantAmount = offer.wantAmount - amountToFill;
+    if (offerAmount === 0) {
+      this.offers.delete(offerHash);
+    } else {
+      this.offers.set(offerHash, { ...offer, offerAmount, wantAmount });
+    }
+    notifyFilled(
+      filler,
+      offerHash,
+      amountToFill,
+      offer.offerAssetID,
+      offer.offerAmount,
+      offer.wantAssetID,
+      offer.wantAmount,
+      amountToTake,
+    );
+
+    return true;
+  }
+
+  public cancelOffer(maker: Address, offerHash: Buffer): boolean {
+    if (!Address.isCaller(maker)) return false;
+
+    const offer = this.getOffer(offerHash);
+    if (offer === undefined) return false;
+
+    this.changeBalance(maker, offer.offerAssetID, offer.offerAmount, 'increase');
+    this.offers.delete(offerHash);
+    notifyOfferCancelled(offerHash);
+
+    return true;
+  }
+
+  private getOfferHash(
+    maker: Address,
+    offerAssetID: Address,
+    offerAmount: Integer,
+    wantAssetID: Address,
+    wantAmount: Integer,
+    // makerFeeAssetID: Address,
+    // makerFeeAvailableAmount: Integer,
+    nonce: string,
+  ): Buffer {
+    const offerBuffer = Buffer.concat([
+      maker,
+      offerAssetID,
+      wantAssetID,
+      // makerFeeAssetID,
+      Buffer.from(
+        [
+          offerAmount,
+          wantAmount,
+          // makerFeeAvailableAmount
+        ].toString(),
+      ),
+      Buffer.from(nonce),
+    ]);
+
+    return crypto.hash256(offerBuffer);
+  }
+
+  private checkBalance(address: Address, assetID: Address, balanceNeeded: Integer): boolean {
+    const balance = this.balanceOf(address, assetID);
+
+    if (balance < balanceNeeded) return false;
+
+    return true;
+  }
+
+  private changeBalance(address: Address, assetID: Address, amount: Integer, direction: 'increase' | 'decrease'): void {
+    const balance = this.balanceOf(address, assetID);
+    const newBalance = direction === 'increase' ? balance + amount : balance - amount;
+    this.balances.set([address, assetID], newBalance);
+  }
+
+  private receivedNEP5(originator: Address, assetID: Address, amount: Integer): boolean {
+    // Verify that deposit is authorized
+    if (!Address.isCaller(originator)) return false;
+    if (this.mutableInitState !== STATE_ACTIVE) return false;
+
+    // Check amount
+    if (amount < 1) return false;
+
+    // Update balances first
+    this.changeBalance(originator, assetID, amount, 'increase');
+    notifyDeposited(originator, assetID, amount);
+
+    return true;
+  }
+
+  private transferNEP5(from: Address, to: Address, assetID: Address, amount: Integer): boolean {
+    const nep5Asset = SmartContract.for<NEP5>(assetID);
+    if (!nep5Asset.transfer(from, to, amount)) {
+      throw new Error('Failed to transfer NEP-5 tokens!');
+    }
+
+    return true;
+  }
+
+  // private getFeeAddress(): Address {
+  //   if (this.mutableFeeAddress === undefined) throw new Error('Fee Address has not been set!');
+
+  //   return this.mutableFeeAddress;
+  // }
+}

--- a/packages/neo-one-cli/src/__e2e__/cmd/__snapshots__/build.test.ts.snap
+++ b/packages/neo-one-cli/src/__e2e__/cmd/__snapshots__/build.test.ts.snap
@@ -4,6 +4,14 @@ exports[`build is a one stop command for local development of the ico project: m
 
 exports[`build is a one stop command for local development of the ico project: mint consumed 2`] = `"0"`;
 
+exports[`build is a one stop command for local development of the ico project: mint consumed 3`] = `"0"`;
+
+exports[`build is a one stop command for local development of the ico project: mint consumed 4`] = `"0"`;
+
 exports[`build is a one stop command for local development of the ico project: mint cost 1`] = `"6.657"`;
 
 exports[`build is a one stop command for local development of the ico project: mint cost 2`] = `"6.657"`;
+
+exports[`build is a one stop command for local development of the ico project: mint cost 3`] = `"6.657"`;
+
+exports[`build is a one stop command for local development of the ico project: mint cost 4`] = `"6.657"`;

--- a/packages/neo-one-cli/src/__e2e__/cmd/build.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/build.test.ts
@@ -30,6 +30,22 @@ describe('build', () => {
       expect(contract.dynamicInvoke).toBeFalsy();
     };
 
+    const verifyCoinICOContract = (contract?: Contract): void => {
+      expect(contract).toBeDefined();
+      if (contract === undefined) {
+        throw new Error('For TS');
+      }
+      expect(contract.codeVersion).toEqual('1.0');
+      expect(contract.author).toEqual('dicarlo2');
+      expect(contract.email).toEqual('alex.dicarlo@neotracker.io');
+      expect(contract.description).toEqual('NEO•ONE Coin ICO');
+      expect(contract.parameters).toEqual(['String', 'Array']);
+      expect(contract.returnType).toEqual('Buffer');
+      expect(contract.payable).toBeTruthy();
+      expect(contract.storage).toBeTruthy();
+      expect(contract.dynamicInvoke).toBeFalsy();
+    };
+
     const verifyTokenContract = (contract?: Contract): void => {
       expect(contract).toBeDefined();
       if (contract === undefined) {
@@ -39,6 +55,22 @@ describe('build', () => {
       expect(contract.author).toEqual('dicarlo2');
       expect(contract.email).toEqual('alex.dicarlo@neotracker.io');
       expect(contract.description).toEqual('NEO•ONE Token');
+      expect(contract.parameters).toEqual(['String', 'Array']);
+      expect(contract.returnType).toEqual('Buffer');
+      expect(contract.payable).toBeFalsy();
+      expect(contract.storage).toBeTruthy();
+      expect(contract.dynamicInvoke).toBeTruthy();
+    };
+
+    const verifyCoinContract = (contract?: Contract): void => {
+      expect(contract).toBeDefined();
+      if (contract === undefined) {
+        throw new Error('For TS');
+      }
+      expect(contract.codeVersion).toEqual('1.0');
+      expect(contract.author).toEqual('dicarlo2');
+      expect(contract.email).toEqual('alex.dicarlo@neotracker.io');
+      expect(contract.description).toEqual('NEO•ONE Coin');
       expect(contract.parameters).toEqual(['String', 'Array']);
       expect(contract.returnType).toEqual('Buffer');
       expect(contract.payable).toBeFalsy();
@@ -62,47 +94,23 @@ describe('build', () => {
       expect(contract.dynamicInvoke).toBeTruthy();
     };
 
-    const verifySmartContracts = async (
-      ico: any,
-      token: any,
-      escrow: any,
-      accountID: UserAccountID,
-      toAccountID: UserAccountID,
-      nowSeconds: number,
-      developerClient?: DeveloperClient,
-    ): Promise<void> => {
-      const [
-        name,
-        symbol,
-        decimals,
-        amountPerNEO,
-        icoOwner,
-        startTimeSeconds,
-        icoDurationSeconds,
-        initialTotalSupply,
-        [initialRemaining, initialBalance],
-      ] = await Promise.all([
-        token.name(),
-        token.symbol(),
-        token.decimals(),
-        ico.amountPerNEO(),
-        ico.owner(),
-        ico.startTimeSeconds(),
-        ico.icoDurationSeconds(),
-        token.totalSupply(),
-        Promise.all([ico.remaining(), token.balanceOf(accountID.address)]),
-      ]);
-      expect(name).toEqual('One');
-      expect(symbol).toEqual('ONE');
-      expect(decimals.toString()).toEqual('8');
-      expect(amountPerNEO.toString()).toEqual('10');
-      expect(icoOwner).toEqual(accountID.address);
-      expect(startTimeSeconds.gte(new BigNumber(nowSeconds))).toBeTruthy();
-      expect(icoDurationSeconds.toString()).toEqual('157700000');
-      expect(initialTotalSupply.toString()).toEqual('0');
-      expect(initialRemaining.toString()).toEqual(new BigNumber(10_000_000_000).toString());
-      expect(initialBalance.toString()).toEqual('0');
+    const verifyExchangeContract = (contract?: Contract): void => {
+      expect(contract).toBeDefined();
+      if (contract === undefined) {
+        throw new Error('For TS');
+      }
+      expect(contract.codeVersion).toEqual('1.0');
+      expect(contract.author).toEqual('dicarlo2');
+      expect(contract.email).toEqual('alex.dicarlo@neotracker.io');
+      expect(contract.description).toEqual('Exchange');
+      expect(contract.parameters).toEqual(['String', 'Array']);
+      expect(contract.returnType).toEqual('Buffer');
+      expect(contract.payable).toBeFalsy();
+      expect(contract.storage).toBeTruthy();
+      // expect(contract.dynamicInvoke).toBeTruthy();
+    };
 
+    const mintTokens = async (ico: any, accountID: UserAccountID, developerClient?: DeveloperClient): Promise<void> => {
       const mintResult = await ico.mintTokens({
         sendTo: [
           {
@@ -133,27 +141,93 @@ describe('build', () => {
       expect(event.parameters.from).toBeUndefined();
       expect(event.parameters.to).toEqual(accountID.address);
       expect(event.parameters.amount.toString()).toEqual('100');
+    };
 
-      await verifySmartContractAfterMint(ico, token, escrow, accountID, toAccountID, developerClient);
+    const verifySmartContracts = async (
+      ico: any,
+      coinICO: any,
+      token: any,
+      coin: any,
+      escrow: any,
+      exchange: any,
+      accountID: UserAccountID,
+      toAccountID: UserAccountID,
+      nowSeconds: number,
+      developerClient?: DeveloperClient,
+    ): Promise<void> => {
+      const [
+        name,
+        symbol,
+        decimals,
+        coinName,
+        coinSymbol,
+        amountPerNEO,
+        icoOwner,
+        startTimeSeconds,
+        icoDurationSeconds,
+        initialTotalSupply,
+        [initialRemaining, initialBalance],
+        initExchangeResult,
+        initialExchangeBalance,
+      ] = await Promise.all([
+        token.name(),
+        token.symbol(),
+        token.decimals(),
+        coin.name(),
+        coin.symbol(),
+        ico.amountPerNEO(),
+        ico.owner(),
+        ico.startTimeSeconds(),
+        ico.icoDurationSeconds(),
+        token.totalSupply(),
+        Promise.all([ico.remaining(), token.balanceOf(accountID.address)]),
+        exchange.initialize.confirmed(),
+        exchange.balanceOf(accountID.address, token.definition.networks[accountID.network].address),
+      ]);
+
+      expect(name).toEqual('One');
+      expect(symbol).toEqual('ONE');
+      expect(decimals.toString()).toEqual('8');
+      expect(coinName).toEqual('Two');
+      expect(coinSymbol).toEqual('TWO');
+      expect(amountPerNEO.toString()).toEqual('10');
+      expect(icoOwner).toEqual(accountID.address);
+      expect(startTimeSeconds.gte(new BigNumber(nowSeconds))).toBeTruthy();
+      expect(icoDurationSeconds.toString()).toEqual('157700000');
+      expect(initialTotalSupply.toString()).toEqual('0');
+      expect(initialRemaining.toString()).toEqual(new BigNumber(10_000_000_000).toString());
+      expect(initialBalance.toString()).toEqual('0');
+      expect(initExchangeResult.result.value).toEqual(true);
+      expect(initialExchangeBalance.toString()).toEqual('0');
+
+      await mintTokens(ico, accountID, developerClient);
+      await mintTokens(coinICO, accountID, developerClient);
+
+      await verifySmartContractAfterMint(ico, token, coin, escrow, exchange, accountID, toAccountID, developerClient);
     };
 
     const verifySmartContractTesting = async (codegenPath: string, nowSeconds: number) => {
       // tslint:disable-next-line no-require-imports
       const test = require(nodePath.resolve(codegenPath, 'test'));
-      await test.withContracts(async ({ ico, token, escrow, masterAccountID, networkName, client }: any) => {
-        await client.providers.memory.keystore.addUserAccount({
-          network: networkName,
-          privateKey: TO_PRIVATE_KEY,
-        });
-        await verifySmartContracts(
-          ico,
-          token,
-          escrow,
-          masterAccountID,
-          { network: networkName, address: privateKeyToAddress(TO_PRIVATE_KEY) },
-          nowSeconds,
-        );
-      });
+      await test.withContracts(
+        async ({ ico, coinIco, token, coin, escrow, exchange, masterAccountID, networkName, client }: any) => {
+          await client.providers.memory.keystore.addUserAccount({
+            network: networkName,
+            privateKey: TO_PRIVATE_KEY,
+          });
+          await verifySmartContracts(
+            ico,
+            coinIco,
+            token,
+            coin,
+            escrow,
+            exchange,
+            masterAccountID,
+            { network: networkName, address: privateKeyToAddress(TO_PRIVATE_KEY) },
+            nowSeconds,
+          );
+        },
+      );
     };
 
     const getGeneratedICOCode = (
@@ -169,6 +243,23 @@ describe('build', () => {
       // tslint:disable-next-line no-require-imports
       const contract = require(nodePath.resolve(dataRoot, 'ICO', 'contract'));
       const createSmartContract = contract.createICOSmartContract;
+
+      return { abi, contract: { createSmartContract } };
+    };
+
+    const getGeneratedCoinICOCode = (
+      dataRoot: string,
+    ): {
+      readonly abi: ABI;
+      readonly contract: {
+        readonly createSmartContract: (client: Client) => any;
+      };
+    } => {
+      // tslint:disable-next-line no-require-imports
+      const abi = require(nodePath.resolve(dataRoot, 'CoinICO', 'abi')).coinIcoABI;
+      // tslint:disable-next-line no-require-imports
+      const contract = require(nodePath.resolve(dataRoot, 'CoinICO', 'contract'));
+      const createSmartContract = contract.createCoinICOSmartContract;
 
       return { abi, contract: { createSmartContract } };
     };
@@ -190,6 +281,23 @@ describe('build', () => {
       return { abi, contract: { createSmartContract } };
     };
 
+    const getGeneratedCoinCode = (
+      dataRoot: string,
+    ): {
+      readonly abi: ABI;
+      readonly contract: {
+        readonly createSmartContract: (client: Client) => any;
+      };
+    } => {
+      // tslint:disable-next-line no-require-imports
+      const abi = require(nodePath.resolve(dataRoot, 'Coin', 'abi')).coinABI;
+      // tslint:disable-next-line no-require-imports
+      const contract = require(nodePath.resolve(dataRoot, 'Coin', 'contract'));
+      const createSmartContract = contract.createCoinSmartContract;
+
+      return { abi, contract: { createSmartContract } };
+    };
+
     const getGeneratedEscrowCode = (
       dataRoot: string,
     ): {
@@ -203,6 +311,23 @@ describe('build', () => {
       // tslint:disable-next-line no-require-imports
       const contract = require(nodePath.resolve(dataRoot, 'Escrow', 'contract'));
       const createSmartContract = contract.createEscrowSmartContract;
+
+      return { abi, contract: { createSmartContract } };
+    };
+
+    const getGeneratedExchangeCode = (
+      dataRoot: string,
+    ): {
+      readonly abi: ABI;
+      readonly contract: {
+        readonly createSmartContract: (client: Client) => any;
+      };
+    } => {
+      // tslint:disable-next-line no-require-imports
+      const abi = require(nodePath.resolve(dataRoot, 'Exchange', 'abi')).exchangeABI;
+      // tslint:disable-next-line no-require-imports
+      const contract = require(nodePath.resolve(dataRoot, 'Exchange', 'contract'));
+      const createSmartContract = contract.createExchangeSmartContract;
 
       return { abi, contract: { createSmartContract } };
     };
@@ -227,36 +352,67 @@ describe('build', () => {
       } = getGeneratedICOCode(dataRoot);
       expect(icoABI).toBeDefined();
       const {
+        abi: coinIcoABI,
+        contract: { createSmartContract: createCoinICOSmartContract },
+      } = getGeneratedCoinICOCode(dataRoot);
+      expect(coinIcoABI).toBeDefined();
+      const {
         abi: tokenABI,
         contract: { createSmartContract: createTokenSmartContract },
       } = getGeneratedTokenCode(dataRoot);
       expect(tokenABI).toBeDefined();
       const {
+        abi: coinABI,
+        contract: { createSmartContract: createCoinSmartContract },
+      } = getGeneratedCoinCode(dataRoot);
+      expect(coinABI).toBeDefined();
+      const {
         abi: escrowABI,
         contract: { createSmartContract: createEscrowSmartContract },
       } = getGeneratedEscrowCode(dataRoot);
       expect(escrowABI).toBeDefined();
+      const {
+        abi: exchangeABI,
+        contract: { createSmartContract: createExchangeSmartContract },
+      } = getGeneratedExchangeCode(dataRoot);
+      expect(exchangeABI).toBeDefined();
 
       const { createClient, createDeveloperClients } = getGeneratedCommonCode(dataRoot);
       const client = createClient();
       const developerClient = createDeveloperClients().local;
 
       const ico = createICOSmartContract(client);
+      const coinICO = createCoinICOSmartContract(client);
       const token = createTokenSmartContract(client);
+      const coin = createCoinSmartContract(client);
       const escrow = createEscrowSmartContract(client);
+      const exchange = createExchangeSmartContract(client);
 
       await client.providers.memory.keystore.addUserAccount({
         network: accountID.network,
         privateKey: TO_PRIVATE_KEY,
       });
 
-      await verifySmartContracts(ico, token, escrow, accountID, toAccountID, nowSeconds, developerClient);
+      await verifySmartContracts(
+        ico,
+        coinICO,
+        token,
+        coin,
+        escrow,
+        exchange,
+        accountID,
+        toAccountID,
+        nowSeconds,
+        developerClient,
+      );
     };
 
     const verifySmartContractAfterMint = async (
       ico: any,
       token: any,
+      coin: any,
       escrow: any,
+      exchange: any,
       accountID: UserAccountID,
       toAccountID: UserAccountID,
       developerClient?: DeveloperClient,
@@ -356,6 +512,157 @@ describe('build', () => {
       expect(balanceAfterClaim.toString()).toEqual('50');
       expect(toBalanceAfterClaim.toString()).toEqual('35');
       expect(escrowPairBalanceAfterClaim.toString()).toEqual('15');
+
+      await verifySmartContractExchange(token, coin, exchange, accountID, toAccountID, developerClient);
+    };
+
+    const verifySmartContractExchange = async (
+      token: any,
+      coin: any,
+      exchange: any,
+      accountID: UserAccountID,
+      toAccountID: UserAccountID,
+      developerClient?: DeveloperClient,
+    ): Promise<void> => {
+      const tokenAssetID = token.definition.networks[accountID.network].address;
+      const coinAssetID = coin.definition.networks[accountID.network].address;
+      const exchangeAddress = exchange.definition.networks[accountID.network].address;
+
+      const approveDepositReceipt = await token.approveSendTransfer.confirmed(
+        accountID.address,
+        exchangeAddress,
+        new BigNumber(10_00000000),
+      );
+      expect(approveDepositReceipt.result.value).toEqual(true);
+
+      const [exchangeDepositReceipt] = await Promise.all([
+        exchange.deposit.confirmed(accountID.address, tokenAssetID, new BigNumber(10_00000000)),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(exchangeDepositReceipt.result.value).toEqual(true);
+      expect(exchangeDepositReceipt.events).toHaveLength(1);
+
+      const [balanceAfterDeposit, exchangeBalanceAfterDeposit, tokensDeposited] = await Promise.all([
+        token.balanceOf(accountID.address),
+        token.balanceOf(exchangeAddress),
+        exchange.balanceOf(accountID.address, tokenAssetID),
+      ]);
+      expect(balanceAfterDeposit.toString()).toEqual('40');
+      expect(exchangeBalanceAfterDeposit.toString()).toEqual('10');
+      expect(tokensDeposited.toString()).toEqual('1000000000');
+
+      const [exchangeWithdrawalReceipt] = await Promise.all([
+        exchange.withdraw.confirmed(accountID.address, tokenAssetID, new BigNumber(4_00000000)),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+
+      expect(exchangeWithdrawalReceipt.result.value).toEqual(true);
+      expect(exchangeWithdrawalReceipt.events).toHaveLength(1);
+
+      const [balanceAfterWithdraw, exchangeBalanceAfterWithdraw, tokensWithdrawn] = await Promise.all([
+        token.balanceOf(accountID.address),
+        token.balanceOf(exchangeAddress),
+        exchange.balanceOf(accountID.address, tokenAssetID),
+      ]);
+      expect(balanceAfterWithdraw.toString()).toEqual('44');
+      expect(exchangeBalanceAfterWithdraw.toString()).toEqual('6');
+      expect(tokensWithdrawn.toString()).toEqual('600000000');
+
+      const [coinTransferReceipt, approveCoinDepositReceipt] = await Promise.all([
+        coin.transfer.confirmed(accountID.address, toAccountID.address, new BigNumber(100)),
+        coin.approveSendTransfer.confirmed(toAccountID.address, exchangeAddress, new BigNumber(70_00000000), {
+          from: toAccountID,
+        }),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(coinTransferReceipt.result.value).toEqual(true);
+      expect(approveCoinDepositReceipt.result.value).toEqual(true);
+
+      const [exchangeCoinDepositReceipt] = await Promise.all([
+        exchange.deposit.confirmed(toAccountID.address, coinAssetID, new BigNumber(70_00000000), { from: toAccountID }),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(exchangeCoinDepositReceipt.result.value).toEqual(true);
+
+      const [coinBalanceAfterDeposit, exchangeCoinBalanceAfterDeposit, coinsDeposited] = await Promise.all([
+        coin.balanceOf(toAccountID.address),
+        coin.balanceOf(exchangeAddress),
+        exchange.balanceOf(toAccountID.address, coinAssetID),
+      ]);
+      expect(coinBalanceAfterDeposit.toString()).toEqual('30');
+      expect(exchangeCoinBalanceAfterDeposit.toString()).toEqual('70');
+      expect(coinsDeposited.toString()).toEqual('7000000000');
+
+      const [makeOfferReceipt] = await Promise.all([
+        exchange.makeOffer.confirmed(
+          accountID.address,
+          tokenAssetID,
+          new BigNumber(5_00000000),
+          coinAssetID,
+          new BigNumber(50_00000000),
+          // tokenAssetID,
+          // new BigNumber(1_00000000),
+          'nonce1',
+        ),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(makeOfferReceipt.result.value).toEqual(true);
+      const offerHash = makeOfferReceipt.events[0].parameters.offerHash;
+      expect(offerHash).toBeDefined();
+
+      const offer = await exchange.getOffer(offerHash);
+      expect(offer.maker).toEqual(accountID.address);
+      expect(offer.offerAssetID).toEqual(tokenAssetID);
+      expect(offer.offerAmount.toString()).toEqual('500000000');
+      expect(offer.wantAssetID).toEqual(coinAssetID);
+      expect(offer.wantAmount.toString()).toEqual('5000000000');
+      // expect(offer.makerFeeAssetID).toEqual(tokenAssetID);
+      // expect(offer.makerFeeAvailableAmount.toString()).toEqual('100000000');
+      expect(offer.nonce).toEqual('nonce1');
+
+      const [fillOfferReceipt] = await Promise.all([
+        exchange.fillOffer.confirmed(toAccountID.address, offerHash, new BigNumber(3_00000000), { from: toAccountID }),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(fillOfferReceipt.result.value).toEqual(true);
+
+      const [
+        exchangeMakerTokenBalanceAfterFill,
+        exchangeTakerTokenBalanceAfterFill,
+        exchangeMakerCoinBalanceAfterFill,
+        exchangeTakerCoinBalanceAfterFill,
+        offerAfterFill,
+      ] = await Promise.all([
+        exchange.balanceOf(accountID.address, tokenAssetID),
+        exchange.balanceOf(toAccountID.address, tokenAssetID),
+        exchange.balanceOf(accountID.address, coinAssetID),
+        exchange.balanceOf(toAccountID.address, coinAssetID),
+        exchange.getOffer(offerHash),
+      ]);
+      expect(exchangeMakerTokenBalanceAfterFill.toString()).toEqual('100000000');
+      expect(exchangeTakerTokenBalanceAfterFill.toString()).toEqual('300000000');
+      expect(exchangeMakerCoinBalanceAfterFill.toString()).toEqual('3000000000');
+      expect(exchangeTakerCoinBalanceAfterFill.toString()).toEqual('4000000000');
+      expect(offerAfterFill.maker).toEqual(accountID.address);
+      expect(offerAfterFill.offerAssetID).toEqual(tokenAssetID);
+      expect(offerAfterFill.offerAmount.toString()).toEqual('200000000');
+      expect(offerAfterFill.wantAssetID).toEqual(coinAssetID);
+      expect(offerAfterFill.wantAmount.toString()).toEqual('2000000000');
+      // expect(offerAfterFill.makerFeeAssetID).toEqual(tokenAssetID);
+      // expect(offerAfterFill.makerFeeAvailableAmount.toString()).toEqual('100000000');
+      expect(offerAfterFill.nonce).toEqual('nonce1');
+
+      const [cancelOfferReceipt] = await Promise.all([
+        exchange.cancelOffer.confirmed(accountID.address, offerHash),
+        developerClient === undefined ? Promise.resolve() : developerClient.runConsensusNow(),
+      ]);
+      expect(cancelOfferReceipt.result.value).toEqual(true);
+      const [exchangeMakerTokenBalanceAfterCancel, offerAfterCancel] = await Promise.all([
+        exchange.balanceOf(accountID.address, tokenAssetID),
+        exchange.getOffer(offerHash),
+      ]);
+      expect(exchangeMakerTokenBalanceAfterCancel.toString()).toEqual('300000000');
+      expect(offerAfterCancel).toEqual(undefined);
     };
 
     const start = Math.round(Date.now() / 1000);
@@ -368,8 +675,11 @@ describe('build', () => {
     const [{ client: outerClient }, config] = await Promise.all([getClients('ico'), one.getProjectConfig('ico')]);
     const contracts = await getContracts(outerClient, constants.LOCAL_NETWORK_NAME);
     verifyICOContract(contracts.find((contract) => contract.name === 'ICO'));
+    verifyCoinICOContract(contracts.find((contract) => contract.name === 'CoinICO'));
     verifyTokenContract(contracts.find((contract) => contract.name === 'Token'));
+    verifyCoinContract(contracts.find((contract) => contract.name === 'Coin'));
     verifyEscrowContract(contracts.find((contract) => contract.name === 'Escrow'));
+    verifyExchangeContract(contracts.find((contract) => contract.name === 'Exchange'));
 
     await Promise.all([
       verifySmartContractTesting(config.codegen.path, start),

--- a/packages/neo-one-smart-contract/src/index.d.ts
+++ b/packages/neo-one-smart-contract/src/index.d.ts
@@ -1096,6 +1096,39 @@ export interface DeployConstructor {
  * @param name Event name
  * @param argName Event argument name
  */
+export function createEventNotifier<A0, A1, A2, A3, A4, A5, A6, A7, A8>(
+  name: string,
+  arg0Name: string,
+  arg1Name: string,
+  arg2Name: string,
+  arg3Name: string,
+  arg4Name: string,
+  arg5Name: string,
+  arg6Name: string,
+  arg7Name: string,
+  arg8Name: string,
+): (arg0: A0, arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8) => void;
+export function createEventNotifier<A0, A1, A2, A3, A4, A5, A6, A7>(
+  name: string,
+  arg0Name: string,
+  arg1Name: string,
+  arg2Name: string,
+  arg3Name: string,
+  arg4Name: string,
+  arg5Name: string,
+  arg6Name: string,
+  arg7Name: string,
+): (arg0: A0, arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7) => void;
+export function createEventNotifier<A0, A1, A2, A3, A4, A5, A6>(
+  name: string,
+  arg0Name: string,
+  arg1Name: string,
+  arg2Name: string,
+  arg3Name: string,
+  arg4Name: string,
+  arg5Name: string,
+  arg6Name: string,
+): (arg0: A0, arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6) => void;
 export function createEventNotifier<A0, A1, A2, A3, A4, A5>(
   name: string,
   arg0Name: string,


### PR DESCRIPTION
### Description of the Change
Added an exchange contract based on Switcheo's exchange and some tests.  In this PR, the contract allows the exchange of NEP5 tokens without accounting for Fees.

Things to Add after this PR:
- Allow exchange of system assets
- Account for Fees

It seems that the contract becomes too large if I try to add in much more.  I think it may be hitting the maximum size limit for contracts when more code is added.  

### Applicable Issues
#1684 