### PR TITLE
fix(syscalls): minor updates to syscalls

### DIFF
--- a/packages/neo-one-node-core/src/vm.ts
+++ b/packages/neo-one-node-core/src/vm.ts
@@ -26,7 +26,8 @@ export enum TriggerType {
   System = 0x01,
   Verification = 0x20,
   Application = 0x40,
-  // TODO: We may need to add an "All" member like they do in C# code
+  // tslint:disable-next-line: no-bitwise
+  All = 0x01 | 0x20 | 0x40,
 }
 
 // Application
@@ -62,7 +63,8 @@ export interface VMListeners {
   readonly onNotify?: (options: { readonly args: readonly ContractParameter[]; readonly scriptHash: UInt160 }) => void;
 
   readonly onLog?: (options: { readonly message: string; readonly scriptHash: UInt160 }) => void;
-  // TODO: we may be able to remove this listener since there is no SysCall `Neo.Contract.Migrate` anymore
+  // TODO: update this to be onUpdateContract. Make it implement the same type of logic for when "updating" contracts
+  // then add to System.Contract.Update syscall
   readonly onMigrateContract?: (options: { readonly from: UInt160; readonly to: UInt160 }) => void;
   readonly onSetVotes?: (options: { readonly address: UInt160; readonly votes: readonly ECPoint[] }) => void;
 }

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/__snapshots__/storage.test.ts.snap
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/__snapshots__/storage.test.ts.snap
@@ -10,15 +10,7 @@ exports[`SysCalls: System.Storage System.Storage.AsReadOnly 4`] = `Array []`;
 
 exports[`SysCalls: System.Storage System.Storage.Delete 1`] = `"contract.get"`;
 
-exports[`SysCalls: System.Storage System.Storage.Delete 2`] = `
-Array [
-  Array [
-    Object {
-      "hash": "3f67626522f6e54e4e92ada1b1da8133409d5ec3",
-    },
-  ],
-]
-`;
+exports[`SysCalls: System.Storage System.Storage.Delete 2`] = `Array []`;
 
 exports[`SysCalls: System.Storage System.Storage.Delete 3`] = `"storageItem.tryGet"`;
 
@@ -58,7 +50,7 @@ exports[`SysCalls: System.Storage System.Storage.Find 1`] = `
 Array [
   IteratorStackItem {
     "mutableCount": 1,
-    "referenceID": 1,
+    "referenceID": 3,
     "value": StackItemIterator {
       "enumerator": Object {
         "next": [Function],

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/blockchain.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/blockchain.test.ts
@@ -6,9 +6,9 @@ import { keys, runSysCalls, scriptAttributeHash, TestCase, transactions } from '
 import { FEES } from '../../constants';
 import {
   BlockStackItem,
-  BufferStackItem,
   ContractStackItem,
   IntegerStackItem,
+  NullStackItem,
   TransactionStackItem,
 } from '../../stackItem';
 
@@ -140,7 +140,7 @@ const SYSCALLS: readonly TestCase[] = [
 
   {
     name: 'System.Blockchain.GetContract',
-    result: [new BufferStackItem(Buffer.alloc(0, 0))],
+    result: [new NullStackItem()],
     mockBlockchain: ({ blockchain }) => {
       blockchain.contract.tryGet = jest.fn(async () => Promise.resolve(undefined));
     },

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/json.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/json.test.ts
@@ -86,42 +86,42 @@ const SYSCALLS: readonly TestCase[] = [
     name: 'System.Json.Serialize',
     result: [new StringStackItem(JSON.stringify(simpleJson))],
     args: [simpleJsonToBuffer],
-    gas: FEES[400],
+    gas: FEES[100_000],
   },
 
   {
     name: 'System.Json.Serialize',
     result: [new StringStackItem(JSON.stringify(nestedJson))],
     args: [nestedJsonToBuffer],
-    gas: FEES[400],
+    gas: FEES[100_000],
   },
 
   {
     name: 'System.Json.Serialize',
     result: [new StringStackItem(JSON.stringify(1))],
     args: [1],
-    gas: FEES[400],
+    gas: FEES[100_000],
   },
 
   {
     name: 'System.Json.Deserialize',
     result: [simpleMapStackItem],
     args: [JSON.stringify(simpleJson)],
-    gas: FEES[400],
+    gas: FEES[500_000],
   },
 
   {
     name: 'System.Json.Deserialize',
     result: [nestedMapStackItem],
     args: [JSON.stringify(nestedJson)],
-    gas: FEES[400],
+    gas: FEES[500_000],
   },
 
   {
     name: 'System.Json.Deserialize',
     result: [new IntegerStackItem(new BN(1))],
     args: ['1'],
-    gas: FEES[400],
+    gas: FEES[500_000],
   },
 ];
 

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/runtime.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/runtime.test.ts
@@ -10,6 +10,7 @@ import {
   BufferStackItem,
   ConsensusPayloadStackItem,
   IntegerStackItem,
+  NullStackItem,
   TransactionStackItem,
   UInt160StackItem,
   UInt256StackItem,
@@ -40,14 +41,14 @@ const SYSCALLS: readonly TestCase[] = [
     name: 'System.Runtime.Notify',
     result: [],
     args: [[true]],
-    gas: FEES[250],
+    gas: FEES[1_000_000],
   },
 
   {
     name: 'System.Runtime.Log',
     result: [],
     args: ['foo'],
-    gas: FEES[30_0000],
+    gas: FEES[1_000_000],
   },
 
   {
@@ -171,7 +172,7 @@ const SYSCALLS: readonly TestCase[] = [
 
   {
     name: 'System.Runtime.GetCallingScriptHash',
-    result: [new BufferStackItem(Buffer.alloc(0, 0))],
+    result: [new NullStackItem()],
     gas: FEES[400],
   },
   {

--- a/packages/neo-one-node-vm/src/__tests__/syscalls/storage.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls/storage.test.ts
@@ -5,7 +5,7 @@ import { AsyncIterableX } from '@reactivex/ix-es2015-cjs/asynciterable/asynciter
 import { BN } from 'bn.js';
 import { runSysCalls, TestCase } from '../../__data__';
 import { FEES } from '../../constants';
-import { BufferStackItem, StorageContextStackItem } from '../../stackItem';
+import { BufferStackItem, NullStackItem, StorageContextStackItem } from '../../stackItem';
 
 const SYSCALLS: readonly TestCase[] = [
   {
@@ -49,7 +49,7 @@ const SYSCALLS: readonly TestCase[] = [
 
   {
     name: 'System.Storage.Get',
-    result: [new BufferStackItem(Buffer.from([]))],
+    result: [new NullStackItem()],
     args: [
       {
         type: 'calls',

--- a/packages/neo-one-node-vm/src/constants.ts
+++ b/packages/neo-one-node-vm/src/constants.ts
@@ -1,4 +1,4 @@
-import { common, OpCode, SysCallName, UInt160, VMState } from '@neo-one/client-common';
+import { OpCode, SysCallName, UInt160, VMState } from '@neo-one/client-common';
 import { Block, ExecutionAction, ScriptContainer, TriggerType, VMListeners, WriteBlockchain } from '@neo-one/node-core';
 import { BN } from 'bn.js';
 import { StackItem } from './stackItem';
@@ -51,7 +51,7 @@ export const FEES = {
   8_000_000: new BN(8000000),
 };
 
-export const FREE_GAS = common.TEN_FIXED8;
+export const FREE_GAS = FEES[0];
 export type ExecutionStack = readonly StackItem[];
 export interface ExecutionInit {
   readonly scriptContainer: ScriptContainer;


### PR DESCRIPTION
### Description of the Change

Some minor updates to SysCall fees and returning NullStackItems where applicable.

### Test Plan

`rush test -t packages/neo-one-node-vm/src/__tests__/syscalls/storage.test.ts`
`rush test -t packages/neo-one-node-vm/src/__tests__/syscalls/runtime.test.ts`
`rush test -t packages/neo-one-node-vm/src/__tests__/syscalls/blockchain.test.ts`
`rush test -t packages/neo-one-node-vm/src/__tests__/syscalls/json.test.ts`

### Benefits

Closer to NEO 3.0

### Applicable Issues

#1874 
#1974 