### PR TITLE
fix(website): fixup neo-one source file loading into pouchDB

### DIFF
--- a/packages/neo-one-editor/src/engine/main/initializeFileSystem.ts
+++ b/packages/neo-one-editor/src/engine/main/initializeFileSystem.ts
@@ -1,5 +1,7 @@
 // tslint:disable no-submodule-imports no-implicit-dependencies
 // @ts-ignore
+import files from '!../../loaders/packagesLoaderEntry!../../../../neo-one-smart-contract';
+// @ts-ignore
 import jest_d_ts from '!raw-loader!../../../../../common/temp/node_modules/@types/jest/index.d.ts';
 // @ts-ignore
 import node_d_ts from '!raw-loader!../../../../../common/temp/node_modules/@types/node/index.d.ts';
@@ -111,12 +113,10 @@ import { FileSystem } from '@neo-one/local-browser';
 import jestPackageJSONContents from '../../../../../common/temp/node_modules/@types/jest/package.json';
 // @ts-ignore
 import nodePackageJSONContents from '../../../../../common/temp/node_modules/@types/node/package.json';
-import { getPackages } from '../../loaders/getPackages';
 
 const writeFile = async (fs: FileSystem, path: string, content: string) => fs.writeFile(path, content);
 
 export const initializeFileSystem = async (fs: FileSystem): Promise<void> => {
-  const includedPackages = await getPackages();
   // tslint:disable-next-line no-any
   await Promise.all<any>([
     writeFile(fs, '/node_modules/typescript/lib/lib.d.ts', lib_d_ts),
@@ -176,7 +176,7 @@ export const initializeFileSystem = async (fs: FileSystem): Promise<void> => {
     writeFile(fs, '/node_modules/@types/node/package.json', JSON.stringify(nodePackageJSONContents)),
     Promise.all(
       // tslint:disable-next-line no-any
-      Object.entries(includedPackages).map(async ([path, contents]: any) => {
+      Object.entries(files).map(async ([path, contents]: any) => {
         await writeFile(fs, path, contents);
       }),
     ),

--- a/packages/neo-one-editor/src/loaders/packagesLoaderEntry.js
+++ b/packages/neo-one-editor/src/loaders/packagesLoaderEntry.js
@@ -1,0 +1,4 @@
+require('ts-node/register/transpile-only');
+const { packagesLoader } = require('./packagesLoader');
+
+module.exports = packagesLoader;

--- a/packages/neo-one-local-browser/src/filesystem/PouchDBFileSystem.ts
+++ b/packages/neo-one-local-browser/src/filesystem/PouchDBFileSystem.ts
@@ -59,11 +59,6 @@ export class PouchDBFileSystem implements FileSystem {
       }
     }
 
-    console.log('\n\n\n\n\n\n\nLOGGGING FILES\n\n\n\n\n\n\n\n');
-    for (const file of mutableFiles.keys()) {
-      console.log(file);
-    }
-    console.log('\n\n\n\n\n\n\nLOGGGING FILES\n\n\n\n\n\n\n\n');
     return new PouchDBFileSystem(db, changes$, subscription, mutableFiles);
   }
 

--- a/packages/neo-one-react-common/src/LoadingDots.tsx
+++ b/packages/neo-one-react-common/src/LoadingDots.tsx
@@ -32,11 +32,11 @@ const Wrapper = styled(Box)`
     animation-fill-mode: both;
   }
 
-  & > div:first-child {
+  & > div:first-of-type {
     animation-delay: -0.32s;
   }
 
-  & > div:nth-child(2) {
+  & > div:nth-of-type(2) {
     animation-delay: -0.16s;
   }
 `;


### PR DESCRIPTION
title, changes `packagesLoader.ts` to use per-file dependencies rather than directory context dependencies. Also stops using `@neo-one/utils` for a simple filter function as that was causing babel issues.