### PR TITLE
fix(storageitem): revert further storageitem changes

### DIFF
--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -156,8 +156,10 @@ export type ActionJSON = NotificationActionJSON | LogActionJSON;
 export type ActionTypeJSON = ActionJSON['type'];
 
 export interface StorageItemJSON {
+  readonly hash: string;
+  readonly key: string;
   readonly value: string;
-  readonly isConstant: boolean;
+  readonly flags: StorageFlagsJSON;
 }
 
 export type StorageFlagsJSON = keyof typeof StorageFlagsModel;

--- a/packages/neo-one-node-core/src/StorageItem.ts
+++ b/packages/neo-one-node-core/src/StorageItem.ts
@@ -1,4 +1,11 @@
-import { BinaryWriter, IOHelper, JSONHelper, StorageItemJSON, UInt160 } from '@neo-one/client-common';
+import {
+  BinaryWriter,
+  IOHelper,
+  JSONHelper,
+  StorageItemJSON,
+  toJSONStorageFlags,
+  UInt160,
+} from '@neo-one/client-common';
 import {
   createSerializeWire,
   DeserializeWireBaseOptions,
@@ -8,13 +15,19 @@ import {
   SerializeJSONContext,
   SerializeWire,
 } from './Serializable';
+import { StorageFlags } from './StorageFlags';
 import { BinaryReader, utils } from './utils';
 
 export interface StorageItemAdd {
   readonly hash: UInt160;
   readonly key: Buffer;
   readonly value: Buffer;
-  readonly isConstant: boolean;
+  readonly flags: StorageFlags;
+}
+
+export interface StorageItemUpdate {
+  readonly value: Buffer;
+  readonly flags: StorageFlags;
 }
 
 export interface StorageItemsKey {
@@ -27,22 +40,18 @@ export interface StorageItemKey {
   readonly key: Buffer;
 }
 
-export interface StorageItemUpdate {
-  readonly value: Buffer;
-}
-
 export class StorageItem implements SerializableWire<StorageItem>, SerializableJSON<StorageItemJSON> {
   public static deserializeWireBase({ reader }: DeserializeWireBaseOptions): StorageItem {
     const hash = reader.readUInt160();
     const key = reader.readVarBytesLE();
     const value = reader.readVarBytesLE();
-    const isConstant = reader.readBoolean();
+    const flags = reader.readUInt8();
 
     return new this({
       hash,
       key,
       value,
-      isConstant,
+      flags,
     });
   }
 
@@ -56,22 +65,21 @@ export class StorageItem implements SerializableWire<StorageItem>, SerializableJ
   public readonly hash: UInt160;
   public readonly key: Buffer;
   public readonly value: Buffer;
-  public readonly isConstant: boolean;
+  public readonly flags: StorageFlags;
   public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
   private readonly sizeInternal: () => number;
 
-  public constructor({ hash, key, value, isConstant }: StorageItemAdd) {
+  public constructor({ hash, key, value, flags }: StorageItemAdd) {
     this.hash = hash;
     this.key = key;
     this.value = value;
-    this.isConstant = isConstant;
+    this.flags = flags;
     this.sizeInternal = utils.lazy(
       () =>
         IOHelper.sizeOfUInt160 +
         IOHelper.sizeOfVarBytesLE(this.key) +
         IOHelper.sizeOfVarBytesLE(this.value) +
-        IOHelper.sizeOfVarBytesLE(this.value) +
-        IOHelper.sizeOfBoolean,
+        IOHelper.sizeOfUInt8,
     );
   }
 
@@ -79,24 +87,28 @@ export class StorageItem implements SerializableWire<StorageItem>, SerializableJ
     return this.sizeInternal();
   }
 
-  public update({ value }: StorageItemUpdate): StorageItem {
+  public update({ value, flags }: StorageItemUpdate): StorageItem {
     return new StorageItem({
       hash: this.hash,
       key: this.key,
       value,
-      isConstant: this.isConstant,
+      flags,
     });
   }
 
   public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeUInt160(this.hash);
+    writer.writeVarBytesLE(this.key);
     writer.writeVarBytesLE(this.value);
-    writer.writeBoolean(this.isConstant);
+    writer.writeUInt8(this.flags);
   }
 
   public serializeJSON(_context: SerializeJSONContext): StorageItemJSON {
     return {
+      hash: JSONHelper.writeUInt160(this.hash),
+      key: JSONHelper.writeBuffer(this.key),
       value: JSONHelper.writeBuffer(this.value),
-      isConstant: this.isConstant,
+      flags: toJSONStorageFlags(this.flags),
     };
   }
 }


### PR DESCRIPTION
### Description of the Change

This does more work to add to the revert from earlier to add back keys and hashes to `StorageItem`. See [here](https://github.com/neo-one-suite/neo-one/pull/1950). There are some places that I missed changing back. Note that this also changes back to the use of `flags` instead of just the `isConstant`, which keeps this part of the `StorageItem` as more extensible in the future should NEO decide to add more flags. This seems especially pertinent given that NEO changes thing in unpredictable ways.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Closer to NEO 3.0

### Possible Drawbacks

None.

### Applicable Issues

None.