### PR TITLE
feat(jest watch): add watch flag to run jest in watch mode

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -402,6 +402,12 @@
       "associatedCommands": ["test", "test-ci", "e2e", "e2e-ci", "e2e-ci:coverage"]
     },
     {
+      "parameterKind": "flag",
+      "longName": "--watch",
+      "description": "jest --watch flag",
+      "associatedCommands": ["test", "test-ci", "e2e", "e2e-ci", "e2e-ci:coverage"]
+    },
+    {
       "parameterKind": "string",
       "longName": "--max-workers",
       "shortName": "-w",


### PR DESCRIPTION
### Description of the Change

Adds the ability to run `jest` unit tests in watch mode with the `--watch` flag

### Test Plan

1. Run a unit test in watch mode, like `rush test -t packages/neo-one-client-common/src/__tests__/common.test.ts --watch`
2. Change `common.ts` or `common.test.ts` and watch Jest re-run the test
