### PR TITLE
Dapcodegen

### DIFF
--- a/packages/neo-one-cli/src/__data__/projects/ico-vue/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico-vue/codegen/client.ts
@@ -1,8 +1,9 @@
-/* @hash af68c169daef58bbb7b20bb203d386b0 */
+/* @hash 0cc5edf6d2f00ee5de7e00feaabb439e */
 // tslint:disable
 /* eslint-disable */
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   LocalKeyStore,
@@ -17,12 +18,30 @@ export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>;
 }
 
-const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider: NEOONEProvider) => {
+  const localUserAccountProvider = {
+    memory: new LocalUserAccountProvider({
+      keystore: new LocalKeyStore(new LocalMemoryStore()),
+      provider,
+    }),
+  };
+
+  const dapi = typeof globalThis === 'undefined' ? undefined : (globalThis as any).neoDapi;
+  if (dapi !== undefined) {
+    return {
+      ...localUserAccountProvider,
+      dapi: new DapiUserAccountProvider({
+        dapi,
+        provider,
+        onError: (error) => {
+          throw error;
+        },
+      }),
+    };
+  }
+
+  return localUserAccountProvider;
+};
 
 const isLocalUserAccountProvider = (userAccountProvider: any): userAccountProvider is LocalUserAccountProvider =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -45,11 +64,13 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10520/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:11070/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(
+    isLocalUserAccountProvider,
+  ) as LocalUserAccountProvider[];
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
@@ -124,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10520/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:11070/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
@@ -1,8 +1,9 @@
-/* @hash 082e95d870600ede7ceeda8ace72a9b6 */
+/* @hash f4ffd06c714d9b771c405e9eaf8a2535 */
 // tslint:disable
 /* eslint-disable */
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   LocalKeyStore,
@@ -17,12 +18,30 @@ export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>;
 }
 
-const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider: NEOONEProvider) => {
+  const localUserAccountProvider = {
+    memory: new LocalUserAccountProvider({
+      keystore: new LocalKeyStore(new LocalMemoryStore()),
+      provider,
+    }),
+  };
+
+  const dapi = typeof globalThis === 'undefined' ? undefined : (globalThis as any).neoDapi;
+  if (dapi !== undefined) {
+    return {
+      ...localUserAccountProvider,
+      dapi: new DapiUserAccountProvider({
+        dapi,
+        provider,
+        onError: (error) => {
+          throw error;
+        },
+      }),
+    };
+  }
+
+  return localUserAccountProvider;
+};
 
 const isLocalUserAccountProvider = (userAccountProvider: any): userAccountProvider is LocalUserAccountProvider =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -45,11 +64,13 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10480/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:11030/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(
+    isLocalUserAccountProvider,
+  ) as LocalUserAccountProvider[];
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
@@ -124,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10480/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:11030/rpc` })),
 });

--- a/packages/neo-one-client/src/index.ts
+++ b/packages/neo-one-client/src/index.ts
@@ -182,6 +182,9 @@ export {
 
 export {
   Client,
+  connectRemoteUserAccountProvider,
+  Dapi,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   Hash256,
@@ -199,6 +202,7 @@ export {
   NEOONEDataProvider,
   NEOONEDataProviderOptions,
   NEOONEProvider,
+  RemoteUserAccountProvider,
   SmartContract,
   SmartContractAny,
   UnlockedWallet,

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
@@ -68,6 +68,7 @@ export class ContractsService {
 /* eslint-disable */
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   LocalKeyStore,
   LocalMemoryStore,
@@ -76,12 +77,30 @@ import {
   NEOONEDataProvider,
 } from '@neo-one/client';
 
-const getDefaultUserAccountProviders = (provider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider) => {
+  const localUserAccountProvider = {
+    memory: new LocalUserAccountProvider({
+      keystore: new LocalKeyStore(new LocalMemoryStore()),
+      provider,
+    }),
+  };
+
+  const dapi = typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
+  if (dapi !== undefined) {
+    return {
+      ...localUserAccountProvider,
+      dapi: new DapiUserAccountProvider({
+        dapi,
+        provider,
+        onError: (error) => {
+          throw error;
+        },
+      }),
+    };
+  }
+
+  return localUserAccountProvider;
+};
 
 const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
@@ -132,6 +151,7 @@ export const createDeveloperClients = (host = 'localhost') => ({
 /* eslint-disable */
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   LocalKeyStore,
@@ -146,12 +166,30 @@ export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>;
 }
 
-const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider: NEOONEProvider) => {
+  const localUserAccountProvider = {
+    memory: new LocalUserAccountProvider({
+      keystore: new LocalKeyStore(new LocalMemoryStore()),
+      provider,
+    }),
+  };
+
+  const dapi = typeof globalThis === 'undefined' ? undefined : (globalThis as any).neoDapi;
+  if (dapi !== undefined) {
+    return {
+      ...localUserAccountProvider,
+      dapi: new DapiUserAccountProvider({
+        dapi,
+        provider,
+        onError: (error) => {
+          throw error;
+        },
+      }),
+    };
+  }
+
+  return localUserAccountProvider;
+};
 
 const isLocalUserAccountProvider = (userAccountProvider: any): userAccountProvider is LocalUserAccountProvider =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -178,7 +216,9 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(
+    isLocalUserAccountProvider,
+  ) as LocalUserAccountProvider[];
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genClient.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/client/__snapshots__/genClient.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "js": "
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   LocalKeyStore,
   LocalMemoryStore,
@@ -13,12 +14,20 @@ import {
   NEOONEDataProvider,
 } from '@neo-one/client';
 
-const getDefaultUserAccountProviders = (provider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider) => {
+    const localUserAccountProvider = {
+      memory: new LocalUserAccountProvider({
+        keystore: new LocalKeyStore(new LocalMemoryStore()),
+        provider,
+      })};
+
+      const dapi = typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
+      if (dapi !== undefined) {
+        return {...localUserAccountProvider, dapi: new DapiUserAccountProvider({ dapi, provider, onError: (error) => { throw error }})}
+      }
+
+      return localUserAccountProvider;
+  };
 
 const isLocalUserAccountProvider = (userAccountProvider) =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -67,6 +76,7 @@ export const createDeveloperClients = (host = 'localhost') => ({
   "ts": "
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   LocalKeyStore,
@@ -81,12 +91,20 @@ export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>,
 }
 
-const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});
+const getDefaultUserAccountProviders = (provider: NEOONEProvider) => {
+    const localUserAccountProvider = {
+      memory: new LocalUserAccountProvider({
+        keystore: new LocalKeyStore(new LocalMemoryStore()),
+        provider,
+      })};
+
+      const dapi = typeof globalThis === 'undefined' ? undefined : (globalThis as any).neoDapi;
+      if (dapi !== undefined) {
+        return {...localUserAccountProvider, dapi: new DapiUserAccountProvider({ dapi, provider, onError: (error) => { throw error }})}
+      }
+
+      return localUserAccountProvider;
+  };
 
 const isLocalUserAccountProvider = (userAccountProvider: any): userAccountProvider is LocalUserAccountProvider =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -110,7 +128,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider) as LocalUserAccountProvider[];
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );

--- a/packages/neo-one-smart-contract-codegen/src/client/genClient.ts
+++ b/packages/neo-one-smart-contract-codegen/src/client/genClient.ts
@@ -20,6 +20,10 @@ export const genClient = ({
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
     providers.push({ network: '${localDevNetworkName}', rpcURL: \`http://\${host}:${localDevNetworkPort}/rpc\` });
   }
+  const neoDapi = window.neoDapi;
+  if (neoDapi !== undefined) {
+    providers.push(new )
+  }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
   const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
@@ -65,6 +69,7 @@ export const genClient = ({
     js: `
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   LocalKeyStore,
   LocalMemoryStore,

--- a/packages/neo-one-smart-contract-codegen/src/client/genClient.ts
+++ b/packages/neo-one-smart-contract-codegen/src/client/genClient.ts
@@ -11,7 +11,7 @@ export const genClient = ({
   readonly wallets: ReadonlyArray<Wallet>;
   readonly networks: ReadonlyArray<NetworkDefinition>;
 }) => {
-  const createClient = `const providers = [
+  const createClient = (language: 'ts' | 'js') => `const providers = [
     ${networks
       .filter(({ name }) => name !== localDevNetworkName)
       .map(({ name, rpcURL }) => `{ network: '${name}', rpcURL: '${rpcURL}' },`)
@@ -20,13 +20,11 @@ export const genClient = ({
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
     providers.push({ network: '${localDevNetworkName}', rpcURL: \`http://\${host}:${localDevNetworkPort}/rpc\` });
   }
-  const neoDapi = window.neoDapi;
-  if (neoDapi !== undefined) {
-    providers.push(new )
-  }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider)${
+    language === 'ts' ? ' as LocalUserAccountProvider[]' : ''
+  };
   const localUserAccountProvider = localUserAccountProviders.find(
     (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
@@ -58,12 +56,22 @@ export const genClient = ({
   '${localDevNetworkName}': new DeveloperClient(new NEOONEDataProvider({ network: '${localDevNetworkName}', rpcURL: \`http://\${host}:${localDevNetworkPort}/rpc\` })),
 });`;
 
-  const getDefaultUserAccountProviders = `({
-  memory: new LocalUserAccountProvider({
-    keystore: new LocalKeyStore(new LocalMemoryStore()),
-    provider,
-  }),
-});`;
+  const getDefaultUserAccountProviders = (language: 'ts' | 'js') => `{
+    const localUserAccountProvider = {
+      memory: new LocalUserAccountProvider({
+        keystore: new LocalKeyStore(new LocalMemoryStore()),
+        provider,
+      })};
+
+      const dapi = typeof globalThis === 'undefined' ? undefined : ${
+        language === 'ts' ? '(globalThis as any)' : 'globalThis'
+      }.neoDapi;
+      if (dapi !== undefined) {
+        return {...localUserAccountProvider, dapi: new DapiUserAccountProvider({ dapi, provider, onError: (error) => { throw error }})}
+      }
+
+      return localUserAccountProvider;
+  };`;
 
   return {
     js: `
@@ -78,7 +86,7 @@ import {
   NEOONEDataProvider,
 } from '@neo-one/client';
 
-const getDefaultUserAccountProviders = (provider) => ${getDefaultUserAccountProviders}
+const getDefaultUserAccountProviders = (provider) => ${getDefaultUserAccountProviders('js')}
 
 const isLocalUserAccountProvider = (userAccountProvider) =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -92,7 +100,7 @@ export const createClient = (getUserAccountProvidersOrHost) => {
     getUserAccountProviders = getUserAccountProvidersOrHost;
   }
 
-  ${createClient}
+  ${createClient('js')}
 
   return new Client(userAccountProviders);
 };
@@ -102,6 +110,7 @@ export const createDeveloperClients = (host = 'localhost') => ${createDeveloperC
     ts: `
 import {
   Client,
+  DapiUserAccountProvider,
   DeveloperClient,
   DeveloperClients,
   LocalKeyStore,
@@ -116,7 +125,7 @@ export interface DefaultUserAccountProviders {
   readonly memory: LocalUserAccountProvider<LocalKeyStore, NEOONEProvider>,
 }
 
-const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ${getDefaultUserAccountProviders}
+const getDefaultUserAccountProviders = (provider: NEOONEProvider) => ${getDefaultUserAccountProviders('ts')}
 
 const isLocalUserAccountProvider = (userAccountProvider: any): userAccountProvider is LocalUserAccountProvider =>
   userAccountProvider instanceof LocalUserAccountProvider;
@@ -132,7 +141,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
     getUserAccountProviders = getUserAccountProvidersOrHost as any;
   }
 
-  ${createClient}
+  ${createClient('ts')}
 
   return new Client(userAccountProviders as any);
 }


### PR DESCRIPTION
### Description of the Change
Setup DapiUserAccountProvider by default during codegen.  If the codegen detects `globalThis.neoDapi` to be set, then it will setup a dapi based on this.  

### Test Plan
Tested on a project with O3's dapi.  
1. Download O3 desktop and create a wallet
2. Use this generated code in a neo-one app
3. import neoDapi from 'neo-dapi' and `globalThis.neoDapi = neoDapi` at the entry point
4. Observe the dapi connects as expected

### Applicable Issues
#1687