### PR TITLE
fix(bors): try removing cypress from bors requirement

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,6 +6,5 @@ status = [
   "ci/circleci: e2e12",
   "ci/circleci: build-e2e10",
   "ci/circleci: build-e2e12",
-  "Cypress / cypress12 (push)"
 ]
 timeout_sec = 18000


### PR DESCRIPTION
### Description of the Change

Sanity check for `bors`. Take out Cypress requirement to see if `bors` will merge. If `bors` works without requiring Cypress then we'll be reassured that we have pinpointed the source of the problem.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Testing.

### Possible Drawbacks

None.

### Applicable Issues

#1446 
