### PR TITLE
fix(website course): include neo-one-node-browser in website

### DIFF
--- a/packages/neo-one-editor/src/loaders/packagesLoader.ts
+++ b/packages/neo-one-editor/src/loaders/packagesLoader.ts
@@ -14,6 +14,7 @@ const INCLUDE_PACKAGES: readonly string[] = [
   'neo-one-client-switch',
   'neo-one-developer-tools',
   'neo-one-local',
+  'neo-one-node-browser',
   'neo-one-local-browser',
   'neo-one-local-singleton',
   'neo-one-logger',


### PR DESCRIPTION
### Description of the Change
Website courses were not working - I think this is because @neo-one/node-browser was not being included and so couldn't be found.  This attempts to fix the problem.