### PR TITLE
feat(vm): add system.blockchain.gettransactionfromblock syscall to vm

### DIFF
--- a/packages/neo-one-client-common/src/models/vm.ts
+++ b/packages/neo-one-client-common/src/models/vm.ts
@@ -222,6 +222,7 @@ export enum SysCall {
   'System.Blockchain.GetBlock' = 'System.Blockchain.GetBlock',
   'System.Blockchain.GetTransaction' = 'System.Blockchain.GetTransaction',
   'System.Blockchain.GetTransactionHeight' = 'System.Blockchain.GetTransactionHeight',
+  'System.Blockchain.GetTransactionFromBlock' = 'System.Blockchain.GetTransactionFromBlock',
   'System.Blockchain.GetContract' = 'System.Blockchain.GetContract',
   'System.Contract.Call' = 'System.Contract.Call',
   'System.Contract.Destroy' = 'System.Contract.Destroy',

--- a/packages/neo-one-node-vm/src/__tests__/__snapshots__/syscalls.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/__snapshots__/syscalls.test.ts.snap
@@ -765,6 +765,70 @@ exports[`syscalls System.Blockchain.GetTransaction 5`] = `Array []`;
 
 exports[`syscalls System.Blockchain.GetTransaction 6`] = `Array []`;
 
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 1`] = `"block.tryGet"`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 2`] = `
+Array [
+  Array [
+    Object {
+      "hashOrIndex": "0303030303030303030303030303030303030303030303030303030303030303",
+    },
+  ],
+]
+`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 3`] = `"transaction.tryGet"`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 4`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a643872d1abf90296b503716c64662e1af0c4fe4e4efec893b7504a26a365abb",
+    },
+  ],
+]
+`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 5`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 6`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 7`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 8`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 9`] = `"block.tryGet"`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 10`] = `
+Array [
+  Array [
+    Object {
+      "hashOrIndex": "0303030303030303030303030303030303030303030303030303030303030303",
+    },
+  ],
+]
+`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 11`] = `"transaction.tryGet"`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 12`] = `
+Array [
+  Array [
+    Object {
+      "hash": "df09c9981eb0c4a2a182ce6090148647a2f4f6053c970380a645ed63b91ce258",
+    },
+  ],
+]
+`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 13`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 14`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 15`] = `Array []`;
+
+exports[`syscalls System.Blockchain.GetTransactionFromBlock 16`] = `Array []`;
+
 exports[`syscalls System.Blockchain.GetTransactionHeight 1`] = `"transactionData.get"`;
 
 exports[`syscalls System.Blockchain.GetTransactionHeight 2`] = `

--- a/packages/neo-one-node-vm/src/__tests__/syscalls.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls.test.ts
@@ -594,6 +594,52 @@ const SYSCALLS = [
   },
 
   {
+    name: 'System.Blockchain.GetTransactionFromBlock',
+    result: [new TransactionStackItem(transactions.kycTransaction)],
+    args: [Buffer.alloc(32, 3), new BN(0)],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.block.tryGet = jest.fn(async () => Promise.resolve(new Block(dummyBlock)));
+      blockchain.transaction.tryGet = jest.fn(async () => Promise.resolve(transactions.kycTransaction));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  {
+    name: 'System.Blockchain.GetTransactionFromBlock',
+    result: [new TransactionStackItem(transactions.mintTransaction)],
+    args: [Buffer.alloc(32, 3), new BN(1)],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.block.tryGet = jest.fn(async () => Promise.resolve(new Block(dummyBlock)));
+      blockchain.transaction.tryGet = jest.fn(async () => Promise.resolve(transactions.mintTransaction));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  {
+    name: 'System.Blockchain.GetTransactionFromBlock',
+    result: [new TransactionStackItem(transactions.mintTransaction)],
+    args: [Buffer.alloc(32, 3), new BN(2)],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.block.tryGet = jest.fn(async () => Promise.resolve(new Block(dummyBlock)));
+      blockchain.transaction.tryGet = jest.fn(async () => Promise.resolve(transactions.mintTransaction));
+    },
+    gas: FEES[1_000_000],
+    error: 'Invalid Transaction Index Argument: 2. Transactions length: 2',
+  },
+
+  {
+    name: 'System.Blockchain.GetTransactionFromBlock',
+    result: [new TransactionStackItem(transactions.mintTransaction)],
+    args: [Buffer.alloc(32, 3), new BN(-1)],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.block.tryGet = jest.fn(async () => Promise.resolve(new Block(dummyBlock)));
+      blockchain.transaction.tryGet = jest.fn(async () => Promise.resolve(transactions.mintTransaction));
+    },
+    gas: FEES[1_000_000],
+    error: 'Invalid Transaction Index Argument: -1. Transactions length: 2',
+  },
+
+  {
     name: 'System.Blockchain.GetContract',
     result: [new ContractStackItem(transactions.kycContract)],
     mockBlockchain: ({ blockchain }) => {

--- a/packages/neo-one-node-vm/src/errors.ts
+++ b/packages/neo-one-node-vm/src/errors.ts
@@ -144,6 +144,11 @@ export const InvalidGetBlockArgumentsError = makeErrorWithCode(
 export const InvalidIndexError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Invalid Index.'),
 );
+export const InvalidTransactionIndexError = makeErrorWithCode(
+  'VM_ERROR',
+  (context: ExecutionContext, index: number, length: number) =>
+    getMessage(context, `Invalid Transaction Index Argument: ${index}. Transactions length: ${length}`),
+);
 export const InvalidInvocationTransactionError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Expected InvocationTransaction.'),
 );


### PR DESCRIPTION
### Description of the Change

Adds new `SYSCALL` to the `neo-one-node-vm`: `System.Blockchain.GetTransactionFromBlock`. Also added tests for this new SysCall and a new VM error for invalid transaction index in a block's transaction list.

The implementation of this SysCall in the NEO Project C# code can be found here: https://github.com/neo-project/neo/blob/master/src/neo/SmartContract/InteropService.cs#L374

This should be thoroughly reviewed by someone else to check that I'm on the right track. It's probably best that I discuss this in-person with someone because I have a few questions about when to throw errors vs when to push a null stack item, which itself appears to be a new `StackItem` in Neo3.

### Test Plan

Run `yarn jest packages/neo-one-node-vm/src/__tests__/syscalls.test.ts`

### Alternate Designs

None.

### Benefits

Gets us one step closer to NEO v3.0

### Possible Drawbacks

The NEO v3 VM/compiler could be changed from now until NEO v3 launch, which would mean this would be obsolete.

### Applicable Issues

#1786 
