### PR TITLE
fix(web): fix developer tools clipping

### DIFF
--- a/packages/neo-one-developer-tools-frame/src/ResizeHandler.ts
+++ b/packages/neo-one-developer-tools-frame/src/ResizeHandler.ts
@@ -67,7 +67,7 @@ export class ResizeHandler {
       this.mutableResizeTimeout = undefined;
       this.resize();
       // tslint:disable-next-line no-any
-    }, 1500) as any;
+    }, 1000) as any;
   };
 
   private readonly resize = () => {

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genBrowserClient.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genBrowserClient.test.ts.snap
@@ -70,6 +70,7 @@ import {
   NEOONEDataProvider,
   UserAccountProviders,
 } from '@neo-one/client';
+import { getJSONRPCLocalProviderManager } from '@neo-one/local-singleton';
 
 export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>,

--- a/packages/neo-one-smart-contract-codegen/src/client/genBrowserClient.ts
+++ b/packages/neo-one-smart-contract-codegen/src/client/genBrowserClient.ts
@@ -97,6 +97,7 @@ import {
   NEOONEDataProvider,
   UserAccountProviders,
 } from '@neo-one/client';
+import { getJSONRPCLocalProviderManager } from '@neo-one/local-singleton';
 
 export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>,


### PR DESCRIPTION
Fix the developer tools clipping. Also add an `ifProp` switch to stop some initial transition clipping, also changes the behavior of the size observer. Works much better now after test and looking at the i-frame in different instances.

Fixes #1726 