### PR TITLE
feat(vm): add syscall system.contract.call, plus more fixes

### DIFF
--- a/packages/neo-one-client-full-common/src/__tests__/models/ContractPermissionDescriptorModel.test.ts
+++ b/packages/neo-one-client-full-common/src/__tests__/models/ContractPermissionDescriptorModel.test.ts
@@ -8,17 +8,29 @@ describe('ContractPermissionDescriptorModel - serializeWireBase', () => {
   });
 
   test('UInt160', () => {
-    contractPermissionDescriptorModel('uint160').serializeWireBase(writer);
+    const permission = contractPermissionDescriptorModel('uint160');
+    expect(permission.isHash()).toBeTruthy();
+    expect(permission.isGroup()).toBeFalsy();
+    expect(permission.isWildcard()).toBeFalsy();
+    permission.serializeWireBase(writer);
     expect(writer.toBuffer()).toMatchSnapshot();
   });
 
   test('ECPoint', () => {
-    contractPermissionDescriptorModel('ecpoint').serializeWireBase(writer);
+    const permission = contractPermissionDescriptorModel('ecpoint');
+    expect(permission.isGroup()).toBeTruthy();
+    expect(permission.isHash()).toBeFalsy();
+    expect(permission.isWildcard()).toBeFalsy();
+    permission.serializeWireBase(writer);
     expect(writer.toBuffer()).toMatchSnapshot();
   });
 
   test('undefined', () => {
-    contractPermissionDescriptorModel(undefined).serializeWireBase(writer);
+    const permission = contractPermissionDescriptorModel(undefined);
+    expect(permission.isWildcard()).toBeTruthy();
+    expect(permission.isHash()).toBeFalsy();
+    expect(permission.isGroup()).toBeFalsy();
+    permission.serializeWireBase(writer);
     expect(writer.toBuffer()).toMatchSnapshot();
   });
 });

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -650,7 +650,7 @@ export class Blockchain {
           },
           {
             measure: blockLatencySec,
-            value: commonUtils.nowSeconds() - entry.block.timestamp,
+            value: new BN(commonUtils.nowSeconds()).sub(entry.block.timestamp.divn(1000)).toNumber(),
           },
         ]);
 

--- a/packages/neo-one-node-blockchain/src/__tests__/StorageCache.test.ts
+++ b/packages/neo-one-node-blockchain/src/__tests__/StorageCache.test.ts
@@ -35,7 +35,7 @@ describe('StorageCache', () => {
     const firstGet = await storageCache.tryGet({ hash, key });
     expect(firstGet).toBeUndefined();
 
-    const storageItem = new StorageItem({ hash, key, value: Buffer.from('hello', 'utf-8'), flags: StorageFlags.None });
+    const storageItem = new StorageItem({ value: Buffer.from('hello', 'utf-8'), isConstant: true });
     await storageCache.add(storageItem);
 
     const secondGet = await storageCache.tryGet({ hash, key });

--- a/packages/neo-one-node-vm/src/__tests__/__snapshots__/syscalls.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/__snapshots__/syscalls.test.ts.snap
@@ -717,6 +717,31 @@ exports[`syscalls System.Blockchain.GetTransactionHeight 5`] = `Array []`;
 
 exports[`syscalls System.Blockchain.GetTransactionHeight 6`] = `Array []`;
 
+exports[`syscalls System.Contract.Call 1`] = `"contract.tryGet"`;
+
+exports[`syscalls System.Contract.Call 2`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0101010101010101010101010101010101010101",
+    },
+  ],
+  Array [
+    Object {
+      "hash": "d62351631d2cc13da590348467f5375fd0464b35",
+    },
+  ],
+]
+`;
+
+exports[`syscalls System.Contract.Call 3`] = `Array []`;
+
+exports[`syscalls System.Contract.Call 4`] = `Array []`;
+
+exports[`syscalls System.Contract.Call 5`] = `Array []`;
+
+exports[`syscalls System.Contract.Call 6`] = `Array []`;
+
 exports[`syscalls System.Contract.Destroy 1`] = `"contract.tryGet"`;
 
 exports[`syscalls System.Contract.Destroy 2`] = `

--- a/packages/neo-one-node-vm/src/errors.ts
+++ b/packages/neo-one-node-vm/src/errors.ts
@@ -158,8 +158,18 @@ export const InvalidClaimTransactionError = makeErrorWithCode('VM_ERROR', (conte
 export const ContractNoStorageError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext, hash: string) =>
   getMessage(context, `Contract Does Not Have Storage: ${hash}`),
 );
-export const ContractNoDynamicInvokeError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext, hash: string) =>
-  getMessage(context, `Contract Does Not Have Dynamic Invoke: ${hash}`),
+export const ContractHashNotFoundError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext, hash: string) =>
+  getMessage(context, `Contract Hash Not Found: ${hash}`),
+);
+export const ContractMethodUndefinedError = makeErrorWithCode(
+  'VM_ERROR',
+  (context: ExecutionContext, hash: string, method: string) =>
+    getMessage(context, `Contract Method Undefined for Contract: ${hash}. Method: ${method}`),
+);
+export const InvalidPermissionError = makeErrorWithCode(
+  'VM_ERROR',
+  (context: ExecutionContext, hash: string, method: string) =>
+    getMessage(context, `Contract ${hash} does not have permission to call ${method}`),
 );
 export const TooManyVotesError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Too Many Votes'),


### PR DESCRIPTION
### Description of the Change

- Updates the new SysCall `System.Contract.Call`, which replaces the old OpCodes `APPCALL`, `TAILCALL`, `CALL_E`, `CALL_ED`.
- Adds unit tests for this new SysCall. Also makes minor fixes to some SysCalls and their respective unit tests. Some SnapShots have not been updated, but I want to keep it that way for the moment because a handful of SysCalls still need to be added/updated, and their respective tests need to be changed as well.
- Adds unit tests for the new methods in the `ContractPermissionDescriptorModel`.

### Test Plan

- `rush test -t packages/neo-one-node-vm/src/__tests__/syscalls.test.ts`
- `rush test -t packages/neo-one-client-full-common/src/__tests__/models/ContractPermissionDescriptorModel.test.ts`

### Alternate Designs

None.

### Benefits

One step closer to NEO 3.0.

### Possible Drawbacks

`System.Contract.Call` is quite complicated, so we may want to double check that now and/or later.

### Applicable Issues

#1879 