### PR TITLE
fix(bors): use SQL pattern matcher on Cypress job(s)

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,5 +6,6 @@ status = [
   "ci/circleci: e2e12",
   "ci/circleci: build-e2e10",
   "ci/circleci: build-e2e12",
+  "Cypress%"
 ]
 timeout_sec = 18000


### PR DESCRIPTION
### Description of the Change

Add Cypress requirement back to `bors.toml` but this time using the SQL pattern matcher as specified in the `bors` docs [here](https://bors.tech/documentation/). This *should* 

### Test Plan

See that `bors` successfully builds and merges on the next PR

### Alternate Designs

None.

### Benefits

`bors` working.

### Possible Drawbacks

None.

### Applicable Issues

#1446 
