### PR TITLE
fix(ts): revert back to TS v3.5.3 until v3.6.3 is released

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "tslint-immutable": "^6.0.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.6.2",
+    "typescript": "^3.5.3",
     "typescript-styled-plugin": "^0.14.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.39.3",

--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -32,7 +32,7 @@
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
     "ts-node": "^8.3.0",
-    "typescript": "^3.6.2",
+    "typescript": "^3.5.3",
     "yargs": "^14.0.0"
   },
   "devDependencies": {

--- a/packages/neo-one-editor/package.json
+++ b/packages/neo-one-editor/package.json
@@ -61,7 +61,7 @@
     "source-map": "^0.7.3",
     "styled-tools": "^1.7.1",
     "ts-node": "^8.3.0",
-    "typescript": "^3.6.2",
+    "typescript": "^3.5.3",
     "typescript-fsa": "^3.0.0-beta-2",
     "typescript-fsa-reducers": "^1.2.1",
     "webpack": "^4.39.3"

--- a/packages/neo-one-local-browser/package.json
+++ b/packages/neo-one-local-browser/package.json
@@ -20,7 +20,7 @@
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.138",

--- a/packages/neo-one-smart-contract-compiler-node/package.json
+++ b/packages/neo-one-smart-contract-compiler-node/package.json
@@ -7,7 +7,7 @@
     "@neo-one/utils": "^1.2.1",
     "app-root-dir": "^1.0.2",
     "glob": "^7.1.4",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@types/app-root-dir": "^0.1.0",

--- a/packages/neo-one-smart-contract-compiler/package.json
+++ b/packages/neo-one-smart-contract-compiler/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.15",
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@neo-one/client-switch": "^1.4.2",

--- a/packages/neo-one-smart-contract-typescript-plugin/package.json
+++ b/packages/neo-one-smart-contract-typescript-plugin/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@neo-one/smart-contract-compiler": "^1.3.4",
     "@neo-one/smart-contract-compiler-node": "^1.1.7",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "sideEffects": false
 }

--- a/packages/neo-one-smart-contract-typescript-plugin/src/SmartContractPlugin.ts
+++ b/packages/neo-one-smart-contract-typescript-plugin/src/SmartContractPlugin.ts
@@ -18,13 +18,7 @@ export class SmartContractPlugin {
 
     proxy.getSemanticDiagnostics = (fileName) => {
       // tslint:disable-next-line no-non-null-assertion
-      const [result] = info.languageServiceHost.resolveModuleNames!(
-        ['@neo-one/smart-contract'],
-        fileName,
-        undefined,
-        undefined,
-        info.project.getCompilerOptions(),
-      );
+      const [result] = info.languageServiceHost.resolveModuleNames!(['@neo-one/smart-contract'], fileName);
 
       return [
         ...getSemanticDiagnostics(

--- a/packages/neo-one-ts-utils/package.json
+++ b/packages/neo-one-ts-utils/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "source-map": "^0.7.3",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.138"

--- a/packages/neo-one-typescript-concatenator/package.json
+++ b/packages/neo-one-typescript-concatenator/package.json
@@ -8,7 +8,7 @@
     "@neo-one/utils": "^1.2.1",
     "lodash": "^4.17.15",
     "toposort": "^2.0.2",
-    "typescript": "^3.6.2"
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@neo-one/smart-contract-compiler-node": "^1.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18748,10 +18748,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@^3.2.2, typescript@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.2.2, typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 u2f-api@0.2.7:
   version "0.2.7"


### PR DESCRIPTION
### Description of the Change

Reverts back to TS version 3.5.3. There's fatal issue with TS v3.6.2 which breaks our website editor. The fix for this error will be released in v3.6.3, hopefully to be released any day now.

Fixes: #1743

### Test Plan

Reinstall `node_modules` and run `yarn website:start-testRunner`, navigate to `localhost:8081` and open the console. You shouldn't see any errors.

### Alternate Designs

None.

### Benefits

Editor working until v3.6.3 patch.

### Possible Drawbacks

I'm not sure if there's anything we needed in TS v3.6.2.

### Applicable Issues

#1743 