### PR TITLE
feat(jest): local unit tests now use .ts to not require rebuilding

### DIFF
--- a/packages/neo-one-build-tests/jest/unit-ci.js
+++ b/packages/neo-one-build-tests/jest/unit-ci.js
@@ -4,4 +4,5 @@ const ci = require('./ci');
 module.exports = {
   ...unit,
   ...ci('unit'),
+  moduleNameMapper: undefined,
 };

--- a/packages/neo-one-build-tests/jest/unit.js
+++ b/packages/neo-one-build-tests/jest/unit.js
@@ -3,6 +3,9 @@ const base = require('./base');
 module.exports = {
   ...base({ path: 'test' }),
   displayName: 'unit',
+  moduleNameMapper: {
+    '^@neo-one/(.*)$': '<rootDir>/packages/neo-one-$1/src',
+  },
   testRegex: '^.*/__tests__/.*\\.test\\.tsx?$',
   coverageReporters: ['json'],
   collectCoverageFrom: [

--- a/packages/neo-one-build-tests/tsconfig.jest.json
+++ b/packages/neo-one-build-tests/tsconfig.jest.json
@@ -24,7 +24,8 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "bn.js": ["node_modules/@neo-one/build-tools/types/bn.js.d.ts"]
+      "bn.js": ["node_modules/@neo-one/build-tools/types/bn.js.d.ts"],
+      "@neo-one/*": ["../neo-one-*/src"]
     }
   },
   "exclude": [


### PR DESCRIPTION
jest unit tests no longer require rebuilding locally. CI & E2E tests will still require built files.