### PR TITLE
fix(bors): bors problem fixed forever

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,6 +6,6 @@ status = [
   "ci/circleci: e2e12",
   "ci/circleci: build-e2e10",
   "ci/circleci: build-e2e12",
-  "Cypress / cypress12 (pull_request)"
+  "Cypress / cypress12 (push)"
 ]
 timeout_sec = 18000


### PR DESCRIPTION
### Description of the Change

`bors` was timing out after the Cypress-CI PR went it. It turns out that `bors` was looking for `Cypress / cypress12 (pull_request)` but should have been looking for `Cypress / cypress12 (push)` since `bors` is pushing to the staging branch and not opening a pull request on the staging branch. Thus it was looking for the wrong CI check to pass before merge it with `master` branch. This fixes that problem.

### Test Plan

See that this fixes `bors`.

### Alternate Designs

None.

### Benefits

Fixes `bors`.

### Possible Drawbacks

None.

### Applicable Issues

#1446 
