### PR TITLE
fix(dockerhub tags): ensure tagged node-bin images are pushed to dockerhub

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags:
-      - '*neo-one/node-bin*'
+      - \@neo-one/node-bin*
 jobs:
   push:
     runs-on: ubuntu-18.04

--- a/actions/dockerhub/entrypoint.sh
+++ b/actions/dockerhub/entrypoint.sh
@@ -10,19 +10,26 @@ REPOSITORY=${GITHUB_REPOSITORY#*/}
 ref_tmp=${GITHUB_REF#*/} ## throw away the first part of the ref (GITHUB_REF=refs/heads/master or refs/tags/2019/03/13)
 ref_type=${ref_tmp%%/*} ## extract the second element of the ref (heads or tags)
 ref_value=${ref_tmp#*/} ## extract the third+ elements of the ref (master or 2019/03/13)
-echo ref_tmp
-echo ref_type
-echo ref_value
+echo GITHUB_REF: $GITHUB_REF
+echo ref_tmp: $ref_tmp
+echo ref_type: $ref_type
+echo ref_value: $ref_value
+
 IMAGE_TAG=${ref_value//\//-} ## replace `/` with `-` in ref for docker tag requirement (master or 2019-03-13)
+IMAGE_TAG=${IMAGE_TAG//\@/v}
+IMAGE_TAG=${IMAGE_TAG:1}
 NAMESPACE=${DOCKER_NAMESPACE:-$USERNAME} ## use github username as docker namespace unless specified
 IMAGE_NAME=${DOCKER_IMAGE_NAME:-$REPOSITORY} ## use github repository name as docker image name unless specified
 REGISTRY_IMAGE="$NAMESPACE/$IMAGE_NAME"
-echo IMAGE_TAG
+echo IMAGE_TAG: $IMAGE_TAG
+echo NAMESPAACE: $NAMESPACE
+echo IMAGE_NAME: $IMAGE_NAME
+echo REGISTRY_IMAGE: $REGISTRY_IMAGE
 
 ## login if needed
 if [ -n "${DOCKER_PASSWORD+set}" ]
 then
-  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 fi
 
 ## build the image locally


### PR DESCRIPTION
### Description of the Change
The github action for pushing node images to dockerhub was working fine on pushes to master, but not running on tag pushes.  This should fix that issue.

Also switches to using --password-stdin for logging into dockerhub.  This is more secure and matches what the official https://github.com/actions/docker/tree/master/login does.

### Test Plan
Tested on the https://github.com/neo-one-suite/test-actions repo.
