### PR TITLE
feat(ci): add playground to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,33 @@ aliases:
           path: reports
     parallelism: 2
 
+  - &playground12
+    working_directory: ~/neo-one
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Clone NEO-ONE Playground
+          command: git clone https://github.com/neo-one-suite/neo-one-playground.git
+      - run:
+          name: Yarn Install Playground
+          command: cd neo-one-playground && yarn install
+      - run:
+          name: Replace Playground's NEO-ONE Packages
+          command: node packages/neo-one-build-tools/lib/replacePackages
+      - run:
+          name: NEO-ONE Build
+          command: cd neo-one-playground && yarn neo-one build
+      - run:
+          name: Run Smart Contract Tests
+          command: cd neo-one-playground && yarn test
+      - run:
+          name: Run Playground Cypress Tests
+          command: cd neo-one-playground && yarn test:cypress
+      - store_artifacts:
+          path: /cypress/screenshots
+
 node10: &node10
   docker:
     - image: neotracker/neo-one-circleci-node@sha256:0f047d3662ad72b75e9550e41b22a2be0bf7fa8ee6563b65272b5af966b07f20
@@ -161,6 +188,9 @@ jobs:
   nit:
     <<: *node12
     <<: *nit
+  playground12:
+    <<: *node12
+    <<: *playground12
 
 workflows:
   version: 2
@@ -182,6 +212,10 @@ workflows:
       - build-12:
           filters: *filter-ignore-bors-tmp
       - test12:
+          filters: *filter-ignore-bors-tmp
+          requires:
+            - build-12
+      - playground12:
           filters: *filter-ignore-bors-tmp
           requires:
             - build-12

--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
   "ci/circleci: test10",
   "ci/circleci: test12",
   "ci/circleci: build-10",
-  "ci/circleci: build-12"
+  "ci/circleci: build-12",
+  "ci/circleci: playground12"
 ]
 timeout_sec = 18000

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -242,6 +242,14 @@
     },
     {
       "commandKind": "global",
+      "name": "prep-playground",
+      "summary": "Copies built neo-one packages into neo-one-playground modules for testing",
+      "description": "Used for neo-one-playground CI check",
+      "safeForSimultaneousRushProcesses": false,
+      "shellCommand": "node ./packages/neo-one-build-tools/lib/replacePackages"
+    },
+    {
+      "commandKind": "global",
       "name": "upload-coverage",
       "summary": "upload coverage (CI)",
       "description": "uploaded codecov coverage reports from unit tests",

--- a/packages/neo-one-build-tools/src/replacePackages.ts
+++ b/packages/neo-one-build-tools/src/replacePackages.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+const playgroundPackagesPath = path.resolve('neo-one-playground', 'node_modules', '@neo-one');
+const distPackagesPath = path.resolve('packages');
+const exceptions: readonly string[] = [
+  'ec-key',
+  'local',
+  'monitor',
+  'node-data-backup',
+  'server',
+  'server-client',
+  'server-plugin',
+  'server-grpc',
+  'server-http-client',
+  'server-plugin-neotracker',
+  'server-plugin-network',
+  'server-plugin-project',
+  'server-plugin-wallet',
+];
+
+const getInstallPackageName = (name: string) => name.slice(8);
+const pruneExceptions = (modules: readonly string[], exceptionsIn: readonly string[]) =>
+  modules.filter((mod) => !exceptionsIn.includes(mod));
+const deleteModules = (modules: readonly string[]) => {
+  modules.forEach((dir) => fs.removeSync(path.resolve(playgroundPackagesPath, dir)));
+};
+const copyModules = (modules: readonly string[]) => {
+  modules.forEach((mod) => {
+    try {
+      fs.copySync(
+        path.resolve(distPackagesPath, mod, 'lib'),
+        path.resolve(playgroundPackagesPath, getInstallPackageName(mod)),
+      );
+    } catch (error) {
+      // tslint:disable-next-line: no-console
+      console.error(error);
+    }
+  });
+};
+
+const modulesRead = fs.readdirSync(playgroundPackagesPath);
+const prunedModules = pruneExceptions(modulesRead, exceptions);
+const modulesToGet = prunedModules.map((mod) => `neo-one-${mod}`);
+
+deleteModules(prunedModules);
+copyModules(modulesToGet);


### PR DESCRIPTION
### Description of the Change

Integrates the NEO ONE playground into our CI. It will...

1. `git clone` the playground repo
2. `yarn build` the `neo-one` packages
3. Then it will look for `neo-one` packages that the playground uses and replace those packages with the newly built `neo-one` packages
4. Then it will run `yarn neo-one build` in the playground
5. Then it will run the playground's smart contract tests with `yarn test`
6. Then test run the playground's Cypress tests with `yarn test:cypress`

### Test Plan

This new GitHub Action should pass in this PR.

### Alternate Designs

None.

### Benefits

Test new NEO ONE updates in the playground.

### Possible Drawbacks

None.

### Applicable Issues

#1450 
