### PR TITLE
feat(vm): add null stack item, PUSHNULL, ISNULL, and tests

### DIFF
--- a/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
@@ -20,6 +20,7 @@ import {
   BufferStackItem,
   IntegerStackItem,
   MapStackItem,
+  NullStackItem,
   StackItem,
   StructStackItem,
 } from '../stackItem';
@@ -261,6 +262,12 @@ const OPCODES = ([
       },
 
       {
+        op: 'PUSHNULL',
+        result: [new NullStackItem()],
+        gas: FEES[30],
+      },
+
+      {
         op: 'NOP',
         result: [],
         gas: FEES[30],
@@ -404,6 +411,34 @@ const OPCODES = ([
         op: 'FROMALTSTACK',
         argsAlt: [new BN(1)],
         result: [new IntegerStackItem(new BN(1))],
+        gas: FEES[60],
+      },
+
+      {
+        op: 'ISNULL',
+        preOps: [{ op: 'PUSHNULL' }],
+        result: [new BooleanStackItem(true)],
+        gas: FEES[60].add(FEES[30]),
+      },
+
+      {
+        op: 'ISNULL',
+        preOps: [{ op: 'PUSH16' }, { op: 'PUSHNULL' }],
+        result: [new BooleanStackItem(true), new IntegerStackItem(new BN(16))],
+        gas: FEES[60].add(FEES[30]).add(FEES[30]),
+      },
+
+      {
+        op: 'ISNULL',
+        preOps: [{ op: 'PUSHNULL' }, { op: 'PUSH16' }],
+        result: [new BooleanStackItem(false), new NullStackItem()],
+        gas: FEES[60].add(FEES[30]).add(FEES[30]),
+      },
+
+      {
+        op: 'ISNULL',
+        args: [new BN(1)],
+        result: [new BooleanStackItem(false)],
         gas: FEES[60],
       },
 

--- a/packages/neo-one-node-vm/src/__tests__/stackItem/StackItem.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/stackItem/StackItem.test.ts
@@ -16,6 +16,7 @@ import {
   HeaderStackItem,
   InputStackItem,
   IntegerStackItem,
+  NullStackItem,
   OutputStackItem,
   StackItemType,
   StorageContextStackItem,
@@ -224,8 +225,22 @@ describe('Stack Item Tests', () => {
     expect(storageContextStackItem.asBuffer()).toEqual(Buffer.from(uInt160));
   });
 
+  test('Null Stack Item', () => {
+    const nullStackItem = new NullStackItem();
+    const secondNullStackItem = new NullStackItem();
+
+    expect(nullStackItem.equals(undefined)).toBe(true);
+    expect(nullStackItem.equals(nullStackItem)).toBe(true);
+    expect(nullStackItem.equals(secondNullStackItem)).toBe(true);
+    expect(nullStackItem.equals(new BufferStackItem(Buffer.from([0])))).toBe(false);
+    expect(() => nullStackItem.asBuffer()).toThrowError('Invalid Value. Expected Buffer');
+    expect(nullStackItem.asBoolean()).toEqual(false);
+    expect(nullStackItem.convertJSON()).toMatchSnapshot();
+    expect(nullStackItem.serialize()).toEqual(Buffer.from([StackItemType.Null]));
+  });
+
   test('StackItemType - Throws On Bad Assert', () => {
-    const badByte = 0xff;
+    const badByte = 0x99;
     expect(() => assertStackItemType(badByte)).toThrowError(`Expected StackItemType, found: ${badByte.toString(16)}`);
   });
 });

--- a/packages/neo-one-node-vm/src/__tests__/stackItem/StackItemBase.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/stackItem/StackItemBase.test.ts
@@ -1,5 +1,5 @@
 import { factory, testUtils } from '../../__data__';
-import { HeaderStackItem, InputStackItem, UInt160StackItem, UInt256StackItem } from '../../stackItem';
+import { HeaderStackItem, InputStackItem, NullStackItem, UInt160StackItem, UInt256StackItem } from '../../stackItem';
 
 describe('Stack Item Base', () => {
   const uInt160 = factory.createUInt160();
@@ -10,6 +10,7 @@ describe('Stack Item Base', () => {
   const uInt256StackItem = new UInt256StackItem(uInt256);
   const headerStackItem = new HeaderStackItem(header);
   const inputStackItem = new InputStackItem(input);
+  const nullStackItem = new NullStackItem();
 
   test('equals - undefined', () => {
     expect(uInt160StackItem.equals(undefined)).toBeFalsy();
@@ -100,6 +101,21 @@ describe('Stack Item Base', () => {
   });
   test('Errors - asIterator', () => {
     expect(() => uInt160StackItem.asIterator()).toThrowError('Invalid Value. Expected Iterator');
+  });
+  test('Base - isNull', () => {
+    expect(nullStackItem.isNull()).toBeTruthy();
+  });
+  test('Base - isNull', () => {
+    expect(uInt160StackItem.isNull()).toBeFalsy();
+  });
+  test('Base - isNull', () => {
+    expect(uInt256StackItem.isNull()).toBeFalsy();
+  });
+  test('Base - isNull', () => {
+    expect(headerStackItem.isNull()).toBeFalsy();
+  });
+  test('Base - isNull', () => {
+    expect(inputStackItem.isNull()).toBeFalsy();
   });
   test('Base - isMap', () => {
     expect(uInt160StackItem.isMap()).toBeFalsy();

--- a/packages/neo-one-node-vm/src/__tests__/stackItem/__snapshots__/StackItem.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/stackItem/__snapshots__/StackItem.test.ts.snap
@@ -72,6 +72,8 @@ Object {
 }
 `;
 
+exports[`Stack Item Tests Null Stack Item 1`] = `"UNKNOWN"`;
+
 exports[`Stack Item Tests UInt160 Stack Item 1`] = `
 Object {
   "__$type": "Hash160ContractParameter",

--- a/packages/neo-one-node-vm/src/opcodes.ts
+++ b/packages/neo-one-node-vm/src/opcodes.ts
@@ -44,6 +44,7 @@ import {
   BufferStackItem,
   IntegerStackItem,
   MapStackItem,
+  NullStackItem,
   StackItem,
   StructStackItem,
 } from './stackItem';
@@ -265,6 +266,15 @@ const OPCODE_PAIRS = ([
   )
   .concat([
     [
+      0x50,
+      createOp({
+        name: 'PUSHNULL',
+        fee: FEES[30],
+        out: 1,
+        invoke: ({ context }) => ({ context, results: [new NullStackItem()] }),
+      }),
+    ],
+    [
       0x61,
       createOp({
         name: 'NOP',
@@ -350,7 +360,7 @@ const OPCODE_PAIRS = ([
       },
     ],
     [
-      0x69,
+      0x6e,
       createOp({
         name: 'DUPFROMALTSTACKBOTTOM',
         fee: FEES[60],
@@ -399,6 +409,19 @@ const OPCODE_PAIRS = ([
         invoke: ({ context, argsAlt }) => ({
           context,
           results: [argsAlt[0]],
+        }),
+      }),
+    ],
+    [
+      0x70,
+      createOp({
+        name: 'ISNULL',
+        fee: FEES[60],
+        in: 1,
+        out: 1,
+        invoke: ({ context, args }) => ({
+          context,
+          results: [new BooleanStackItem(args[0].isNull())],
         }),
       }),
     ],

--- a/packages/neo-one-node-vm/src/stackItem/NullStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/NullStackItem.ts
@@ -1,0 +1,46 @@
+import { BinaryWriter } from '@neo-one/client-common';
+import { InvalidValueBufferError } from './errors';
+import { StackItemBase } from './StackItemBase';
+import { StackItemType } from './StackItemType';
+
+export class NullStackItem extends StackItemBase {
+  public constructor() {
+    super();
+  }
+
+  // tslint:disable-next-line: no-any
+  public equals(other: any): boolean {
+    if (this === other) {
+      return true;
+    }
+
+    if (other instanceof NullStackItem) {
+      return true;
+    }
+
+    if (other === undefined) {
+      return true;
+    }
+
+    return false;
+  }
+
+  public isNull(): boolean {
+    return true;
+  }
+
+  public asBoolean(): boolean {
+    return false;
+  }
+
+  public asBuffer(): Buffer {
+    throw new InvalidValueBufferError();
+  }
+
+  protected serializeInternal(): Buffer {
+    const writer = new BinaryWriter();
+    writer.writeUInt8(StackItemType.Null);
+
+    return writer.toBuffer();
+  }
+}

--- a/packages/neo-one-node-vm/src/stackItem/StackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItem.ts
@@ -14,6 +14,7 @@ import { InputStackItem } from './InputStackItem';
 import { IntegerStackItem } from './IntegerStackItem';
 import { IteratorStackItem } from './IteratorStackItem';
 import { MapStackItem } from './MapStackItem';
+import { NullStackItem } from './NullStackItem';
 import { OutputStackItem } from './OutputStackItem';
 import { StorageContextStackItem } from './StorageContextStackItem';
 import { StructStackItem } from './StructStackItem';
@@ -47,4 +48,5 @@ export type StackItem =
   | StorageContextStackItem
   | ECPointStackItem
   | StructStackItem
-  | WitnessStackItem;
+  | WitnessStackItem
+  | NullStackItem;

--- a/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
@@ -274,6 +274,10 @@ export class StackItemBase implements Equatable {
     throw new InvalidValueStorageContextStackItemError();
   }
 
+  public isNull(): boolean {
+    return false;
+  }
+
   public isArray(): boolean {
     return false;
   }

--- a/packages/neo-one-node-vm/src/stackItem/StackItemType.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItemType.ts
@@ -8,6 +8,7 @@ export enum StackItemType {
   Array = 0x80,
   Struct = 0x81,
   Map = 0x82,
+  Null = 0xff,
 }
 
 export const InvalidStackItemTypeError = makeErrorWithCode(

--- a/packages/neo-one-node-vm/src/stackItem/deserializeStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/deserializeStackItem.ts
@@ -8,6 +8,7 @@ import { BufferStackItem } from './BufferStackItem';
 import { UnsupportedStackItemSerdeError } from './errors';
 import { IntegerStackItem } from './IntegerStackItem';
 import { MapStackItem } from './MapStackItem';
+import { NullStackItem } from './NullStackItem';
 import { StackItem } from './StackItem';
 import { assertStackItemType, StackItemType } from './StackItemType';
 import { StructStackItem } from './StructStackItem';
@@ -47,6 +48,8 @@ const deserializeStackItemBase = (reader: BinaryReader): StackItem => {
 
       return new MapStackItem({ referenceKeys, referenceValues });
     }
+    case StackItemType.Null: // NULL
+      return new NullStackItem();
     /* istanbul ignore next */
     default:
       commonUtils.assertNever(type);

--- a/packages/neo-one-node-vm/src/stackItem/index.ts
+++ b/packages/neo-one-node-vm/src/stackItem/index.ts
@@ -24,6 +24,7 @@ export { StructStackItem } from './StructStackItem';
 export { StackItemEnumerator } from './StackItemEnumerator';
 export { StackItemIterator } from './StackItemIterator';
 export { WitnessStackItem } from './WitnessStackItem';
+export { NullStackItem } from './NullStackItem';
 
 export { deserializeStackItem } from './deserializeStackItem';
 export { StackItem } from './StackItem';


### PR DESCRIPTION
### Description of the Change

- Adds the new `Null` stack item to the VM, including unit tests.
- Adds the `PUSHNULL` and `ISNULL` OpCodes to the VM, including unit tests.
- Adds `isNull()` method to `StackItemBase`, including unit tests.
- Also changes the hex code for `DUPFROMALTSTACKBOTTOM` OpCode to match the hex code in the NEO C# VM.

### Test Plan

Run `yarn jest`...
- `packages/neo-one-node-vm/src/__tests__/opcodes.test.ts`
- `packages/neo-one-node-vm/src/__tests__/StackItem.test.ts`
- `packages/neo-one-node-vm/src/__tests__/StackItemBase.test.ts`

I was having trouble running the unit tests due to a TypeScript error. So there's likely a small edit on the way to the `NullStackItem` class to fix this.

### Alternate Designs

None.

### Benefits

Gets us one step closer to NEO v3.0

### Possible Drawbacks

The NEO v3 VM/compiler could be changed from now until NEO v3 launch, which would mean this would be obsolete.

### Applicable Issues

#1786 