### PR TITLE
test(new private-key): add e2e test for new private-key command

### DIFF
--- a/packages/neo-one-cli/src/__e2e__/cmd/new/privateKey.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/new/privateKey.test.ts
@@ -1,0 +1,11 @@
+import { common } from '@neo-one/client-common';
+
+describe('new private-key', () => {
+  it('logs new private key to the console', async () => {
+    const exec = one.createExec('ico');
+    const stdout = await exec('new private-key');
+
+    const privateKey = common.stringToPrivateKey(stdout);
+    expect(common.isPrivateKey(privateKey)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Description of the Change
Added test to confirm `neo-one new private-key` logs a correctly formed privateKey to the console.

### Applicable Issues
#1683