### PR TITLE
fix(gulp): fix static imports in neo-one-react-common

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -543,6 +543,7 @@ const compileTypescript = ((cache) =>
         .pipe(
           gulpReplace("import { BN } from 'bn.js';", "import BN from 'bn.js';"),
         )
+        .pipe(gulpReplace('../static', './static'))
         .pipe(
           gulpRename((name) => {
             name.dirname = name.dirname


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to guard against regressions

### Description of the Change

Building the `neo-one-react-common` package caused problems with importing static assets into components for that package. The path for static imports was wrong. This fixes that problem.

### Test Plan

I ran `yarn build` and saw that the imports were correct in the `dist/neo-one/packages/neo-one-react-common`. These are the affected built files/components:

`Background.js`
`FileIcon.js`
`LineLogoPrimary.js`
`Logo.js`
`Monogram.js`

### Alternate Designs

None

### Benefits

Correct static imports

### Possible Drawbacks

None

### Applicable Issues

#1719 