### PR TITLE
test(native contracts): Add unit tests for GAS & NEO native contract methods

### DIFF
--- a/packages/neo-one-client-common/src/models/vm.ts
+++ b/packages/neo-one-client-common/src/models/vm.ts
@@ -248,6 +248,8 @@ export enum SysCall {
   'System.Iterator.Values' = 'System.Iterator.Values',
   'Neo.Native.Deploy' = 'Neo.Native.Deploy',
   'Neo.Native.Policy' = 'Neo.Native.Policy',
+  'Neo.Native.Tokens.GAS' = 'Neo.Native.Tokens.GAS',
+  'Neo.Native.Tokens.NEO' = 'Neo.Native.Tokens.NEO',
   'Neo.Crypto.ECDsaVerify' = 'Neo.Crypto.ECDsaVerify',
   'Neo.Crypto.ECDsaCheckMultiSig' = 'Neo.Crypto.ECDsaCheckMultiSig',
   'System.Json.Serialize' = 'System.Json.Serialize',

--- a/packages/neo-one-node-vm/src/__tests__/stackItem/__snapshots__/serializeJson.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/stackItem/__snapshots__/serializeJson.test.ts.snap
@@ -1257,6 +1257,14 @@ exports[`syscalls Neo.Native.Policy 63`] = `Array []`;
 
 exports[`syscalls Neo.Native.Policy 64`] = `Array []`;
 
+exports[`syscalls Neo.Native.Tokens.GAS 1`] = `Array []`;
+
+exports[`syscalls Neo.Native.Tokens.GAS 2`] = `Array []`;
+
+exports[`syscalls Neo.Native.Tokens.GAS 3`] = `Array []`;
+
+exports[`syscalls Neo.Native.Tokens.GAS 4`] = `Array []`;
+
 exports[`syscalls Neo.Storage.Find 1`] = `
 Array [
   IteratorStackItem {

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/__snapshots__/native.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/__snapshots__/native.test.ts.snap
@@ -197,7 +197,14 @@ Array [
           "methods": Array [
             ContractMethodDescriptor {
               "name": "getSysFeeAmount",
-              "parameters": Array [],
+              "parameters": Array [
+                ContractParameterDeclaration {
+                  "name": "index",
+                  "serializeWire": [Function],
+                  "sizeInternal": [Function],
+                  "type": 2,
+                },
+              ],
               "returnType": 7,
               "serializeWire": [Function],
               "sizeInternal": [Function],
@@ -782,3 +789,835 @@ exports[`SysCalls: Neo.Native Neo.Native.Policy 62`] = `Array []`;
 exports[`SysCalls: Neo.Native Neo.Native.Policy 63`] = `Array []`;
 
 exports[`SysCalls: Neo.Native Neo.Native.Policy 64`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 1`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 2`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 3`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 4`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 5`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 6`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 7`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 8`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 9`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 10`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 11`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 12`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 13`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 14`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "11",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 15`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 16`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 17`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 18`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 19`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 20`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "200101010101010101010101010101010101010101",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 21`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 22`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 23`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 24`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 25`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 26`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "1505",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 27`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 28`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 29`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 30`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 31`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 32`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "1505",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 33`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 34`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 35`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 36`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 37`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 38`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 39`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 40`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 41`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 42`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 43`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 44`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 45`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 46`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 47`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 48`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 49`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 50`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 51`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 52`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 53`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 54`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 55`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 56`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 57`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 58`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 59`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 60`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 61`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 62`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 63`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 64`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 65`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 66`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 67`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 68`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 69`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 70`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 71`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 72`] = `
+Array [
+  Array [
+    Object {
+      "hash": "3775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 73`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 74`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 75`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 76`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 77`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 78`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 79`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 80`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 81`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 82`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "200000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 83`] = `"storageItem.delete"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 84`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 85`] = `"storageItem.add"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 86`] = `
+Array [
+  Array [
+    StorageItem {
+      "flags": 0,
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "200000000000000000000000000000000000000000",
+      "serializeWire": [Function],
+      "sizeInternal": [Function],
+      "value": "05",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 87`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 88`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 89`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 90`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 91`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 92`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 93`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 94`] = `
+Array [
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+  Array [
+    Object {
+      "hash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+      "key": "200000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 95`] = `"storageItem.update"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 96`] = `
+Array [
+  Array [
+    Object {
+      "value": "5",
+    },
+    Object {
+      "flags": 0,
+      "value": "02",
+    },
+  ],
+  Array [
+    Object {
+      "value": "14",
+    },
+    Object {
+      "flags": 0,
+      "value": "11",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 97`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "173e6724888531bfb401c9f212c4f0b0b9569cdf",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 98`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 99`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.GAS 100`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 1`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 2`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 3`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 4`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 5`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 6`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 7`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 8`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 9`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 10`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 11`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 12`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 13`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 14`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "11",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 15`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 16`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 17`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 18`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 19`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 20`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "200101010101010101010101010101010101010101",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 21`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 22`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 23`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 24`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 25`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 26`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 27`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 28`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 29`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 30`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 31`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 32`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 33`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 34`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 35`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 36`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 37`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 38`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 39`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 40`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 41`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 42`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 43`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 44`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 45`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 46`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 47`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 48`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 49`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 50`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 51`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 52`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 53`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 54`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 55`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 56`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 57`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 58`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 59`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 60`] = `
+Array [
+  Array [
+    Object {
+      "hash": "3775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 61`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 62`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 63`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 64`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 65`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 66`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 67`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 68`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 69`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 70`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "200000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 71`] = `"storageItem.delete"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 72`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 73`] = `"storageItem.add"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 74`] = `
+Array [
+  Array [
+    StorageItem {
+      "flags": 0,
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "200000000000000000000000000000000000000000",
+      "serializeWire": [Function],
+      "sizeInternal": [Function],
+      "value": "05",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 75`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 76`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 77`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 78`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 79`] = `"contract.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 80`] = `
+Array [
+  Array [
+    Object {
+      "hash": "0000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 81`] = `"storageItem.tryGet"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 82`] = `
+Array [
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "203775292229eccdf904f16fff8e83e7cffdc0f0ce",
+    },
+  ],
+  Array [
+    Object {
+      "hash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+      "key": "200000000000000000000000000000000000000000",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 83`] = `"storageItem.update"`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 84`] = `
+Array [
+  Array [
+    Object {
+      "value": "5",
+    },
+    Object {
+      "flags": 0,
+      "value": "02",
+    },
+  ],
+  Array [
+    Object {
+      "value": "14",
+    },
+    Object {
+      "flags": 0,
+      "value": "11",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 85`] = `
+Array [
+  Array [
+    Object {
+      "args": Array [],
+      "scriptHash": "a2d96c2ec153e9e3255a84db1881745555fecb6c",
+    },
+  ],
+]
+`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 86`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 87`] = `Array []`;
+
+exports[`SysCalls: Neo.Native Neo.Native.Tokens.NEO 88`] = `Array []`;

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/native.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/native.test.ts
@@ -1,9 +1,16 @@
 // tslint:disable no-object-mutation
 import { common } from '@neo-one/client-common';
+import { ContractPropertyState, createContract, createContractManifest } from '@neo-one/node-core';
 import { BN } from 'bn.js';
-import { runSysCalls, TestCase } from '../../__data__';
+import { keys, runSysCalls, TestCase } from '../../__data__';
 import { FEES } from '../../constants';
-import { ArrayStackItem, BooleanStackItem, IntegerStackItem, UInt160StackItem } from '../../stackItem';
+import { ArrayStackItem, BooleanStackItem, IntegerStackItem, StringStackItem, UInt160StackItem } from '../../stackItem';
+
+const contract = createContract({
+  manifest: createContractManifest({
+    features: ContractPropertyState.HasStorage,
+  }),
+});
 
 const SYSCALLS: readonly TestCase[] = [
   {
@@ -118,6 +125,326 @@ const SYSCALLS: readonly TestCase[] = [
       blockchain.storageItem.update = jest.fn(async () => Promise.resolve());
     },
     gas: FEES[3_000_000],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new StringStackItem('GAS')],
+    args: ['name', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new StringStackItem('gas')],
+    args: ['symbol', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new IntegerStackItem(new BN(8))],
+    args: ['decimals', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new IntegerStackItem(new BN(1500))],
+    args: ['totalSupply', []],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(1500) }));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new IntegerStackItem(new BN(12))],
+    args: ['balanceOf', [Buffer.alloc(20, 1)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(12) }));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new IntegerStackItem(new BN(1200))],
+    args: ['getSysFeeAmount', [new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(1200) }));
+    },
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new IntegerStackItem(new BN(0))],
+    args: ['getSysFeeAmount', [new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[0],
+  },
+
+  // Amount less than 0
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(-1)]],
+    gas: FEES[8_000_000],
+    error: `VM Error: Native NEP5 Contract expected amount`,
+  },
+
+  // context.scriptHash !== from
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [Buffer.alloc(20, 1), Buffer.alloc(20, 0), new BN(10)]],
+    gas: FEES[8_000_000],
+  },
+
+  // to is a contract without payable feature
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(10)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve(contract));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // 0 amount
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(0)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(12) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from has no storage/balance
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from has less balance than amount
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(3) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from === to
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, keys[0].scriptHash, new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(5) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // amount equal to from balance & to storage undefined
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest
+        .fn()
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(5) }))
+        .mockImplementationOnce(async () => Promise.resolve());
+      blockchain.storageItem.delete = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.add = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from & to have nonzero balances not equal to amount
+  {
+    name: 'Neo.Native.Tokens.GAS',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(3)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest
+        .fn()
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(5) }))
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(14) }));
+      blockchain.storageItem.update = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new StringStackItem('NEO')],
+    args: ['name', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new StringStackItem('neo')],
+    args: ['symbol', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new IntegerStackItem(new BN(0))],
+    args: ['decimals', []],
+    gas: FEES[0],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new IntegerStackItem(new BN(2500))],
+    args: ['totalSupply', []],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(2500) }));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new IntegerStackItem(new BN(12000))],
+    args: ['balanceOf', [Buffer.alloc(20, 1)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(12000) }));
+    },
+    gas: FEES[1_000_000],
+  },
+
+  // Amount less than 0
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(-1)]],
+    gas: FEES[8_000_000],
+    error: `VM Error: Native NEP5 Contract expected amount`,
+  },
+
+  // context.scriptHash !== from
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [Buffer.alloc(20, 1), Buffer.alloc(20, 0), new BN(10)]],
+    gas: FEES[8_000_000],
+  },
+
+  // to is a contract without payable feature
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(10)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve(contract));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // 0 amount
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(0)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(12) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from has no storage/balance
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from has less balance than amount
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(false)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(3) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from === to
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, keys[0].scriptHash, new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest.fn(async () => Promise.resolve({ value: new BN(5) }));
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // amount equal to from balance & to storage undefined
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(5)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest
+        .fn()
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(5) }))
+        .mockImplementationOnce(async () => Promise.resolve());
+      blockchain.storageItem.delete = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.add = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
+  },
+
+  // from & to have nonzero balances not equal to amount
+  {
+    name: 'Neo.Native.Tokens.NEO',
+    result: [new BooleanStackItem(true)],
+    args: ['transfer', [keys[0].scriptHash, Buffer.alloc(20, 0), new BN(3)]],
+    mockBlockchain: ({ blockchain }) => {
+      blockchain.contract.tryGet = jest.fn(async () => Promise.resolve());
+      blockchain.storageItem.tryGet = jest
+        .fn()
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(5) }))
+        .mockImplementationOnce(async () => Promise.resolve({ value: new BN(14) }));
+      blockchain.storageItem.update = jest.fn(async () => Promise.resolve());
+    },
+    gas: FEES[8_000_000],
   },
 ];
 

--- a/packages/neo-one-node-vm/src/native/NativeContract.ts
+++ b/packages/neo-one-node-vm/src/native/NativeContract.ts
@@ -3,12 +3,12 @@ import { GasToken, NeoToken } from './tokens';
 
 export interface NativeContract {
   readonly 'Neo.Native.Policy': PolicyContract;
-  readonly 'Neo.Native.Tokens.Gas': GasToken;
-  readonly 'Neo.Native.Tokens.Neo': NeoToken;
+  readonly 'Neo.Native.Tokens.GAS': GasToken;
+  readonly 'Neo.Native.Tokens.NEO': NeoToken;
 }
 
 export const NativeContract: NativeContract = {
   'Neo.Native.Policy': new PolicyContract(),
-  'Neo.Native.Tokens.Gas': new GasToken(),
-  'Neo.Native.Tokens.Neo': new NeoToken(),
+  'Neo.Native.Tokens.GAS': new GasToken(),
+  'Neo.Native.Tokens.NEO': new NeoToken(),
 };

--- a/packages/neo-one-node-vm/src/native/index.ts
+++ b/packages/neo-one-node-vm/src/native/index.ts
@@ -1,3 +1,4 @@
 export * from './NativeContract';
+export * from './NativeContractBase';
 export * from './PolicyContract';
 export * from './tokens';

--- a/packages/neo-one-node-vm/src/native/tokens/GasToken.ts
+++ b/packages/neo-one-node-vm/src/native/tokens/GasToken.ts
@@ -1,5 +1,5 @@
 import { common } from '@neo-one/client-common';
-import { ContractParameterType } from '@neo-one/node-core';
+import { ContractParameterDeclaration, ContractParameterType } from '@neo-one/node-core';
 import { BN } from 'bn.js';
 import { ExecutionContext, FEES, OpInvokeArgs } from '../../constants';
 import { IntegerStackItem } from '../../stackItem';
@@ -11,7 +11,7 @@ export const GAS_METHODS: readonly ContractMethodData[] = [
     name: 'getSysFeeAmount',
     price: FEES[0],
     returnType: ContractParameterType.String,
-    parameters: [],
+    parameters: [new ContractParameterDeclaration({ type: ContractParameterType.Integer, name: 'index' })],
     safeMethod: true,
     delegate: (contract: NativeContractBase) => async ({ context, args }: OpInvokeArgs) => {
       const index = args[0].asBigInteger();

--- a/packages/neo-one-node-vm/src/native/tokens/Nep5Token.ts
+++ b/packages/neo-one-node-vm/src/native/tokens/Nep5Token.ts
@@ -1,4 +1,4 @@
-import { UInt160 } from '@neo-one/client-common';
+import { common, UInt160 } from '@neo-one/client-common';
 import { HasPayable } from '@neo-one/client-full-common';
 import { ContractParameterDeclaration, ContractParameterType, StorageFlags, StorageItem } from '@neo-one/node-core';
 import { BN } from 'bn.js';
@@ -144,7 +144,7 @@ export const NEP5_METHODS = (
         if (stateFrom.mutableBalance.lt(amount)) {
           return new BooleanStackItem(false);
         }
-        if (from === to) {
+        if (common.uInt160ToHex(from) === common.uInt160ToHex(to)) {
           onBalanceChange(context, from, stateFrom, new BN(0));
         } else {
           onBalanceChange(context, from, stateFrom, amount.neg());

--- a/packages/neo-one-node-vm/src/syscalls.ts
+++ b/packages/neo-one-node-vm/src/syscalls.ts
@@ -57,7 +57,7 @@ import {
   UnknownNativeContractMethodError,
   UnknownSysCallError,
 } from './errors';
-import { NativeContract } from './native';
+import { NativeContract, NativeContractServiceName } from './native';
 import {
   ArrayStackItem,
   BlockStackItem,
@@ -389,11 +389,11 @@ const createPut = ({ name }: { readonly name: 'System.Storage.Put' | 'System.Sto
   })({ context: contextIn });
 };
 
-const createNative = ({ name }: { readonly name: 'Neo.Native.Policy' }) => ({
+const createNative = ({ name }: { readonly name: NativeContractServiceName }) => ({
   context: contextIn,
 }: CreateSysCallArgs) => {
   const contract = NativeContract[name];
-  if (contract === undefined) {
+  if ((contract as typeof contract | undefined) === undefined) {
     throw new UnknownNativeContractError(contextIn, name);
   }
   const methodName = contextIn.stack[0].asString();
@@ -943,6 +943,10 @@ export const SYSCALLS: { readonly [K in SysCallEnum]: CreateSysCall } = {
   }),
 
   'Neo.Native.Policy': createNative({ name: 'Neo.Native.Policy' }),
+
+  'Neo.Native.Tokens.GAS': createNative({ name: 'Neo.Native.Tokens.GAS' }),
+
+  'Neo.Native.Tokens.NEO': createNative({ name: 'Neo.Native.Tokens.NEO' }),
 
   'System.Enumerator.Create': createSysCall({
     name: 'System.Enumerator.Create',


### PR DESCRIPTION
### Description of the Change
Adds tests for the GAS Token and Nep5 methods of the NEO token.  These are tested as syscalls through the syscall unit tests.  

### Test Plan
This tests the native contracts as unit tests with storage mocked out.  Eventually we will also want to add tests which include storage and blockchain state, similar to the execute tests.  

### Applicable Issues
https://github.com/neo-one-suite/neo-one/issues/1953