### PR TITLE
fix(cypress): more time for website:start:prod to finish in cypress script

### DIFF
--- a/scripts/website/runCypress.ts
+++ b/scripts/website/runCypress.ts
@@ -96,8 +96,8 @@ const run = async () => {
   });
 
   const TEN_MINUTES = 10 * 60 * 1000;
-  const THREE_MINUTES = 3 * 60 * 1000;
-  await timer(argv.local ? THREE_MINUTES : TEN_MINUTES).toPromise();
+  const FIVE_MINUTES = 5 * 60 * 1000;
+  await timer(argv.local ? FIVE_MINUTES : TEN_MINUTES).toPromise();
   await runCypress();
 };
 


### PR DESCRIPTION
### Description of the Change

Bumps the time from 3 minutes to 5 minutes for the website to startup in the `runCypress` script. 3 minutes wasn't enough time to finish the `website:start:prod` script, thus causing the Cypress tests to fail when run in `--local` mode.

### Test Plan

Run `yarn test:cypress-express --local` locally and see the Cypress express test pass.

### Alternate Designs

None.

### Benefits

Passing tests.

### Possible Drawbacks

None.

### Applicable Issues

#1740 