### PR TITLE
fix(bors): remove bors check for Cypress

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,7 +5,6 @@ status = [
   "ci/circleci: e2e10",
   "ci/circleci: e2e12",
   "ci/circleci: build-e2e10",
-  "ci/circleci: build-e2e12",
-  "Cypress%"
+  "ci/circleci: build-e2e12"
 ]
 timeout_sec = 18000


### PR DESCRIPTION
### Description of the Change

Removes `cypress` test from the `bors` required checks while we figure out how to make this work. The Cypress test will still run in CI but `bors` won't check for it when merging.

### Test Plan

See that `bors` works.

### Alternate Designs

None.

### Benefits

`bors` merging.

### Possible Drawbacks

This means that bugs *could* slip through when `bors` merges multiple PRs together. But this should be caught in the very next rebase/PR. And we want to have this working in `bors` very soon.

### Applicable Issues

#1446 