### PR TITLE
feat(rush clean): add new rush clean command/script

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -27,14 +27,6 @@
     },
     {
       "commandKind": "global",
-      "name": "build-tools",
-      "summary": "Build NEO-ONE web tools",
-      "description": "Build the NEO-ONE tools from source",
-      "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "cross-env NODE_OPTIONS=\"--max-old-space-size=3072\" node ./packages/neo-one-build-tools-web/lib/compile --watch --bundle tools"
-    },
-    {
-      "commandKind": "global",
       "name": "build-test-runner",
       "summary": "Build NEO-ONE test-runner",
       "description": "Build the NEO-ONE test-runner from source",
@@ -80,6 +72,14 @@
       "description": "Start the NEO-ONE website from source in prod mode",
       "safeForSimultaneousRushProcesses": true,
       "shellCommand": "serve packages/neo-one-website/dist -p 3000"
+    },
+    {
+      "commandKind": "global",
+      "name": "clean",
+      "summary": "Clean up NEO-ONE packages",
+      "description": "Remove build logs from all packages (and optionally lib/* and package-deps.json)",
+      "safeForSimultaneousRushProcesses": false,
+      "shellCommand": "cross-env NODE_OPTIONS=\"--max-old-space-size=6144\" node ./packages/neo-one-build-tools/lib/clean"
     },
     {
       "commandKind": "global",
@@ -179,6 +179,20 @@
       "shortName": "-c",
       "description": "flag to enable coverage collection for jest",
       "associatedCommands": ["test", "test-ci"]
+    },
+    {
+      "parameterKind": "flag",
+      "longName": "--debug",
+      "shortName": "-d",
+      "description": "enables logging/debug mode for associated command",
+      "associatedCommands": ["clean", "start-website"]
+    },
+    {
+      "parameterKind": "flag",
+      "longName": "--full",
+      "shortName": "-f",
+      "description": "enables cleaning of lib/* and *.build.log files",
+      "associatedCommands": ["clean"]
     },
     {
       "parameterKind": "string",

--- a/packages/neo-one-build-tools/src/clean.ts
+++ b/packages/neo-one-build-tools/src/clean.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import yargs from 'yargs';
+
+const argv = yargs
+  .boolean('full')
+  .describe('full', 'flag for also cleaning lib/* and package-deps.json')
+  .default('full', false)
+  .boolean('debug')
+  .describe('debug', 'flag for logging actions')
+  .default('debug', false).argv;
+
+const APP_ROOT_DIR = path.resolve(__dirname, '..', '..', '..');
+const PACKAGES_DIR = path.resolve(APP_ROOT_DIR, 'packages');
+
+const getLogger = (debug: boolean = false) =>
+  debug
+    ? (input: string | readonly string[]) => console.log(input)
+    : (_input: string | readonly string[]) => {
+        /* do nothing */
+      };
+
+const debug = getLogger(argv.debug);
+
+const packagesToScan: readonly string[] = fs
+  .readdirSync(PACKAGES_DIR)
+  .filter((dir) => dir !== '.DS_Store')
+  .map((dir) => path.join(PACKAGES_DIR, dir));
+
+debug('Packages being scanned:');
+debug(packagesToScan);
+
+const deleteAll = (modules: readonly string[]): void => {
+  modules.forEach((dir) => {
+    if (argv.full) {
+      debug(`Removing package-deps: ${path.resolve(dir, 'package-deps.json')}`);
+      fs.removeSync(path.resolve(dir, 'package-deps.json'));
+      debug(`Removing /lib: ${path.resolve(dir, 'lib')}`);
+      fs.removeSync(path.resolve(dir, 'lib'));
+    }
+    const filesInPackage = fs.readdirSync(dir);
+    filesInPackage.forEach((file) => {
+      if (file.includes('.log')) {
+        debug(`Removing log file: ${path.resolve(dir, file)}`);
+        fs.removeSync(path.resolve(dir, file));
+      }
+    });
+  });
+  console.log('Done cleaning.');
+};
+
+deleteAll(packagesToScan);


### PR DESCRIPTION
### Description of the Change

Adds a `rush` command to easily delete all the `*.build.log` files. The `-d` or `--debug` flag will log exactly what it's deleting. The `-f` or `--full` flag will also delete all the `lib` directories, and `package-deps.json` files.

### Test Plan

Run `rush clean -d` to see it delete all the `*.build.log` files. The `-d` or `--debug` flag will log exactly what it's deleting.

Run `rush clean -d -f` to see it delete all the `lib` directories and `package-deps.json` files as well.

### Alternate Designs

None.

### Benefits

Ability to clean out files with a single command.

### Possible Drawbacks

None.

### Applicable Issues

#1820 