### PR TITLE
feat(ts): upgrade TS to v3.8.1-rc

### DIFF
--- a/common/changes/@neo-one/cli-common-node/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/cli-common-node/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli-common-node",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli-common-node",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/cli/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/cli/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-blockchain/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/node-blockchain/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-blockchain",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/node-blockchain",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-core/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/node-core/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-core",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/node-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-vm/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/node-vm/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-vm",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-vm",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/react-common/upgrade-ts_2020-02-26-01-35.json
+++ b/common/changes/@neo-one/react-common/upgrade-ts_2020-02-26-01-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/react-common",
+      "comment": "Upgrade TS to v3.8.1-rc. Fix types.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/react-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/react-core/upgrade-ts_2020-02-26-01-35.json
+++ b/common/changes/@neo-one/react-core/upgrade-ts_2020-02-26-01-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/react-core",
+      "comment": "Upgrade TS to v3.8.1-rc. Fix types.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/react-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-codegen/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/smart-contract-codegen/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-codegen",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-codegen",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-compiler-node/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/smart-contract-compiler-node/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler-node",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler-node",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-compiler/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/smart-contract-compiler/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler",
+      "comment": "Upgrade TS to v3.8.1-rc. Add support for Nullish Coalescing",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-typescript-plugin/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/smart-contract-typescript-plugin/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-typescript-plugin",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-typescript-plugin",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/ts-utils/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/ts-utils/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/ts-utils",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/ts-utils",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/typescript-concatenator/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/typescript-concatenator/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/typescript-concatenator",
+      "comment": "Upgrade TS to v3.8.1-rc. Add support for namespace exports",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/typescript-concatenator",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/utils/upgrade-ts_2020-02-26-01-16.json
+++ b/common/changes/@neo-one/utils/upgrade-ts_2020-02-26-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/utils",
+      "comment": "Upgrade TS to v3.8.1-rc",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/utils",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -17,7 +17,7 @@
     "tslint-immutable": "^6.0.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "implicitlyPreferredVersions": true,
 

--- a/common/config/rush/yarn.lock
+++ b/common/config/rush/yarn.lock
@@ -2010,7 +2010,7 @@
     ts-loader "^6.1.0"
     ts-node "^8.4.1"
     tslint "^5.20.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     url-loader "^3.0.0"
     webpack "^4.40.2"
     webpack-bundle-analyzer "^3.4.1"
@@ -2064,7 +2064,7 @@
     tslint-immutable "^6.0.1"
     tslint-microsoft-contrib "^6.2.0"
     tslint-sonarts "^1.9.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     yargs "^14.2.0"
 
 "@rush-temp/cli-common-node@file:./projects/cli-common-node.tgz":
@@ -2125,7 +2125,7 @@
     source-map "^0.7.3"
     ts-node "^8.4.1"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     yargs "^14.2.0"
     zone.js "^0.10.2"
 
@@ -2375,7 +2375,7 @@
     styled-tools "^1.7.1"
     ts-node "^8.4.1"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     typescript-fsa "^3.0.0-beta-2"
     typescript-fsa-reducers "^1.2.1"
     webpack "^4.40.2"
@@ -2433,7 +2433,7 @@
     safe-stable-stringify "^1.1.0"
     source-map "^0.7.3"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/local-singleton@file:./projects/local-singleton.tgz":
   version "0.0.0"
@@ -2752,7 +2752,7 @@
     glob "^7.1.4"
     gulp "~4.0.2"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/smart-contract-compiler@file:./projects/smart-contract-compiler.tgz":
   version "0.0.0"
@@ -2776,7 +2776,7 @@
     safe-stable-stringify "^1.1.0"
     source-map "^0.7.3"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/smart-contract-lib@file:./projects/smart-contract-lib.tgz":
   version "0.0.0"
@@ -2820,7 +2820,7 @@
   resolved "file:./projects/smart-contract-typescript-plugin.tgz"
   dependencies:
     gulp "~4.0.2"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/smart-contract@file:./projects/smart-contract.tgz":
   version "0.0.0"
@@ -2843,7 +2843,7 @@
     lodash "^4.17.15"
     source-map "^0.7.3"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/typescript-concatenator@file:./projects/typescript-concatenator.tgz":
   version "0.0.0"
@@ -2861,7 +2861,7 @@
     lodash "^4.17.15"
     toposort "^2.0.2"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     yargs "^14.2.0"
 
 "@rush-temp/utils-node@file:./projects/utils-node.tgz":
@@ -2891,7 +2891,7 @@
     lodash "^4.17.15"
     rxjs "^6.5.3"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
 
 "@rush-temp/website@file:./projects/website.tgz":
   version "0.0.0"
@@ -2957,7 +2957,7 @@
     styled-tools "^1.7.1"
     ts-node "^8.4.1"
     tslib "^1.10.0"
-    typescript "3.6.3"
+    typescript "3.8.1-rc"
     typescript-fsa "^3.0.0-beta-2"
     typescript-fsa-reducers "^1.2.1"
     webpack "^4.40.2"
@@ -13862,11 +13862,6 @@ monaco-editor@^0.17.1:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.17.1.tgz#8fbe96ca54bfa75262706e044f8f780e904aa45c"
   integrity sha512-JAc0mtW7NeO+0SwPRcdkfDbWLgkqL9WfP1NbpP9wNASsW6oWqgZqNIWt4teymGjZIXTElx3dnQmUYHmVrJ7HxA==
 
-monaco-editor@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
-  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
-
 monaco-textmate@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/monaco-textmate/-/monaco-textmate-3.0.1.tgz#b6d26d266aa12edaff7069dae0d6e3747cba5cd7"
@@ -15873,7 +15868,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.18.2:
+prettier@1.19.1, prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -19328,10 +19323,10 @@ typescript-fsa@^3.0.0-beta-2:
   resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-3.0.0.tgz#3ad1cb915a67338e013fc21f67c9b3e0e110c912"
   integrity sha512-xiXAib35i0QHl/+wMobzPibjAH5TJLDj+qGq5jwVLG9qR4FUswZURBw2qihBm0m06tHoyb3FzpnJs1GRhRwVag==
 
-typescript@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@3.8.1-rc:
+  version "3.8.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.1-rc.tgz#f94333c14da70927ccd887be2e91be652a9a09f6"
+  integrity sha512-aOIe066DyZn2uYIiND6fXMUUJ70nxwu/lKhA92QuQzXyC86fr0ywo1qvO8l2m0EnDcfjprYPuFRgNgDj7U2GlQ==
 
 typescript@^3.2.2:
   version "3.7.3"

--- a/packages/neo-one-build-tools-web/package.json
+++ b/packages/neo-one-build-tools-web/package.json
@@ -35,6 +35,7 @@
     "last 2 edge versions",
     "last 2 firefox versions"
   ],
+  "sideEffects": false,
   "dependencies": {
     "@babel/core": "^7.6.2",
     "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
@@ -77,7 +78,7 @@
     "thread-loader": "^2.1.3",
     "ts-loader": "^6.1.0",
     "ts-node": "^8.4.1",
-    "typescript": "3.6.3",
+    "typescript": "3.8.1-rc",
     "url-loader": "^3.0.0",
     "webpack": "^4.40.2",
     "webpack-bundle-analyzer": "^3.4.1",
@@ -108,6 +109,5 @@
     "gulp-rename": "^2.0.0",
     "gulp-typescript": "^5.0.1",
     "tslint": "^5.20.0"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-build-tools/bin/neo-one-tsc.js
+++ b/packages/neo-one-build-tools/bin/neo-one-tsc.js
@@ -2,8 +2,10 @@
 const path = require('path');
 const execa = require('execa');
 
-execa(path.resolve(__dirname, '..', 'node_modules', '.bin', 'tsc'), [
-  '--project',
-  '.',
-  '--noEmit',
-]);
+execa(
+  path.resolve(__dirname, '..', 'node_modules', '.bin', 'tsc'),
+  ['--project', '.', '--noEmit'],
+  {
+    stdio: 'inherit',
+  },
+);

--- a/packages/neo-one-build-tools/package.json
+++ b/packages/neo-one-build-tools/package.json
@@ -41,14 +41,15 @@
     "last 2 edge versions",
     "last 2 firefox versions"
   ],
+  "sideEffects": false,
   "dependencies": {
     "execa": "^3.2.0",
     "fs-extra": "^8.1.0",
     "gulp": "~4.0.2",
     "gulp-banner": "^0.1.3",
-    "gulp-if": "^3.0.0",
     "gulp-filter": "^6.0.0",
     "gulp-flatten": "^0.4.0",
+    "gulp-if": "^3.0.0",
     "gulp-json-transform": "^0.4.7",
     "gulp-plumber": "^1.2.1",
     "gulp-rename": "^2.0.0",
@@ -62,6 +63,7 @@
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-typescript2": "^0.25.0",
     "rxjs-tslint-rules": "^4.24.3",
+    "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
     "tslint-clean-code": "^0.2.9",
     "tslint-config-prettier": "^1.18.0",
@@ -69,16 +71,15 @@
     "tslint-immutable": "^6.0.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-sonarts": "^1.9.0",
-    "ts-node": "^8.4.1",
-    "typescript": "3.6.3",
+    "typescript": "3.8.1-rc",
     "yargs": "^14.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
     "@types/gulp": "^4.0.6",
-    "@types/gulp-if": "^0.0.33",
     "@types/gulp-filter": "^3.0.33",
     "@types/gulp-flatten": "^0.0.31",
+    "@types/gulp-if": "^0.0.33",
     "@types/gulp-plumber": "^0.0.32",
     "@types/gulp-rename": "^0.0.33",
     "@types/gulp-replace": "^0.0.31",
@@ -86,6 +87,5 @@
     "@types/lodash": "^4.14.138",
     "@types/minimatch": "^3.0.3",
     "@types/yargs": "^13.0.3"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -278,7 +278,10 @@ const validateConfig = async (rootDir: string, configIn: any): Promise<Configura
   let newFramework: CodegenFramework | undefined;
   let newLanguage: CodegenLanguage | undefined;
   if (Object.keys(configIn).length === 0) {
-    [newFramework, newLanguage] = await Promise.all([getProjectFramework(rootDir), getProjectLanguage(rootDir)]);
+    [newFramework, newLanguage] = await Promise.all([
+      getProjectFramework(rootDir),
+      getProjectLanguage(rootDir),
+    ] as const);
   }
 
   return {

--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -13,12 +13,13 @@
   "bin": {
     "neo-one": "bin/neo-one.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@babel/core": "^7.6.2",
     "@babel/register": "^7.5.5",
-    "@neo-one/client": "^2.3.0",
     "@neo-one/cli-common": "^2.4.0",
     "@neo-one/cli-common-node": "^2.4.0",
+    "@neo-one/client": "^2.3.0",
     "@neo-one/client-common": "^2.3.0",
     "@neo-one/client-core": "^2.3.0",
     "@neo-one/client-full": "^2.3.0",
@@ -47,9 +48,9 @@
     "prompts": "^2.2.1",
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
-    "tslib": "^1.10.0",
     "ts-node": "^8.4.1",
-    "typescript": "3.6.3",
+    "tslib": "^1.10.0",
+    "typescript": "3.8.1-rc",
     "yargs": "^14.2.0"
   },
   "devDependencies": {
@@ -69,6 +70,5 @@
     "react": "^16.12.0",
     "rxjs": "^6.5.3",
     "zone.js": "^0.10.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-cli/src/__data__/projects/exchange/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/exchange/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash a1c197d60788400088cc39a4ff04466d */
+/* @hash cc22deec02b78c38de97754994eeef14 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -64,7 +64,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10210/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:10000/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -145,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10210/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10000/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico-Js/codegen/client.js
+++ b/packages/neo-one-cli/src/__data__/projects/ico-Js/codegen/client.js
@@ -1,4 +1,4 @@
-/* @hash 8e632ab2286d0f4b535b6faf0848ec52 */
+/* @hash 22117686016222857105d2c4f9dfcb88 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -20,8 +20,7 @@ const getDefaultUserAccountProviders = (provider) => {
     }),
   };
 
-  const dapi =
-    typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
+  const dapi = typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
   if (dapi !== undefined) {
     return {
       ...localUserAccountProvider,
@@ -38,8 +37,7 @@ const getDefaultUserAccountProviders = (provider) => {
   return localUserAccountProvider;
 };
 
-const isLocalUserAccountProvider = (userAccountProvider) =>
-  userAccountProvider instanceof LocalUserAccountProvider;
+const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = (getUserAccountProvidersOrHost) => {
   let getUserAccountProviders = getDefaultUserAccountProviders;
@@ -51,25 +49,16 @@ export const createClient = (getUserAccountProvidersOrHost) => {
   }
 
   const providers = [];
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10220/rpc` });
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
+    providers.push({ network: 'local', rpcURL: `http://${host}:10010/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(
-    isLocalUserAccountProvider,
-  );
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
   const localUserAccountProvider = localUserAccountProviders.find(
-    (userAccountProvider) =>
-      userAccountProvider.keystore instanceof LocalKeyStore,
+    (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
     if (localUserAccountProvider !== undefined) {
       const localKeyStore = localUserAccountProvider.keystore;
       if (localKeyStore instanceof LocalKeyStore) {
@@ -140,10 +129,5 @@ export const createClient = (getUserAccountProvidersOrHost) => {
 };
 
 export const createDeveloperClients = (host = 'localhost') => ({
-  local: new DeveloperClient(
-    new NEOONEDataProvider({
-      network: 'local',
-      rpcURL: `http://${host}:10220/rpc`,
-    }),
-  ),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10010/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico-angular/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico-angular/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash 41c2926d74e576594da57e5577bca924 */
+/* @hash 62c81cb3802f775995035832c616b05b */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -64,7 +64,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10230/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:10020/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -145,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10230/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10020/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico-angularJs/codegen/client.js
+++ b/packages/neo-one-cli/src/__data__/projects/ico-angularJs/codegen/client.js
@@ -1,4 +1,4 @@
-/* @hash d744b54b8eda56be8728d023b3c76f92 */
+/* @hash f46d3990a4894d6a61d9ff22499ee172 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -20,8 +20,7 @@ const getDefaultUserAccountProviders = (provider) => {
     }),
   };
 
-  const dapi =
-    typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
+  const dapi = typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
   if (dapi !== undefined) {
     return {
       ...localUserAccountProvider,
@@ -38,8 +37,7 @@ const getDefaultUserAccountProviders = (provider) => {
   return localUserAccountProvider;
 };
 
-const isLocalUserAccountProvider = (userAccountProvider) =>
-  userAccountProvider instanceof LocalUserAccountProvider;
+const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = (getUserAccountProvidersOrHost) => {
   let getUserAccountProviders = getDefaultUserAccountProviders;
@@ -51,25 +49,16 @@ export const createClient = (getUserAccountProvidersOrHost) => {
   }
 
   const providers = [];
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10240/rpc` });
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
+    providers.push({ network: 'local', rpcURL: `http://${host}:10030/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(
-    isLocalUserAccountProvider,
-  );
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
   const localUserAccountProvider = localUserAccountProviders.find(
-    (userAccountProvider) =>
-      userAccountProvider.keystore instanceof LocalKeyStore,
+    (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
     if (localUserAccountProvider !== undefined) {
       const localKeyStore = localUserAccountProvider.keystore;
       if (localKeyStore instanceof LocalKeyStore) {
@@ -140,10 +129,5 @@ export const createClient = (getUserAccountProvidersOrHost) => {
 };
 
 export const createDeveloperClients = (host = 'localhost') => ({
-  local: new DeveloperClient(
-    new NEOONEDataProvider({
-      network: 'local',
-      rpcURL: `http://${host}:10240/rpc`,
-    }),
-  ),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10030/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico-vue/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico-vue/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash c6fd7a5eb87f74583e5407858293dbb3 */
+/* @hash 52c353d47e30c3e4c1036416ac26de71 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -64,7 +64,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10250/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:10040/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -145,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10250/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10040/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico-vueJs/codegen/client.js
+++ b/packages/neo-one-cli/src/__data__/projects/ico-vueJs/codegen/client.js
@@ -1,4 +1,4 @@
-/* @hash a3b54647441b42452734c12bdec93ad7 */
+/* @hash db83d007b86b64c594c868c08d8b514a */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -20,8 +20,7 @@ const getDefaultUserAccountProviders = (provider) => {
     }),
   };
 
-  const dapi =
-    typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
+  const dapi = typeof globalThis === 'undefined' ? undefined : globalThis.neoDapi;
   if (dapi !== undefined) {
     return {
       ...localUserAccountProvider,
@@ -38,8 +37,7 @@ const getDefaultUserAccountProviders = (provider) => {
   return localUserAccountProvider;
 };
 
-const isLocalUserAccountProvider = (userAccountProvider) =>
-  userAccountProvider instanceof LocalUserAccountProvider;
+const isLocalUserAccountProvider = (userAccountProvider) => userAccountProvider instanceof LocalUserAccountProvider;
 
 export const createClient = (getUserAccountProvidersOrHost) => {
   let getUserAccountProviders = getDefaultUserAccountProviders;
@@ -51,25 +49,16 @@ export const createClient = (getUserAccountProvidersOrHost) => {
   }
 
   const providers = [];
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10260/rpc` });
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
+    providers.push({ network: 'local', rpcURL: `http://${host}:10050/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
-  const localUserAccountProviders = Object.values(userAccountProviders).filter(
-    isLocalUserAccountProvider,
-  );
+  const localUserAccountProviders = Object.values(userAccountProviders).filter(isLocalUserAccountProvider);
   const localUserAccountProvider = localUserAccountProviders.find(
-    (userAccountProvider) =>
-      userAccountProvider.keystore instanceof LocalKeyStore,
+    (userAccountProvider) => userAccountProvider.keystore instanceof LocalKeyStore,
   );
-  if (
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEO_ONE_DEV === 'true'
-  ) {
+  if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
     if (localUserAccountProvider !== undefined) {
       const localKeyStore = localUserAccountProvider.keystore;
       if (localKeyStore instanceof LocalKeyStore) {
@@ -140,10 +129,5 @@ export const createClient = (getUserAccountProvidersOrHost) => {
 };
 
 export const createDeveloperClients = (host = 'localhost') => ({
-  local: new DeveloperClient(
-    new NEOONEDataProvider({
-      network: 'local',
-      rpcURL: `http://${host}:10260/rpc`,
-    }),
-  ),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10050/rpc` })),
 });

--- a/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash a1c197d60788400088cc39a4ff04466d */
+/* @hash cc22deec02b78c38de97754994eeef14 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -64,7 +64,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10210/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:10000/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -145,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10210/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10000/rpc` })),
 });

--- a/packages/neo-one-cli/src/__e2e__/cmd/start/neotracker.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/start/neotracker.test.ts
@@ -17,6 +17,9 @@ describe('start network', () => {
     });
 
     execAsync('start neotracker');
+    // this allows us to run the e2e tests in parallel, successfully
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
     await one.until(async () => {
       const live = await isRunning(config.neotracker.port);
       expect(live).toEqual(true);

--- a/packages/neo-one-cli/src/__e2e__/cmd/stop/neotracker.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/stop/neotracker.test.ts
@@ -17,6 +17,8 @@ describe('start network', () => {
     });
 
     execAsync('start neotracker');
+    // this allows us to run the e2e tests in parallel, successfully
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     await one.until(async () => {
       const live = await isRunning(config.neotracker.port);

--- a/packages/neo-one-developer-tools-frame/package.json
+++ b/packages/neo-one-developer-tools-frame/package.json
@@ -9,6 +9,7 @@
     "lint:staged": "lint-staged --relative",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
@@ -43,6 +44,5 @@
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@types/react-select": "^3.0.0"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-developer-tools-frame/src/BalanceSelector.tsx
+++ b/packages/neo-one-developer-tools-frame/src/BalanceSelector.tsx
@@ -16,15 +16,14 @@ import { Token } from './types';
 
 const { useContext } = React;
 
-// tslint:disable-next-line no-any
-const AssetInput: any = styled(ToolbarSelector)`
+const AssetInput = styled(ToolbarSelector)`
   &&& {
     border-left: 0;
     width: 88px;
   }
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
   align-items: center;

--- a/packages/neo-one-developer-tools-frame/src/BlockIndex.tsx
+++ b/packages/neo-one-developer-tools-frame/src/BlockIndex.tsx
@@ -11,7 +11,7 @@ import { ToolbarButton } from './ToolbarButton';
 
 const { useCallback } = React;
 
-const IndexWrapper = styled<typeof Box, { readonly width: number }>(Box)`
+const IndexWrapper = styled(Box)<{ readonly width: number }, { readonly width: number }>`
   width: ${prop('width')}px;
 `;
 

--- a/packages/neo-one-developer-tools-frame/src/BlockTime.tsx
+++ b/packages/neo-one-developer-tools-frame/src/BlockTime.tsx
@@ -16,13 +16,15 @@ import { ToolbarButton } from './ToolbarButton';
 
 const { useState } = React;
 
-const Time = Box.withComponent('time');
-const StyledTime = styled<typeof Time, { readonly minWidth: number }>(Time)`
+// tslint:disable-next-line: no-any
+const Time = Box.withComponent<any>('time');
+const StyledTime = styled(Time)<typeof Time, { readonly minWidth: number }>`
   min-width: ${prop('minWidth')}px;
 `;
 const getMinWidth = (value: string) => Math.max(30, value.length * 8);
 
-const StyledDivider = styled(Divider)`
+// tslint:disable-next-line: no-any
+const StyledDivider = styled(Divider)<any>`
   height: 22px;
   margin: 0 8px;
 `;

--- a/packages/neo-one-developer-tools-frame/src/DateTimePicker.tsx
+++ b/packages/neo-one-developer-tools-frame/src/DateTimePicker.tsx
@@ -7,7 +7,7 @@ import { prop } from 'styled-tools';
 
 const { useState, useCallback } = React;
 
-const ErrorText = styled(Box)`
+const ErrorText = styled(Box)<{}, {}>`
   color: ${prop('theme.error')};
 `;
 

--- a/packages/neo-one-developer-tools-frame/src/Dialog.tsx
+++ b/packages/neo-one-developer-tools-frame/src/Dialog.tsx
@@ -17,7 +17,7 @@ import { ResizeHandlerContext } from './ResizeHandlerContext';
 
 const { useContext, useCallback } = React;
 
-const StyledHeader = styled(Box)`
+const StyledHeader = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
   background-color: ${prop('theme.primary')};
@@ -27,13 +27,13 @@ const StyledHeader = styled(Box)`
   padding: 16px;
 `;
 
-const StyledHeading = styled(H3)`
+const StyledHeading = styled(H3)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.headline')};
   margin: 0;
 `;
 
-const StyledBody = styled(Box)`
+const StyledBody = styled(Box)<{}, {}>`
   display: grid;
   gap: 8px;
   background-color: ${prop('theme.gray0')};

--- a/packages/neo-one-developer-tools-frame/src/NetworkSelector.tsx
+++ b/packages/neo-one-developer-tools-frame/src/NetworkSelector.tsx
@@ -9,7 +9,7 @@ import { useAddError } from './ToastsContext';
 
 const { useContext } = React;
 
-const StyledSelect: any = styled(Select)`
+const StyledSelect = styled(Select)`
   &&& {
     width: 100px;
     height: 40px;

--- a/packages/neo-one-developer-tools-frame/src/SettingsLabel.tsx
+++ b/packages/neo-one-developer-tools-frame/src/SettingsLabel.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { Label } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const SettingsLabel = styled(Label)`
+// tslint:disable-next-line: no-any
+export const SettingsLabel = styled(Label)<any>`
   ${prop('theme.fontStyles.subheading')};
   grid-auto-flow: column;
   align-items: center;

--- a/packages/neo-one-developer-tools-frame/src/Toast.tsx
+++ b/packages/neo-one-developer-tools-frame/src/Toast.tsx
@@ -8,7 +8,7 @@ import { Toast as ToastType } from './ToastsContext';
 
 const { useEffect, useCallback } = React;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   gap: 8px;
   background-color: ${prop('theme.gray0')};

--- a/packages/neo-one-developer-tools-frame/src/ToastsContext.tsx
+++ b/packages/neo-one-developer-tools-frame/src/ToastsContext.tsx
@@ -40,7 +40,7 @@ export const useToasts = (): readonly [ReadonlyArray<Toast>, typeof addToast, ty
 
 export type AddError = (error: Error) => void;
 
-const ErrorText = styled(Box.withComponent('span'))`
+const ErrorText = styled(Box.withComponent('span'))<{}, {}>`
   color: ${prop('theme.error')};
 `;
 

--- a/packages/neo-one-developer-tools-frame/src/Toolbar.tsx
+++ b/packages/neo-one-developer-tools-frame/src/Toolbar.tsx
@@ -18,7 +18,7 @@ import { WalletButton } from './WalletButton';
 
 const { useCallback, useState } = React;
 
-const Wrapper = styled<typeof Box, { readonly active: boolean }>(Box)`
+const Wrapper = styled(Box)<{ readonly active: boolean }, { readonly active: boolean }>`
   display: flex;
   bottom: 0;
   left: 0;

--- a/packages/neo-one-developer-tools-frame/src/ToolbarSelector.tsx
+++ b/packages/neo-one-developer-tools-frame/src/ToolbarSelector.tsx
@@ -5,8 +5,7 @@ import * as React from 'react';
 
 const { useCallback, useState } = React;
 
-// tslint:disable-next-line no-any
-const StyledSelect: any = styled(Select)`
+const StyledSelect = styled(Select)`
   &&& {
     border-right: 0;
     width: 100px;

--- a/packages/neo-one-developer-tools-frame/src/TransferTo.tsx
+++ b/packages/neo-one-developer-tools-frame/src/TransferTo.tsx
@@ -9,7 +9,8 @@ import { getWalletSelectorOptions$, makeWalletSelectorValueOption, WalletSelecto
 
 const { useContext } = React;
 
-const Wrapper = styled(Label)`
+// tslint:disable-next-line: no-any
+const Wrapper = styled(Label)<any>`
   border-top: 1px solid rgba(0, 0, 0, 0.3);
   margin-top: 8px;
   padding-top: 16px;
@@ -43,7 +44,7 @@ export function TransferTo({ to, onChangeTo, ...props }: Props & React.Component
       Transfer To
       <WalletSelectorBase
         data-test="neo-one-transfer-to-selector"
-        value={to.map((userAccount) => makeWalletSelectorValueOption({ userAccount }))}
+        value={to.map((userAccount: UserAccount) => makeWalletSelectorValueOption({ userAccount }))}
         options={options}
         onChange={(option: any) => {
           if (option != undefined) {

--- a/packages/neo-one-editor/package.json
+++ b/packages/neo-one-editor/package.json
@@ -10,6 +10,10 @@
     "lint:staged": "lint-staged --relative",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": [
+    "src/engine/test/polyfill.ts",
+    "src/preview/window/polyfill.ts"
+  ],
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
@@ -32,8 +36,8 @@
     "@neo-one/node-browser-worker": "^2.3.0",
     "@neo-one/react": "^2.3.0",
     "@neo-one/react-common": "^2.3.0",
-    "@neo-one/smart-contract-test-browser": "^2.3.1",
     "@neo-one/smart-contract-compiler": "^2.3.0",
+    "@neo-one/smart-contract-test-browser": "^2.3.1",
     "@neo-one/utils": "^2.3.0",
     "@neo-one/worker": "^2.3.0",
     "@render-props/scrollable": "^0.1.20",
@@ -71,7 +75,7 @@
     "styled-tools": "^1.7.1",
     "ts-node": "^8.4.1",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3",
+    "typescript": "3.8.1-rc",
     "typescript-fsa": "^3.0.0-beta-2",
     "typescript-fsa-reducers": "^1.2.1",
     "webpack": "^4.40.2"
@@ -92,9 +96,5 @@
     "@types/react-redux": "^7.1.1",
     "@types/resolve": "^0.0.8",
     "@types/webpack": "^4.39.0"
-  },
-  "sideEffects": [
-    "src/engine/test/polyfill.ts",
-    "src/preview/window/polyfill.ts"
-  ]
+  }
 }

--- a/packages/neo-one-editor/src/editor/Editor.tsx
+++ b/packages/neo-one-editor/src/editor/Editor.tsx
@@ -21,8 +21,7 @@ const Wrapper = styled(Box)`
   min-height: 0;
 `;
 
-// tslint:disable-next-line no-any
-const StyledSplitPane = styled(SplitPane as any)`
+const StyledSplitPane = styled(SplitPane)`
   min-height: 0;
   min-width: 0;
   height: 100%;

--- a/packages/neo-one-editor/src/editor/EditorToolbar.tsx
+++ b/packages/neo-one-editor/src/editor/EditorToolbar.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled(DispatchWrapper)`
     / auto;
 `;
 
-const ToolbarWrapper = styled(Box)`
+const ToolbarWrapper = styled(Box)<{}, {}>`
   display: grid;
   width: 100%;
   background-color: ${prop('theme.accent')};

--- a/packages/neo-one-editor/src/editor/PreviewButton.tsx
+++ b/packages/neo-one-editor/src/editor/PreviewButton.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled(Box)`
   place-items: center;
 `;
 
-const StyledButton = styled(ButtonBase)<{ readonly open: boolean }>`
+const StyledButton = styled(ButtonBase)`
   color: ${ifProp('open', prop('theme.gray0'), prop('theme.gray3'))};
   cursor: pointer;
   outline: none;

--- a/packages/neo-one-editor/src/editor/toolbar/Console.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/Console.tsx
@@ -6,7 +6,7 @@ import { TextRange } from '../types';
 import { ConsoleContent } from './ConsoleContent';
 import { ConsoleHeader } from './ConsoleHeader';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   width: 100%;
   grid:

--- a/packages/neo-one-editor/src/editor/toolbar/ConsoleButton.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ConsoleButton.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled(Box)`
   place-items: center;
 `;
 
-const IconWrapper = styled(ButtonBase)`
+const IconWrapper = styled(ButtonBase)<typeof ButtonBase>`
   color: ${prop('theme.gray0')};
   cursor: pointer;
   outline: none;

--- a/packages/neo-one-editor/src/editor/toolbar/ConsoleOutput.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ConsoleOutput.tsx
@@ -12,7 +12,8 @@ import {
   selectConsoleOutputOwner,
 } from '../redux';
 
-const Wrapper = styled<typeof Box, { readonly shadowed: boolean }>(Box)`
+// tslint:disable-next-line: no-any
+const Wrapper = styled(Box)<any>`
   color: ${prop('theme.gray0')};
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-editor/src/editor/toolbar/ConsoleTab.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ConsoleTab.tsx
@@ -15,7 +15,8 @@ const Wrapper = styled(Box)`
   grid-auto-flow: column;
 `;
 
-const TextWrapper = styled(Box)<{ readonly selected: boolean }>`
+// tslint:disable-next-line: no-any
+const TextWrapper = styled(Box)<any>`
   color: ${ifProp('selected', prop('theme.gray0'), prop('theme.gray2'))};
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-editor/src/editor/toolbar/Feedback.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/Feedback.tsx
@@ -61,7 +61,8 @@ const ExperienceWrapper = styled(RowWrapper)`
   grid-gap: 8px;
 `;
 
-const InputBox = styled(Input.withComponent('textarea'))`
+// tslint:disable-next-line: no-any
+const InputBox = styled(Input.withComponent<any>('textarea'))`
   color: ${prop('theme.gray0')};
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-editor/src/editor/toolbar/FileText.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/FileText.tsx
@@ -13,13 +13,13 @@ const Wrapper = styled(Box)`
   grid-gap: 8px;
 `;
 
-const LightText = styled(Box)`
+const LightText = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
   color: ${prop('theme.gray0')};
 `;
 
-const DarkText = styled(Box)`
+const DarkText = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.caption')};
   color: ${prop('theme.gray3')};

--- a/packages/neo-one-editor/src/editor/toolbar/Help.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/Help.tsx
@@ -10,7 +10,8 @@ const Wrapper = styled(Box)`
   grid-auto-rows: auto;
 `;
 
-const Text = styled(Box)`
+// tslint:disable-next-line: no-any
+const Text = styled(Box)<any>`
   color: ${prop('theme.gray0')};
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.subheading')};

--- a/packages/neo-one-editor/src/editor/toolbar/ProblemCount.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ProblemCount.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Box } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const ProblemCount = styled(Box)`
+export const ProblemCount = styled(Box)<{}, {}>`
   color: ${prop('theme.gray0')};
   ${prop('theme.font.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-editor/src/editor/toolbar/ProblemRoot.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ProblemRoot.tsx
@@ -29,7 +29,9 @@ const StyledEditorFileIcon = styled(FileIcon)`
   height: 16px;
   width: 16px;
 `;
-const StyledProblemCount = styled(ProblemCount)`
+
+// tslint:disable-next-line: no-any
+const StyledProblemCount = styled(ProblemCount)<any>`
   padding-top: 1.5px;
 `;
 

--- a/packages/neo-one-editor/src/editor/toolbar/ProblemWrapper.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ProblemWrapper.tsx
@@ -3,7 +3,7 @@ import { Box, ButtonBase } from '@neo-one/react-common';
 import * as React from 'react';
 import { prop } from 'styled-tools';
 
-const Wrapper = styled(ButtonBase)`
+const Wrapper = styled(ButtonBase)<typeof ButtonBase>`
   cursor: pointer;
   outline: none;
   width: 100%;

--- a/packages/neo-one-editor/src/editor/toolbar/Problems.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/Problems.tsx
@@ -15,7 +15,8 @@ import { ConsoleType } from '../types';
 import { Text } from './Text';
 import { Wrapper } from './Wrapper';
 
-const GridWrapper = styled(Text)`
+// tslint:disable-next-line: no-any
+const GridWrapper = styled(Text)<any>`
   display: grid;
   gap: 2px;
   grid-auto-flow: column;

--- a/packages/neo-one-editor/src/editor/toolbar/ProblemsView.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ProblemsView.tsx
@@ -11,7 +11,7 @@ import { FileProblems, selectConsoleProblems } from '../redux';
 import { TextRange } from '../types';
 import { ProblemView } from './ProblemView';
 
-const Wrapper = styled<typeof Box, { readonly shadowed: boolean }>(Box)`
+const Wrapper = styled(Box)<{ readonly shadowed: boolean }, { readonly shadowed: boolean }>`
   display: grid;
   align-content: start;
   width: 100%;

--- a/packages/neo-one-editor/src/editor/toolbar/TestDetailError.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/TestDetailError.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Box } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const TestDetailError = styled(Box)`
+export const TestDetailError = styled(Box)<{}, {}>`
   padding: 8px;
   color: ${prop('theme.gray1')};
   background-color: ${prop('theme.gray4')};

--- a/packages/neo-one-editor/src/editor/toolbar/TestDetailListItem.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/TestDetailListItem.tsx
@@ -8,7 +8,7 @@ import { TestDetailError } from './TestDetailError';
 import { TestIcon } from './TestIcon';
 import { TestText } from './TestText';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-gap: 0;
   grid-auto-flow: row;

--- a/packages/neo-one-editor/src/editor/toolbar/TestText.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/TestText.tsx
@@ -8,14 +8,14 @@ export const TestText = styled(Box)<{}, {}>`
   color: ${prop('theme.gray0')};
 `;
 
-export const TestTextDark = styled(TestText)`
+export const TestTextDark = styled(TestText)<{}, {}>`
   color: ${prop('theme.gray3')};
 `;
 
-export const TestPassing = styled(TestText)`
+export const TestPassing = styled(TestText)<{}, {}>`
   color: ${prop('theme.primaryDark')};
 `;
 
-export const TestFailing = styled(TestText)`
+export const TestFailing = styled(TestText)<{}, {}>`
   color: ${prop('theme.error')};
 `;

--- a/packages/neo-one-editor/src/editor/toolbar/Text.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/Text.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Box } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const Text = styled(Box)`
+export const Text = styled(Box)<{}, {}>`
   color: ${prop('theme.gray0')};
   ${prop('theme.fonts.axiformaBook')};
   ${prop('theme.fontStyles.caption')};

--- a/packages/neo-one-editor/src/editor/toolbar/ToolbarPopover.tsx
+++ b/packages/neo-one-editor/src/editor/toolbar/ToolbarPopover.tsx
@@ -5,7 +5,7 @@ import { MdClose } from 'react-icons/md';
 import { prop } from 'styled-tools';
 import { Wrapper } from './Wrapper';
 
-const HeaderWrapper = styled(Box)`
+const HeaderWrapper = styled(Box)<{}, {}>`
   display: grid;
   color: ${prop('theme.gray0')};
   grid-auto-flow: column;
@@ -20,7 +20,7 @@ const BodyWrapper = styled(Box)`
   padding-right: 8px;
 `;
 
-const TitleText = styled(Box)`
+const TitleText = styled(Box)<{}, {}>`
   padding-top: 8px;
   padding-bottom: 8px;
   ${prop('theme.fonts.axiformaRegular')};
@@ -34,7 +34,7 @@ const ToggleWrapper = styled(Wrapper)`
   ${prop('theme.fontStyles.caption')};
 `;
 
-const PopoverWrapper = styled(Box)`
+const PopoverWrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-auto-rows: auto;

--- a/packages/neo-one-editor/src/monaco/AsyncLanguageService.ts
+++ b/packages/neo-one-editor/src/monaco/AsyncLanguageService.ts
@@ -241,7 +241,7 @@ export class AsyncLanguageService {
     fileName: string,
     files: { readonly [key: string]: string },
   ): Promise<readonly FlattenedDiagnostic[]> =>
-    Promise.all([this.fs, this.languageService]).then(([fs, languageService]) =>
+    Promise.all([this.fs, this.languageService] as const).then(([fs, languageService]) =>
       this.withTmpFS(files, () => {
         const diagnostics = this.isSmartContract
           ? getSemanticDiagnostics(fileName, languageService, createCompilerHost({ fs }))

--- a/packages/neo-one-local-browser/package.json
+++ b/packages/neo-one-local-browser/package.json
@@ -9,6 +9,7 @@
     "lint:staged": "lint-staged --relative",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@neo-one/cli-common": "^2.4.0",
     "@neo-one/client-common": "^2.3.0",
@@ -27,13 +28,12 @@
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
     "@types/lodash": "^4.14.138",
     "@types/nanoid": "^2.0.0",
     "@types/pouchdb": "^6.4.0"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -791,7 +791,7 @@ export class Blockchain {
             })
             .pipe(toArray())
             .toPromise(),
-    ]);
+    ] as const);
 
     return {
       asset,
@@ -835,7 +835,7 @@ export class Blockchain {
     const [transactionData, output] = await Promise.all([
       this.transactionData.tryGet({ hash: input.hash }),
       this.output.get(input),
-    ]);
+    ] as const);
 
     if (transactionData === undefined) {
       return undefined;

--- a/packages/neo-one-node-blockchain/src/WriteBatchBlockchain.ts
+++ b/packages/neo-one-node-blockchain/src/WriteBatchBlockchain.ts
@@ -394,7 +394,7 @@ export class WriteBatchBlockchain {
 
       this.block.add(block),
       this.header.add(block.header),
-    ]);
+    ] as const);
 
     const prevBlockData =
       maybePrevBlockData === undefined

--- a/packages/neo-one-node-core/src/transaction/TransactionBase.ts
+++ b/packages/neo-one-node-core/src/transaction/TransactionBase.ts
@@ -257,7 +257,7 @@ export function TransactionBase<
         this.getNetworkFee(context.feeContext),
         // tslint:disable-next-line no-any
         context.tryGetTransactionData(this as any),
-      ]);
+      ] as const);
 
       return {
         txid: common.uInt256ToString(this.hashHex),

--- a/packages/neo-one-node-core/src/transaction/state/StateDescriptor.ts
+++ b/packages/neo-one-node-core/src/transaction/state/StateDescriptor.ts
@@ -180,7 +180,10 @@ export class StateDescriptor implements SerializableWire<StateDescriptor>, Seria
 
     const reader = new BinaryReader(this.value);
     const hash = common.bufferToUInt160(this.key);
-    const [account, validators] = await Promise.all([options.tryGetAccount({ hash }), options.getAllValidators()]);
+    const [account, validators] = await Promise.all([
+      options.tryGetAccount({ hash }),
+      options.getAllValidators(),
+    ] as const);
 
     if (account === undefined || account.isFrozen) {
       throw new VerifyError('Account is frozen');

--- a/packages/neo-one-react-common/package.json
+++ b/packages/neo-one-react-common/package.json
@@ -10,6 +10,9 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": [
+    "*.css"
+  ],
   "dependencies": {
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
@@ -30,8 +33,5 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-select": "^3.0.0",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": [
-    "*.css"
-  ]
+  }
 }

--- a/packages/neo-one-react-common/src/Backdrop.tsx
+++ b/packages/neo-one-react-common/src/Backdrop.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
+import { ColorProps } from '@neo-one/react-core';
 import { theme } from 'styled-tools';
 import { Hidden } from './Hidden';
 
-export const Backdrop = styled(Hidden)`
+export const Backdrop = styled(Hidden)<ColorProps>`
   position: fixed;
   top: 0;
   left: 0;

--- a/packages/neo-one-react-common/src/Background.tsx
+++ b/packages/neo-one-react-common/src/Background.tsx
@@ -3,7 +3,7 @@ import { Box } from '@neo-one/react-core';
 import { prop } from 'styled-tools';
 import background from '../static/img/background.svg';
 
-export const Background = styled(Box)`
+export const Background = styled(Box)<typeof Box>`
   background-color: ${prop('theme.black')};
   background-image: url('${background}');
 `;

--- a/packages/neo-one-react-common/src/Hidden.tsx
+++ b/packages/neo-one-react-common/src/Hidden.tsx
@@ -216,7 +216,17 @@ const hiddenTransition = (props: any) => {
   `;
 };
 
-export const Hidden = styled<typeof HiddenComponent, HiddenStyledProps>(HiddenComponent)`
+export const Hidden = styled(HiddenComponent)<
+  ExpandProps &
+    SlideProps & {
+      readonly duration?: string;
+      readonly timing?: string;
+      readonly defaultSlide?: string | undefined;
+      readonly defaultExpand?: string | undefined;
+      readonly visible?: boolean;
+      readonly unmount?: boolean;
+    }
+>`
   transform: ${translateWithProps};
   ${hiddenTransformOrigin};
 

--- a/packages/neo-one-react-common/src/IconButton.tsx
+++ b/packages/neo-one-react-common/src/IconButton.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { ButtonBase } from '@neo-one/react-core';
 import { prop } from 'styled-tools';
 
-export const IconButton = styled(ButtonBase)`
+export const IconButton = styled(ButtonBase)<typeof ButtonBase>`
   color: ${prop('theme.black')};
   outline: none;
   cursor: pointer;

--- a/packages/neo-one-react-common/src/Loading.tsx
+++ b/packages/neo-one-react-common/src/Loading.tsx
@@ -19,7 +19,7 @@ const fadeInOut = keyframes`
   }
 `;
 
-const LoadingWrapper = styled(Box)`
+const LoadingWrapper = styled(Box)<{}, {}>`
   padding-top: 96px;
   flex: 1 1 auto;
   min-height: 512px;

--- a/packages/neo-one-react-common/src/LoadingDots.tsx
+++ b/packages/neo-one-react-common/src/LoadingDots.tsx
@@ -16,7 +16,7 @@ const animation = keyframes`
   }
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   height: 16px;
   display: grid;
   grid-auto-flow: column;

--- a/packages/neo-one-react-common/src/Overlay.tsx
+++ b/packages/neo-one-react-common/src/Overlay.tsx
@@ -1,9 +1,10 @@
 // tslint:disable no-object-mutation
 import styled from '@emotion/styled';
+import { ColorProps } from '@neo-one/react-core';
 import { theme } from 'styled-tools';
 import { Hidden } from './Hidden';
 
-export const Overlay = styled(Hidden)`
+export const Overlay = styled(Hidden)<ColorProps>`
   position: fixed;
   z-index: 19900410;
   left: 50%;

--- a/packages/neo-one-react-common/src/Popover.tsx
+++ b/packages/neo-one-react-common/src/Popover.tsx
@@ -1,6 +1,6 @@
 // tslint:disable no-null-keyword no-object-mutation
 import styled from '@emotion/styled';
-import { getSelector } from '@neo-one/react-core';
+import { ColorProps, getSelector } from '@neo-one/react-core';
 import Popper from 'popper.js';
 import * as React from 'react';
 import { theme } from 'styled-tools';
@@ -124,7 +124,7 @@ const PopoverComponent = forwardRef<HTMLDivElement, PopoverProps & React.Compone
   },
 );
 
-export const Popover = styled(PopoverComponent)`
+export const Popover = styled(PopoverComponent)<ColorProps>`
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/neo-one-react-common/src/PopoverArrow.tsx
+++ b/packages/neo-one-react-common/src/PopoverArrow.tsx
@@ -6,6 +6,8 @@ import { prop, theme } from 'styled-tools';
 export interface PopoverArrowProps {
   readonly fillColor?: string;
   readonly strokeColor?: string;
+  readonly opaque?: boolean;
+  readonly palette?: string;
 }
 
 const PopoverArrowComponent = (props: PopoverArrowProps & React.ComponentPropsWithoutRef<typeof Box>) => (
@@ -26,7 +28,7 @@ const PopoverArrowComponent = (props: PopoverArrowProps & React.ComponentPropsWi
 
 const popoverTheme = theme('PopoverArrow');
 
-export const PopoverArrow = styled<typeof PopoverArrowComponent, PopoverArrowProps>(PopoverArrowComponent)`
+export const PopoverArrow = styled(PopoverArrowComponent)<{}, {}>`
   position: absolute;
   font-size: 30px;
   width: 1em;

--- a/packages/neo-one-react-common/src/Select.tsx
+++ b/packages/neo-one-react-common/src/Select.tsx
@@ -5,8 +5,7 @@ import * as React from 'react';
 import SelectBase from 'react-select';
 import { prop } from 'styled-tools';
 
-// tslint:disable-next-line:no-any
-const StyledSelect: any = styled(SelectBase)`
+const StyledSelect = styled(SelectBase)`
   border: 1px solid rgba(0, 0, 0, 0.3);
   background-color: ${prop('theme.gray0')};
   outline: none;

--- a/packages/neo-one-react-common/src/Selector.tsx
+++ b/packages/neo-one-react-common/src/Selector.tsx
@@ -4,7 +4,7 @@ import { Input } from '@neo-one/react-core';
 import * as React from 'react';
 import { prop } from 'styled-tools';
 
-const StyledInput = styled(Input.withComponent('select'))`
+const StyledInput = styled(Input.withComponent('select'))<{}, {}>`
   background-color: ${prop('theme.gray0')};
   outline: none;
   ${prop('theme.fonts.axiformaRegular')};

--- a/packages/neo-one-react-common/src/SplitPane.tsx
+++ b/packages/neo-one-react-common/src/SplitPane.tsx
@@ -39,7 +39,7 @@ const Wrapper: any = styled('div')`
   ${wrapperWithProps}
 `;
 
-export const SplitPaneResizer = styled.div`
+export const SplitPaneResizer = styled.div<{}, {}>`
   background-color: ${prop('theme.gray5')};
   background-clip: padding-box;
   box-sizing: border-box;

--- a/packages/neo-one-react-common/src/Tooltip.tsx
+++ b/packages/neo-one-react-common/src/Tooltip.tsx
@@ -5,7 +5,7 @@ import { prop } from 'styled-tools';
 import { PopoverArrow } from './PopoverArrow';
 import { TooltipBase } from './TooltipBase';
 
-export const StyledTooltip = styled(TooltipBase)<{}, {}>`
+export const StyledTooltip = styled(TooltipBase)`
   background-color: ${prop('theme.gray5')};
   border-color: ${prop('theme.gray5')};
   color: ${prop('theme.gray0')};

--- a/packages/neo-one-react-core/package.json
+++ b/packages/neo-one-react-core/package.json
@@ -10,6 +10,7 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
@@ -22,6 +23,5 @@
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-react-core/src/Box.tsx
+++ b/packages/neo-one-react-core/src/Box.tsx
@@ -4,7 +4,7 @@ import { bgColorWithProps, ColorProps, textColorWithProps } from './styledProps'
 
 const boxTheme = theme('Box');
 
-export const Box = styled<'div', ColorProps>('div')`
+export const Box = styled<'div', ColorProps>('div')<{}, {}>`
   margin: unset;
   padding: unset;
   border: unset;

--- a/packages/neo-one-react-core/src/Button.tsx
+++ b/packages/neo-one-react-core/src/Button.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 import { prop } from 'styled-tools';
 import { ButtonBase } from './ButtonBase';
+import { ColorProps } from './styledProps';
 
-export const Button = styled(ButtonBase)`
+export const Button = styled(ButtonBase)<typeof ButtonBase & ColorProps>`
   background-color: ${prop('theme.accent')};
   border: none;
   border-radius: 24px;

--- a/packages/neo-one-react-core/src/ButtonBase.tsx
+++ b/packages/neo-one-react-core/src/ButtonBase.tsx
@@ -1,3 +1,4 @@
 import { Box } from './Box';
 
-export const ButtonBase = Box.withComponent('button');
+// tslint:disable-next-line: no-any
+export const ButtonBase = Box.withComponent<any>('button');

--- a/packages/neo-one-react-core/src/Image.tsx
+++ b/packages/neo-one-react-core/src/Image.tsx
@@ -1,3 +1,4 @@
 import { Box } from './Box';
 
-export const Image = Box.withComponent('img');
+// tslint:disable-next-line: no-any
+export const Image = Box.withComponent<any>('img');

--- a/packages/neo-one-react-core/src/Input.tsx
+++ b/packages/neo-one-react-core/src/Input.tsx
@@ -1,6 +1,7 @@
 import { Box } from './Box';
 
-export const Input = Box.withComponent('input');
+// tslint:disable-next-line: no-any
+export const Input = Box.withComponent<any>('input');
 
 // tslint:disable-next-line:no-object-mutation
 Input.defaultProps = {

--- a/packages/neo-one-react-core/src/Link.tsx
+++ b/packages/neo-one-react-core/src/Link.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { prop, switchProp } from 'styled-tools';
 import { LinkBase } from './LinkBase';
 
-export const Link = styled<typeof LinkBase, { readonly linkColor: string }>(LinkBase)`
+// tslint:disable-next-line: no-any
+export const Link = styled(LinkBase)<any>`
   color: ${switchProp('linkColor', {
     primary: prop('theme.primary'),
     accent: prop('theme.accent'),

--- a/packages/neo-one-react-core/src/LinkBase.tsx
+++ b/packages/neo-one-react-core/src/LinkBase.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import { Box } from './Box';
+import { ColorProps } from './styledProps';
 
-export const LinkBase = styled(Box.withComponent('a'))`
+export const LinkBase = styled(Box.withComponent('a'))<ColorProps>`
   cursor: pointer;
 `;
 

--- a/packages/neo-one-react-core/src/ToolbarContent.tsx
+++ b/packages/neo-one-react-core/src/ToolbarContent.tsx
@@ -8,7 +8,10 @@ export interface ToolbarContentProps {
 
 const toolbarContentTheme = theme('ToolbarContent');
 
-export const ToolbarContent = styled<typeof Box, ToolbarContentProps>(Box)`
+export const ToolbarContent = styled<typeof Box, ToolbarContentProps>(Box)<
+  { readonly align?: string },
+  { readonly align?: string }
+>`
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: min-content;

--- a/packages/neo-one-react-core/src/ToolbarFocusable.tsx
+++ b/packages/neo-one-react-core/src/ToolbarFocusable.tsx
@@ -135,6 +135,6 @@ export const ToolbarFocusableComponent = forwardRef<HTMLDivElement, Props>(
   },
 );
 
-export const ToolbarFocusable = styled(ToolbarFocusableComponent)`
+export const ToolbarFocusable = styled(ToolbarFocusableComponent)<{}, {}>`
   ${theme('ToolbarFocusable')};
 `;

--- a/packages/neo-one-smart-contract-codegen/package.json
+++ b/packages/neo-one-smart-contract-codegen/package.json
@@ -10,6 +10,7 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@neo-one/cli-common": "^2.4.0",
     "@neo-one/client-common": "^2.3.0",
@@ -27,6 +28,5 @@
     "@types/lodash": "^4.14.138",
     "@types/prettier": "^1.18.2",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-smart-contract-compiler-node/package.json
+++ b/packages/neo-one-smart-contract-compiler-node/package.json
@@ -10,6 +10,7 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@neo-one/smart-contract": "^2.3.0",
     "@neo-one/smart-contract-lib": "^2.3.1",
@@ -17,13 +18,12 @@
     "app-root-dir": "^1.0.2",
     "glob": "^7.1.4",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
     "@types/app-root-dir": "^0.1.0",
     "@types/glob": "^7.1.1",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-smart-contract-compiler/package.json
+++ b/packages/neo-one-smart-contract-compiler/package.json
@@ -10,6 +10,7 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@neo-one/client-common": "^2.3.0",
@@ -25,7 +26,7 @@
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
@@ -47,6 +48,5 @@
     "gulp": "~4.0.2",
     "levelup": "^4.1.0",
     "memdown": "^5.0.0"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler3.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/BinaryExpressionCompiler3.test.ts
@@ -104,6 +104,64 @@ describe('BinaryExpressionCompiler', () => {
     `);
   });
 
+  test('null ?? short-circuit [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x = null;
+      const result = x ?? true;
+      if (!result) {
+        throw 'Failure';
+      }
+    `);
+  });
+
+  test('undefined ?? short-circuit [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x = undefined;
+      const result = x ?? true;
+      if (!result) {
+        throw 'Failure';
+      }
+    `);
+  });
+
+  test('1 ?? 0 [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x: number = 1 ?? 0;
+      if (!(x === 1)) {
+        throw 'Failure';
+      }
+    `);
+  });
+
+  test('0 ?? 1 [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x: number = 1 ?? 0;
+      if (!(x === 1)) {
+        throw 'Failure';
+      }
+    `);
+  });
+
+  test('[] ?? 0 [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x: Array<unknown> = [];
+      const result = x ?? 0;
+      if (!(result === x)) {
+        throw 'Failure';
+      }
+    `);
+  });
+
+  test('"" ?? 0 [QuestionQuestionToken]', async () => {
+    await helpers.executeString(`
+      const x: string = "";
+      const result = x ?? 0;
+      if (!(result === "")) {
+        throw 'Failure';
+      }
+    `);
+  });
+
   test('1 < 1 [LessThanToken]', async () => {
     await helpers.executeString(`
       if (1 < 1) {

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/AwaitExpressionCompiler.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/AwaitExpressionCompiler.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AwaitFunctionCompiler await 1`] = `
-"snippetCode.ts (2,7): 'await' expression is only allowed within an async function.
+"snippetCode.ts (2,7): 'await' expressions are only allowed at the top level of a file when that file is a module, but this file has no imports or exports. Consider adding an empty 'export {}' to make this file a module.
 
       1 | 
     > 2 |       await 2;

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/types/boolean/ToNullishBooleanHelper.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/types/boolean/ToNullishBooleanHelper.test.ts
@@ -1,0 +1,253 @@
+import { helpers } from '../../../../../__data__';
+
+describe('ToNullishBooleanHelper', () => {
+  test('array', async () => {
+    await helpers.executeString(`
+      const value: Array<unknown> = [];
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('boolean true', async () => {
+    await helpers.executeString(`
+      const value = true;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('boolean false', async () => {
+    await helpers.executeString(`
+      const value = false;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('buffer', async () => {
+    await helpers.executeString(`
+      const value: Buffer = Buffer.from('', 'hex');
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('null', async () => {
+    await helpers.executeString(`
+      const value = null;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, bad);
+    `);
+  });
+
+  test('number 0', async () => {
+    await helpers.executeString(`
+      const value = 0;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('number 1', async () => {
+    await helpers.executeString(`
+      const value = 1;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('object', async () => {
+    await helpers.executeString(`
+      const value: { [key: string]: string } = {};
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('string ""', async () => {
+    await helpers.executeString(`
+      const value: string = '';
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('string "a"', async () => {
+    await helpers.executeString(`
+      const value: string = 'a';
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('symbol', async () => {
+    await helpers.executeString(`
+      const value: symbol = Symbol.for('a');
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('undefined', async () => {
+    await helpers.executeString(`
+      const value: undefined = undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, bad);
+    `);
+  });
+
+  test('array or undefined', async () => {
+    await helpers.executeString(`
+      const value: Array<number> | undefined = [] as Array<number> | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('boolean or undefined true', async () => {
+    await helpers.executeString(`
+      const value: boolean | undefined = true as boolean | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('boolean or undefined false', async () => {
+    await helpers.executeString(`
+      const value: boolean | undefined = false as boolean | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('buffer or undefined', async () => {
+    await helpers.executeString(`
+      const value: Buffer | undefined = Buffer.from('', 'hex') as Buffer | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('null or undefined', async () => {
+    await helpers.executeString(`
+      const value: null | undefined = null as null | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, bad);
+    `);
+  });
+
+  test('number or undefined 0', async () => {
+    await helpers.executeString(`
+      const value: number | undefined = 0 as number | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('number or undefined 1', async () => {
+    await helpers.executeString(`
+      const value: number | undefined = 1 as number | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('object or undefined', async () => {
+    await helpers.executeString(`
+      const value: { [key: string]: string } | undefined = {} as { [key: string]: string } | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('string or undefined ""', async () => {
+    await helpers.executeString(`
+      const value: string | undefined = '' as string | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('string or undefined "a"', async () => {
+    await helpers.executeString(`
+      const value: string | undefined = 'a' as string | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('symbol or undefined', async () => {
+    await helpers.executeString(`
+      const value: symbol | undefined = Symbol.for('a') as symbol | undefined;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('array or object', async () => {
+    await helpers.executeString(`
+      const value: Array<number> | { [key: string]: number } = [] as Array<number> | { [key: string]: number };
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+
+  test('array or object or number', async () => {
+    await helpers.executeString(`
+      const value: Array<number> | { [key: string]: number } | number = [] as Array<number> | { [key: string]: number } | number;
+      const bad = 'bad';
+      const result = value ?? bad;
+
+      assertEqual(result, value);
+    `);
+  });
+});

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/DeployHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/DeployHelper.ts
@@ -45,7 +45,7 @@ export class DeployHelper extends Helper {
               sb.emitPushString(property, tsUtils.node.getName(property));
               // []
               sb.emitHelper(property, innerOptions, sb.helpers.putCommonStorage);
-            } else if (ts.isParameterPropertyDeclaration(property)) {
+            } else if (ts.isParameterPropertyDeclaration(property, property.parent)) {
               const name = tsUtils.node.getName(property);
               // [val]
               sb.scope.get(sb, property, sb.pushValueOptions(innerOptions), name);

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -347,6 +347,7 @@ import {
   SetPropertyObjectPropertyHelper,
   SetSymbolObjectPropertyHelper,
   ToBooleanHelper,
+  ToNullishBooleanHelper,
   ToNumberHelper,
   ToObjectHelper,
   ToPrimitiveHelper,
@@ -561,6 +562,7 @@ export interface Helpers {
   readonly unwrapSymbol: UnwrapSymbolHelper;
   readonly getObject: GetObjectHelper;
   readonly toBoolean: (options: TypedHelperOptions) => ToBooleanHelper;
+  readonly toNullishBoolean: (options: TypedHelperOptions) => ToNullishBooleanHelper;
   readonly toString: (options: ToStringHelperOptions) => ToStringHelper;
   readonly toNumber: (options: TypedHelperOptions) => ToNumberHelper;
   readonly toObject: (options: TypedHelperOptions) => ToObjectHelper;
@@ -1010,6 +1012,7 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     unwrapSymbol: new UnwrapSymbolHelper(),
     getObject: new GetObjectHelper(),
     toBoolean: (options) => new ToBooleanHelper(options),
+    toNullishBoolean: (options) => new ToNullishBooleanHelper(options),
     toString: (options) => new ToStringHelper(options),
     toNumber: (options) => new ToNumberHelper(options),
     toObject: (options) => new ToObjectHelper(options),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/boolean/ToNullishBooleanHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/boolean/ToNullishBooleanHelper.ts
@@ -1,0 +1,65 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../../sb';
+import { VisitOptions } from '../../../types';
+import { TypedHelper } from '../TypedHelper';
+
+// Input: [val]
+// Output: [boolean]
+export class ToNullishBooleanHelper extends TypedHelper {
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    if (!options.pushValue) {
+      /* istanbul ignore next */
+      sb.emitOp(node, 'DROP');
+
+      /* istanbul ignore next */
+      return;
+    }
+
+    const convertUndefinedOrNull = () => {
+      sb.emitOp(node, 'DROP');
+      sb.emitPushBoolean(node, false);
+    };
+
+    const convertOther = () => {
+      sb.emitOp(node, 'DROP');
+      sb.emitPushBoolean(node, true);
+    };
+
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.forBuiltinType({
+        type: this.type,
+        knownType: this.knownType,
+        array: convertOther,
+        arrayStorage: convertOther,
+        boolean: convertOther,
+        buffer: convertOther,
+        null: convertUndefinedOrNull,
+        number: convertOther,
+        object: convertOther,
+        string: convertOther,
+        symbol: convertOther,
+        undefined: convertUndefinedOrNull,
+        map: convertOther,
+        mapStorage: convertOther,
+        set: convertOther,
+        setStorage: convertOther,
+        error: convertOther,
+        forwardValue: convertOther,
+        iteratorResult: convertOther,
+        iterable: convertOther,
+        iterableIterator: convertOther,
+        transaction: convertOther,
+        output: convertOther,
+        attribute: convertOther,
+        input: convertOther,
+        account: convertOther,
+        asset: convertOther,
+        contract: convertOther,
+        header: convertOther,
+        block: convertOther,
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/boolean/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/boolean/index.ts
@@ -2,5 +2,6 @@ export * from './WrapBooleanHelper';
 export * from './UnwrapBooleanHelper';
 export * from './IsBooleanHelper';
 export * from './ToBooleanHelper';
+export * from './ToNullishBooleanHelper';
 
 export * from './typeTests';

--- a/packages/neo-one-smart-contract-compiler/src/contract/ContractInfoProcessor.ts
+++ b/packages/neo-one-smart-contract-compiler/src/contract/ContractInfoProcessor.ts
@@ -335,7 +335,7 @@ export class ContractInfoProcessor {
         ts.isPropertyDeclaration(decl) ||
         ts.isGetAccessorDeclaration(decl) ||
         ts.isSetAccessorDeclaration(decl) ||
-        ts.isParameterPropertyDeclaration(decl)
+        ts.isParameterPropertyDeclaration(decl, decl.parent)
       )
     ) {
       return undefined;

--- a/packages/neo-one-smart-contract-typescript-plugin/package.json
+++ b/packages/neo-one-smart-contract-typescript-plugin/package.json
@@ -10,14 +10,14 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@neo-one/smart-contract-compiler": "^2.3.0",
     "@neo-one/smart-contract-compiler-node": "^2.3.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-ts-utils/package.json
+++ b/packages/neo-one-ts-utils/package.json
@@ -10,16 +10,16 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "lodash": "^4.17.15",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
     "@types/lodash": "^4.14.138",
     "gulp": "~4.0.2"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-ts-utils/src/class_.ts
+++ b/packages/neo-one-ts-utils/src/class_.ts
@@ -15,7 +15,7 @@ export function isClassProperty(node: ts.Node): node is ClassPropertyType {
 
 export type ClassInstancePropertyType = ClassPropertyType | ts.ParameterPropertyDeclaration;
 export function isClassInstanceProperty(node: ts.Node): node is ClassInstancePropertyType {
-  return (isClassProperty(node) || ts.isParameterPropertyDeclaration(node)) && !modifier.isStatic(node);
+  return (isClassProperty(node) || ts.isParameterPropertyDeclaration(node, node.parent)) && !modifier.isStatic(node);
 }
 
 export type ClassInstanceMemberType = ts.MethodDeclaration | ClassInstancePropertyType;
@@ -80,7 +80,7 @@ export function getMembers(node: ts.ClassDeclaration | ts.ClassExpression): read
     let insertIndex = members.indexOf(ctor) + 1;
     // tslint:disable-next-line no-loop-statement
     for (const param of parametered.getParameters(ctor)) {
-      if (ts.isParameterPropertyDeclaration(param)) {
+      if (ts.isParameterPropertyDeclaration(param, param.parent)) {
         // tslint:disable-next-line no-array-mutation
         members.splice(insertIndex, 0, param);
         insertIndex += 1;

--- a/packages/neo-one-ts-utils/src/exportDeclaration.ts
+++ b/packages/neo-one-ts-utils/src/exportDeclaration.ts
@@ -8,7 +8,7 @@ export function getNamedExports(node: ts.ExportDeclaration): readonly ts.ExportS
     return [];
   }
 
-  const exps = utils.getValueOrUndefined(namedExports.elements);
+  const exps = !ts.isNamedExports(namedExports) ? undefined : utils.getValueOrUndefined(namedExports.elements);
 
   return exps === undefined ? [] : exps;
 }

--- a/packages/neo-one-ts-utils/src/literal.ts
+++ b/packages/neo-one-ts-utils/src/literal.ts
@@ -1,8 +1,15 @@
 import ts from 'typescript';
+import { getText } from './node';
 
 export function getLiteralValue(node: ts.NumericLiteral): number;
 export function getLiteralValue(
-  node: ts.StringLiteral | ts.LiteralExpression | ts.TemplateHead | ts.TemplateMiddle | ts.TemplateTail,
+  node:
+    | ts.StringLiteral
+    | ts.LiteralExpression
+    | ts.TemplateHead
+    | ts.TemplateMiddle
+    | ts.TemplateTail
+    | ts.PrivateIdentifier,
 ): string;
 export function getLiteralValue(
   node:
@@ -11,7 +18,8 @@ export function getLiteralValue(
     | ts.LiteralExpression
     | ts.TemplateHead
     | ts.TemplateMiddle
-    | ts.TemplateTail,
+    | ts.TemplateTail
+    | ts.PrivateIdentifier,
 ): string | number {
   if (ts.isStringLiteral(node)) {
     return node.text;
@@ -23,6 +31,10 @@ export function getLiteralValue(
 
   if (ts.isLiteralExpression(node) || ts.isTemplateHead(node) || ts.isTemplateMiddle(node) || ts.isTemplateTail(node)) {
     return node.text;
+  }
+
+  if (ts.isPrivateIdentifier(node)) {
+    return getText(node);
   }
 
   throw new Error('Never');

--- a/packages/neo-one-ts-utils/src/symbol.ts
+++ b/packages/neo-one-ts-utils/src/symbol.ts
@@ -29,6 +29,13 @@ export function getAliasedSymbol(typeChecker: ts.TypeChecker, node: ts.Symbol): 
     return utils.getValueOrUndefined(typeChecker.getAliasedSymbol(node));
   }
 
+  if (hasSymbolFlag(node, ts.SymbolFlags.TypeAlias)) {
+    const type = utils.getValueOrUndefined(typeChecker.getDeclaredTypeOfSymbol(node));
+    if (type !== undefined) {
+      return utils.getValueOrUndefined(type.getSymbol());
+    }
+  }
+
   return undefined;
 }
 

--- a/packages/neo-one-typescript-concatenator/package.json
+++ b/packages/neo-one-typescript-concatenator/package.json
@@ -10,13 +10,14 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@neo-one/ts-utils": "^2.3.0",
     "@neo-one/utils": "^2.3.0",
     "lodash": "^4.17.15",
     "toposort": "^2.0.2",
     "tslib": "^1.10.0",
-    "typescript": "3.6.3"
+    "typescript": "3.8.1-rc"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
@@ -31,6 +32,5 @@
     "fs-extra": "^8.1.0",
     "gulp": "~4.0.2",
     "yargs": "^14.2.0"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
@@ -80,3 +80,6 @@ export * from './foo3';
 export * from './foo4';
 // Export one of a multi-decl statement
 export { fizz } from './varDecl';
+// Namespace export
+export * as foo5 from './foo5';
+export * as somethingElse from './foo5';

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/foo5.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/foo5.ts
@@ -1,0 +1,3 @@
+export const one = 'one';
+export const two = 'two';
+export const func = () => 'three';

--- a/packages/neo-one-typescript-concatenator/src/__tests__/__snapshots__/concatenate.test.ts.snap
+++ b/packages/neo-one-typescript-concatenator/src/__tests__/__snapshots__/concatenate.test.ts.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`concatenate import 1`] = `
-"const fizz = 'fizz', bang = 'bang';
+"const one = 'one';
+const two = 'two';
+const func = () => 'three';
+const fizz = 'fizz', bang = 'bang';
 type Address = string;
 const foo = 'foo';
 abstract class SmartContract {
@@ -10,7 +13,7 @@ abstract class SmartContract {
     }
 }
 // tslint:disable-next-line no-default-export
-class default52 extends SmartContract {
+class default11 extends SmartContract {
 }
 // tslint:disable-next-line export-name
 class FooType {
@@ -18,22 +21,22 @@ class FooType {
 }
 const fooType = 'fooType';
 // tslint:disable-next-line no-let
-let valc2 = 0;
-function valuec1() {
-    return valc2;
+let valc1 = 0;
+function value44() {
+    return valc1;
 }
-function defaultc3() {
-    valc2 += 1;
+function default41() {
+    valc1 += 1;
 }
-const defaultc4 = 'baz';
+const default33 = 'baz';
 // tslint:disable-next-line no-let
-let valc5 = 0;
+let valc2 = 0;
 const x = 3;
-const value39 = () => valc5;
+const value48 = () => valc2;
 const incrementValue = () => {
-    valc5 += 1;
+    valc2 += 1;
 };
-const bar = { value: value39, incrementValue: incrementValue, x: x };
+const bar = { value: value48, incrementValue: incrementValue, x: x };
 if (foo !== 'foo') {
     throw 'Failure';
 }
@@ -47,17 +50,17 @@ bar.incrementValue();
 if (bar.value() !== 1) {
     throw 'Failure';
 }
-if (valuec1() !== 0) {
+if (value44() !== 0) {
     throw 'Failure';
 }
-defaultc3();
-if (valuec1() !== 1) {
+default41();
+if (value44() !== 1) {
     throw 'Failure';
 }
 if (bar.x !== 3) {
     throw 'Failure';
 }
-if (defaultc4 !== 'baz') {
+if (default33 !== 'baz') {
     throw 'Failure';
 }
 // tslint:disable-next-line export-name
@@ -70,7 +73,7 @@ const qux = new Qux();
 if (qux.foo !== 'foo') {
     throw 'Failure';
 }
-const fooSC = new default52();
+const fooSC = new default11();
 if (fooSC.foo !== 'foo') {
     throw 'Failure';
 }
@@ -78,11 +81,13 @@ export { fooSC as fooSC };
 export { fooSC as barSC };
 export { bar };
 export { bar as bar2 };
-export { defaultc4 as baz };
-export { defaultc4 as baz2 };
+export { default33 as baz };
+export { default33 as baz2 };
 export { FooType as FooType, fooType as fooType };
 export { Address as Address, foo as foo, SmartContract as SmartContract };
-export { SmartContract as SmartContract2Level, default52 as FooSmartContract2Level, foo as foo2level, Address as Address2Level };
+export { SmartContract as SmartContract2Level, default11 as FooSmartContract2Level, foo as foo2level, Address as Address2Level };
 export { fizz as fizz };
+export const foo5 = { one: one, two: two, func: func };
+export const somethingElse = { one: one, two: two, func: func };
 "
 `;

--- a/packages/neo-one-utils/package.json
+++ b/packages/neo-one-utils/package.json
@@ -11,6 +11,7 @@
     "pack": "gulp pack",
     "tsc": "node ./node_modules/@neo-one/build-tools/bin/neo-one-tsc.js"
   },
+  "sideEffects": false,
   "dependencies": {
     "@types/node": "^12.7.7",
     "lodash": "^4.17.15",
@@ -23,7 +24,6 @@
     "@types/lodash": "^4.14.138",
     "gulp": "~4.0.2",
     "jest": "^24.9.0",
-    "typescript": "3.6.3"
-  },
-  "sideEffects": false
+    "typescript": "3.8.1-rc"
+  }
 }

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/0-info/src/ICO.tsx
@@ -10,7 +10,7 @@ import { prop } from 'styled-tools';
 import { WithContracts } from '../one/generated';
 import { getTokenInfo } from './utils';
 
-const StyledGrid = styled(Box)`
+const StyledGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/1-balance/src/ICO.tsx
@@ -9,7 +9,7 @@ import { prop } from 'styled-tools';
 import { WithContracts } from '../one/generated';
 import { getTokenInfo } from './utils';
 
-const StyledGrid = styled(Box)`
+const StyledGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/2-participate/src/ICO.tsx
@@ -11,7 +11,7 @@ import { prop } from 'styled-tools';
 import { TokenSmartContract, WithContracts } from '../one/generated';
 import { getTokenInfo, handleMint } from './utils';
 
-const InfoGrid = styled(Box)`
+const InfoGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -24,7 +24,7 @@ const InfoGrid = styled(Box)`
   gap: 0;
 `;
 
-const ContributeGrid = styled(Box)`
+const ContributeGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/3-reactive/src/ICO.tsx
@@ -11,7 +11,7 @@ import { prop } from 'styled-tools';
 import { TokenSmartContract, WithContracts } from '../one/generated';
 import { createTokenInfoStream$, handleMint } from './utils';
 
-const InfoGrid = styled(Box)`
+const InfoGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -24,7 +24,7 @@ const InfoGrid = styled(Box)`
   gap: 0;
 `;
 
-const ContributeGrid = styled(Box)`
+const ContributeGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/4-transfer/src/ICO.tsx
@@ -13,7 +13,7 @@ import { prop } from 'styled-tools';
 import { TokenSmartContract, WithContracts } from '../one/generated';
 import { createTokenInfoStream$, handleMint, handleTransfer } from './utils';
 
-const InfoGrid = styled(Box)`
+const InfoGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -26,7 +26,7 @@ const InfoGrid = styled(Box)`
   gap: 0;
 `;
 
-const ContributeGrid = styled(Box)`
+const ContributeGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -40,7 +40,7 @@ const ContributeGrid = styled(Box)`
   margin: 8px;
 `;
 
-const TransferGrid = styled(Box)`
+const TransferGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/src/ICO.tsx
+++ b/packages/neo-one-website/courses/0-tokenomics/2-launch/5-withdraw/src/ICO.tsx
@@ -13,7 +13,7 @@ import { prop } from 'styled-tools';
 import { TokenSmartContract, WithContracts } from '../one/generated';
 import { createTokenInfoStream$, handleMint, handleTransfer, handleWithdraw } from './utils';
 
-const InfoGrid = styled(Box)`
+const InfoGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -26,7 +26,7 @@ const InfoGrid = styled(Box)`
   gap: 0;
 `;
 
-const ContributeGrid = styled(Box)`
+const ContributeGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -40,7 +40,7 @@ const ContributeGrid = styled(Box)`
   margin: 8px;
 `;
 
-const TransferGrid = styled(Box)`
+const TransferGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};
@@ -54,7 +54,7 @@ const TransferGrid = styled(Box)`
   margin: 8px;
 `;
 
-const WithdrawGrid = styled(Box)`
+const WithdrawGrid = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.body1')};

--- a/packages/neo-one-website/package.json
+++ b/packages/neo-one-website/package.json
@@ -9,6 +9,11 @@
     "lint:staged": "lint-staged --relative",
     "tsc": "node node_modules/.bin/tsc --noEmit"
   },
+  "sideEffects": [
+    "src/polyfill.ts",
+    "src/Modernizr.js",
+    "*.css"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.6.3",
     "@emotion/core": "^10.0.22",
@@ -46,8 +51,8 @@
     "react-redux": "^7.0.3",
     "react-static": "^7.1.0",
     "react-static-plugin-emotion": "^7.2.2",
-    "react-static-plugin-source-filesystem": "^7.2.3",
     "react-static-plugin-reach-router": "^7.2.3",
+    "react-static-plugin-source-filesystem": "^7.2.3",
     "react-transition-group": "^4.2.1",
     "react-universal-component": "^4.0.0",
     "redux": "^4.0.4",
@@ -57,14 +62,16 @@
     "slugify": "^1.3.3",
     "styled-tools": "^1.7.1",
     "ts-node": "^8.4.1",
-    "typescript": "3.6.3",
     "tslib": "^1.10.0",
+    "typescript": "3.8.1-rc",
     "typescript-fsa": "^3.0.0-beta-2",
     "typescript-fsa-reducers": "^1.2.1",
     "webpack": "^4.40.2"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",
+    "@neo-one/client": "^2.3.0",
+    "@neo-one/react-core": "^2.3.0",
     "@types/clipboard": "^2.0.1",
     "@types/fs-extra": "^8.0.0",
     "@types/jest": "^24.0.18",
@@ -78,14 +85,7 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-redux": "^7.1.1",
     "@types/webpack": "^4.39.0",
-    "@neo-one/client": "^2.3.0",
-    "@neo-one/react-core": "^2.3.0",
-    "bignumber.js":"^9.0.0",
+    "bignumber.js": "^9.0.0",
     "rxjs": "^6.5.3"
-  },
-  "sideEffects": [
-    "src/polyfill.ts",
-    "src/Modernizr.js",
-    "*.css"
-  ]
+  }
 }

--- a/packages/neo-one-website/src/components/Footer.tsx
+++ b/packages/neo-one-website/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import { prop } from 'styled-tools';
 import { LayoutWrapper } from './common';
 import { StyledRouterLink } from './StyledRouterLink';
 
-const LinkSectionTitle = styled(Box)`
+const LinkSectionTitle = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaBold')};
   ${prop('theme.fontStyles.body1')};
   color: ${prop('theme.gray2')};
@@ -44,7 +44,7 @@ const LinkSection = ({
   </LinkSectionWrapper>
 );
 
-const FooterWrapper = styled(Box)`
+const FooterWrapper = styled(Box)<{}, {}>`
   display: grid;
   justify-content: center;
   grid-gap: 64px;
@@ -56,14 +56,14 @@ const FooterWrapper = styled(Box)`
   }
 `;
 
-const Copyright = styled(Box)`
+const Copyright = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.caption')};
   color: ${prop('theme.gray3')};
   text-align: center;
 `;
 
-const LinksGrid = styled(Box)`
+const LinksGrid = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
   grid-gap: 64px;
@@ -73,7 +73,7 @@ const LinksGrid = styled(Box)`
   }
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   background-color: ${prop('theme.black')};
   box-shadow: inset 0 10px 10px -5px rgba(0, 0, 0, 0.2);

--- a/packages/neo-one-website/src/components/Header.tsx
+++ b/packages/neo-one-website/src/components/Header.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { ifProp, prop, withProp } from 'styled-tools';
 import { StyledRouterLinkBase } from './StyledRouterLink';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: flex;
   width: 100%;
   justify-content: center;
@@ -18,7 +18,8 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const StyledToolbar = styled(Toolbar)`
+// tslint:disable-next-line: no-any
+const StyledToolbar = styled(Toolbar)<any>`
   && {
     height: 100%;
     grid-gap: 8px;
@@ -31,7 +32,8 @@ const StyledToolbar = styled(Toolbar)`
   }
 `;
 
-const LogoLink = styled(StyledRouterLinkBase)`
+// tslint:disable-next-line: no-any
+const LogoLink = styled(StyledRouterLinkBase)<any>`
   display: block;
   margin-right: 0;
   margin-bottom: 8px;
@@ -45,7 +47,8 @@ const LogoLink = styled(StyledRouterLinkBase)`
   }
 `;
 
-const NavigationLink = styled<typeof StyledRouterLinkBase, { readonly active: boolean }>(StyledRouterLinkBase)`
+// tslint:disable-next-line: no-any
+const NavigationLink = styled(StyledRouterLinkBase)<any>`
   display: flex;
   align-items: center;
   ${prop('theme.fontStyles.headline')};
@@ -73,19 +76,19 @@ const NavigationLink = styled<typeof StyledRouterLinkBase, { readonly active: bo
 
 const FocusableLink = ToolbarFocusable.withComponent(Link);
 
-const GitHubLink = styled(FocusableLink)`
+const GitHubLink = styled(FocusableLink)<{}, {}>`
   @media (max-width: ${prop('theme.breakpoints.sm')}) {
     display: none;
   }
 `;
 
-const CourseLink = styled(NavigationLink)`
+const CourseLink = styled(NavigationLink)<{}, {}>`
   @media (max-width: ${prop('theme.breakpoints.sm')}) {
     display: none;
   }
 `;
 
-const LeftHeader = styled(ToolbarContent)`
+const LeftHeader = styled(ToolbarContent)<{}, {}>`
   grid-gap: 32px;
 
   @media (max-width: ${prop('theme.breakpoints.md')}) {

--- a/packages/neo-one-website/src/components/Hero.tsx
+++ b/packages/neo-one-website/src/components/Hero.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { prop } from 'styled-tools';
 import { Tagline } from '../elements';
 
-const StyledBackground = styled(Background)`
+// tslint:disable-next-line: no-any
+const StyledBackground = styled(Background)<any>`
   display: flex;
   color: ${prop('theme.gray0')};
   justify-content: center;
@@ -12,7 +13,7 @@ const StyledBackground = styled(Background)`
   width: 100%;
 `;
 
-const Headline = styled(H1)`
+const Headline = styled(H1)<{}, {}>`
   align-self: start;
   justify-self: start;
   color: ${prop('theme.primary')};

--- a/packages/neo-one-website/src/components/StyledRouterLink.tsx
+++ b/packages/neo-one-website/src/components/StyledRouterLink.tsx
@@ -31,7 +31,7 @@ export const StyledRouterLinkBase = styled<typeof RouterLink, StyledRouterLinkBa
   }
 `;
 
-export const StyledRouterLink = styled(StyledRouterLinkBase)`
+export const StyledRouterLink = styled(StyledRouterLinkBase)<{}, {}>`
   ${prop('theme.fonts.axiformaBold')};
   ${prop('theme.fontStyles.body1')};
 `;

--- a/packages/neo-one-website/src/components/blog/BlogAll.tsx
+++ b/packages/neo-one-website/src/components/blog/BlogAll.tsx
@@ -16,7 +16,7 @@ export interface BlogAllProps {
   readonly posts: readonly BlogPost[];
 }
 
-const PostsGrid = styled(Box)`
+const PostsGrid = styled(Box)<{}, {}>`
   display: grid;
   border-top: 1px solid ${prop('theme.gray3')};
   grid-template-columns: 1fr;
@@ -43,7 +43,7 @@ const PostsGrid = styled(Box)`
   }
 `;
 
-const Title = styled(Box)`
+const Title = styled(Box)<{}, {}>`
   ${prop('theme.fontStyles.display2')};
   margin-bottom: 16px;
 
@@ -57,7 +57,7 @@ const Title = styled(Box)`
   }
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   padding-left: 16px;
   padding-right: 16px;
   padding-top: 16px;

--- a/packages/neo-one-website/src/components/blog/PostLink.tsx
+++ b/packages/neo-one-website/src/components/blog/PostLink.tsx
@@ -12,16 +12,17 @@ interface Props {
   readonly author: Author;
 }
 
-const StyledLink = styled(StyledRouterLink)`
+// tslint:disable-next-line: no-any
+const StyledLink = styled(StyledRouterLink)<any>`
   ${prop('theme.fontStyles.headline')};
 `;
 
-const PostInfo = styled(Box)`
+const PostInfo = styled(Box)<{}, {}>`
   color: ${prop('theme.gray5')};
   ${prop('theme.fontStyles.subheading')};
 `;
 
-const Wrapper = styled(List)`
+const Wrapper = styled(List)<{}, {}>`
   list-style-type: none;
   max-width: 320px;
   border-bottom: 1px solid ${prop('theme.gray3')};

--- a/packages/neo-one-website/src/components/common/LayoutWrapper.tsx
+++ b/packages/neo-one-website/src/components/common/LayoutWrapper.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { prop } from 'styled-tools';
 import { SidebarSpacer } from './SidebarSpacer';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid:
     'content' 'sidebar' auto

--- a/packages/neo-one-website/src/components/common/SidebarSpacer.tsx
+++ b/packages/neo-one-website/src/components/common/SidebarSpacer.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Box } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const SidebarSpacer = styled(Box)`
+export const SidebarSpacer = styled(Box)<{}, {}>`
   display: none;
 
   @media (min-width: ${prop('theme.breakpoints.sm')}) {

--- a/packages/neo-one-website/src/components/content/AdjacentLink.tsx
+++ b/packages/neo-one-website/src/components/content/AdjacentLink.tsx
@@ -10,7 +10,7 @@ export interface Props {
   readonly next?: boolean;
 }
 
-const ArticleText = styled<typeof Box, { readonly next: boolean }>(Box)`
+const ArticleText = styled(Box)<{ readonly next: boolean }, { readonly next: boolean }>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.caption')};
   color: ${prop('theme.gray0')};
@@ -18,7 +18,8 @@ const ArticleText = styled<typeof Box, { readonly next: boolean }>(Box)`
   padding-bottom: 8px;
 `;
 
-const StyledLink = styled(StyledRouterLink)`
+// tslint:disable-next-line: no-any
+const StyledLink = styled(StyledRouterLink)<any>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.display1')};
 

--- a/packages/neo-one-website/src/components/content/DateAndAuthor.tsx
+++ b/packages/neo-one-website/src/components/content/DateAndAuthor.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { prop } from 'styled-tools';
 import { Author } from './types';
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')}
   ${prop('theme.fontStyles.subheading')}
   color: ${prop('theme.black')};

--- a/packages/neo-one-website/src/components/content/DocFooter.tsx
+++ b/packages/neo-one-website/src/components/content/DocFooter.tsx
@@ -7,7 +7,7 @@ import { AdjacentInfo } from '../../types';
 import { LayoutWrapper } from '../common';
 import { AdjacentLink } from './AdjacentLink';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   justify-items: center;
   padding-top: 64px;
@@ -16,7 +16,7 @@ const Wrapper = styled(Box)`
   width: 100%;
 `;
 
-const LinkWrapper = styled(Box)`
+const LinkWrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
   justify-content: space-between;

--- a/packages/neo-one-website/src/components/content/Sidebar.tsx
+++ b/packages/neo-one-website/src/components/content/Sidebar.tsx
@@ -10,7 +10,7 @@ import { SidebarList } from './SidebarList';
 
 const Wrapper = styled(Box)``;
 
-const DesktopSidebarWrapper = styled(Box)`
+const DesktopSidebarWrapper = styled(Box)<{}, {}>`
   background-color: ${prop('theme.gray1')};
   position: fixed;
   height: 100vh;
@@ -26,7 +26,7 @@ const DesktopSidebarWrapper = styled(Box)`
   }
 `;
 
-const MobileWrapper = styled(Box)`
+const MobileWrapper = styled(Box)<{}, {}>`
   @media (min-width: ${prop('theme.breakpoints.sm')}) {
     display: none;
   }
@@ -73,7 +73,7 @@ const StyledHidden = styled(Hidden)`
   }
 `;
 
-const MobileSidebarWrapper = styled(Box)`
+const MobileSidebarWrapper = styled(Box)<{}, {}>`
   width: 100%;
   background-color: ${prop('theme.gray1')};
 `;

--- a/packages/neo-one-website/src/components/content/SidebarList.tsx
+++ b/packages/neo-one-website/src/components/content/SidebarList.tsx
@@ -7,7 +7,7 @@ import { Section } from './Section';
 
 const { useEffect } = React;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   background-color: ${prop('theme.gray1')};
   padding-top: 16px;
   padding-bottom: 16px;

--- a/packages/neo-one-website/src/components/content/SubsectionLink.tsx
+++ b/packages/neo-one-website/src/components/content/SubsectionLink.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import { ifProp, prop } from 'styled-tools';
 import { StyledRouterLink } from '../StyledRouterLink';
 
-const Link = styled<typeof StyledRouterLink, { readonly active: boolean }>(StyledRouterLink)`
+// tslint:disable-next-line: no-any
+const Link = styled(StyledRouterLink)<any>`
   ${ifProp('active', prop('theme.fonts.axiformaBold'), prop('theme.fonts.axiformaRegular'))};
   ${prop('theme.fontStyles.subheading')};
 
@@ -39,7 +40,7 @@ const TutorialLink = styled<typeof BaseLink, { readonly active: boolean }>(BaseL
   }
 `;
 
-const ActiveBorder = styled.span`
+const ActiveBorder = styled.span<{}, {}>`
   width: 4px;
   height: 24px;
   border-left: 4px solid ${prop('theme.accent')};

--- a/packages/neo-one-website/src/components/course/App.tsx
+++ b/packages/neo-one-website/src/components/course/App.tsx
@@ -54,13 +54,13 @@ const ChapterRoute = ({ course, lesson, chapter }: RouteComponentProps<ChapterPa
   );
 };
 
-const DesktopWrapper = styled(Box)`
+const DesktopWrapper = styled(Box)<{}, {}>`
   @media (max-width: ${prop('theme.breakpoints.sm')}) {
     display: none;
   }
 `;
 
-const MobileWrapper = styled(Box)`
+const MobileWrapper = styled(Box)<{}, {}>`
   display: none;
 
   @media (max-width: ${prop('theme.breakpoints.sm')}) {
@@ -70,14 +70,14 @@ const MobileWrapper = styled(Box)`
   }
 `;
 
-const Header = styled.h1`
+const Header = styled.h1<{}, {}>`
   ${prop('theme.fonts.axiformaBold')}
   ${prop('theme.fontStyles.headline')}
   color: ${prop('theme.gray0')};
   margin: 0;
 `;
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')}
   ${prop('theme.fontStyles.subheading')}
   color: ${prop('theme.gray0')};

--- a/packages/neo-one-website/src/components/course/CourseHeader.tsx
+++ b/packages/neo-one-website/src/components/course/CourseHeader.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { prop } from 'styled-tools';
 import { RouterLink } from '../RouterLink';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: flex;
   width: 100%;
   justify-content: center;
@@ -17,7 +17,8 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const StyledToolbar = styled(Toolbar)`
+// tslint:disable-next-line: no-any
+const StyledToolbar = styled(Toolbar)<any>`
   &&& {
     height: 100%;
     grid-gap: 8px;
@@ -25,7 +26,7 @@ const StyledToolbar = styled(Toolbar)`
   }
 `;
 
-const LogoLink = styled(RouterLink)`
+const LogoLink = styled(RouterLink)<{}, {}>`
   display: block;
   margin-right: 24px;
   margin-bottom: 16px;

--- a/packages/neo-one-website/src/components/course/CourseRequirementError.tsx
+++ b/packages/neo-one-website/src/components/course/CourseRequirementError.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled(Box)`
   width: 100%;
 `;
 
-const BoxWrapper = styled(Box)`
+const BoxWrapper = styled(Box)<{}, {}>`
   display: grid;
   background-color: ${prop('theme.gray6')};
   padding-top: 64px;
@@ -23,7 +23,7 @@ const BoxWrapper = styled(Box)`
   place-content: center;
 `;
 
-const InnerWrapper = styled(Box)`
+const InnerWrapper = styled(Box)<{}, {}>`
   display: grid;
   background-color: ${prop('theme.black')};
   max-width: 480px;
@@ -32,7 +32,7 @@ const InnerWrapper = styled(Box)`
   box-shadow: 0 6px 4px 4px rgba(0, 0, 0, 0.2);
 `;
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   color: ${prop('theme.gray0')};
   ${prop('theme.fontStyles.subheading')};
 `;

--- a/packages/neo-one-website/src/components/course/chapter/DocsFooter.tsx
+++ b/packages/neo-one-website/src/components/course/chapter/DocsFooter.tsx
@@ -10,7 +10,7 @@ import { DocsSolution } from './DocsSolution';
 import { NextButton } from './NextButton';
 import { PreviousButton } from './PreviousButton';
 
-const Wrapper = styled(DispatchWrapper)`
+const Wrapper = styled(DispatchWrapper)<{}, {}>`
   display: grid;
   grid:
     'solution' auto

--- a/packages/neo-one-website/src/components/course/chapter/NextButton.tsx
+++ b/packages/neo-one-website/src/components/course/chapter/NextButton.tsx
@@ -26,7 +26,8 @@ const getNextLesson = (selected: SelectedChapter) => {
   return course.lessons[selected.lesson + 1] as Lesson | undefined;
 };
 
-const ButtonLink = Button.withComponent(RouterLink);
+// tslint:disable-next-line: no-any
+const ButtonLink = Button.withComponent<any>(RouterLink);
 
 const NextButtonBase = ({ selected, onClick, complete, ...props }: Props) => {
   const nextChapter = getNextChapter(selected);

--- a/packages/neo-one-website/src/components/course/chapter/PreviousButton.tsx
+++ b/packages/neo-one-website/src/components/course/chapter/PreviousButton.tsx
@@ -23,7 +23,8 @@ const getPreviousLesson = (selected: SelectedChapter) => {
   return course.lessons[selected.lesson - 1] as Lesson | undefined;
 };
 
-const ButtonLink = Button.withComponent(RouterLink);
+// tslint:disable-next-line: no-any
+const ButtonLink = Button.withComponent<any>(RouterLink);
 
 export const PreviousButton = ({ selected, onClick, ...props }: Props) => {
   const previousChapter = getPreviousChapter(selected);

--- a/packages/neo-one-website/src/components/course/courses/CourseExplainer.tsx
+++ b/packages/neo-one-website/src/components/course/courses/CourseExplainer.tsx
@@ -5,17 +5,17 @@ import { prop } from 'styled-tools';
 import { maxWidth } from './constants';
 import { ContentWrapper } from './ContentWrapper';
 
-const NavLink = styled(Link)`
+const NavLink = styled(Link)<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
 `;
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.subheading')};
   color: ${prop('theme.black')};
 `;
 
-const Header = styled(H2)`
+const Header = styled(H2)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')}
   ${prop('theme.fontStyles.headline')}
   color: ${prop('theme.black')};

--- a/packages/neo-one-website/src/components/course/courses/CoursesView.tsx
+++ b/packages/neo-one-website/src/components/course/courses/CoursesView.tsx
@@ -8,7 +8,8 @@ import { courses } from '../coursesData';
 import { CourseExplainer } from './CourseExplainer';
 import { CourseSection } from './CourseSection';
 
-const StyledBackground = styled(Background)`
+// tslint:disable-next-line: no-any
+const StyledBackground = styled(Background)<any>`
   display: flex;
   color: ${prop('theme.gray0')};
   justify-content: center;
@@ -16,7 +17,7 @@ const StyledBackground = styled(Background)`
   width: 100%;
 `;
 
-const Headline = styled(Box)`
+const Headline = styled(Box)<{}, {}>`
   color: ${prop('theme.gray0')};
   ${prop('theme.fontStyles.display1')};
   ${prop('theme.fonts.axiformaRegular')};

--- a/packages/neo-one-website/src/components/course/courses/LessonItem.tsx
+++ b/packages/neo-one-website/src/components/course/courses/LessonItem.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled(Box)`
     / auto;
 `;
 
-const Title = styled(ButtonBase.withComponent(RouterLink))`
+const Title = styled(ButtonBase.withComponent(RouterLink))<{}, {}>`
   width: 100%;
   ${prop('theme.fontStyles.headline')};
   ${prop('theme.fonts.axiformaMedium')};

--- a/packages/neo-one-website/src/components/course/lesson/LessonView.tsx
+++ b/packages/neo-one-website/src/components/course/lesson/LessonView.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled(Box)`
   width: 100%;
 `;
 
-const BoxWrapper = styled(Box)`
+const BoxWrapper = styled(Box)<{}, {}>`
   display: grid;
   background-color: ${prop('theme.gray6')};
   padding-top: 64px;
@@ -28,7 +28,7 @@ const BoxWrapper = styled(Box)`
   place-content: center;
 `;
 
-const InnerWrapper = styled(Box)`
+const InnerWrapper = styled(Box)<{}, {}>`
   display: grid;
   background-color: ${prop('theme.black')};
   max-width: 720px;
@@ -36,13 +36,14 @@ const InnerWrapper = styled(Box)`
   box-shadow: 0 6px 4px 4px rgba(0, 0, 0, 0.2);
 `;
 
-const StartButton = styled(Button.withComponent(RouterLink))`
+// tslint:disable-next-line: no-any
+const StartButton = styled(Button.withComponent<any>(RouterLink))`
   text-decoration: none;
   cursor: pointer;
   border-radius: 16px;
 `;
 
-const ButtonWrapper = styled(Box)`
+const ButtonWrapper = styled(Box)<{}, {}>`
   display: grid;
   color: ${prop('theme.gray0')};
   background-color: ${prop('theme.gray4')};
@@ -54,7 +55,7 @@ const ButtonWrapper = styled(Box)`
   padding: 8px;
 `;
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   ${prop('theme.fontStyles.headline')};
 `;
 

--- a/packages/neo-one-website/src/components/home/AssetSectionGrid.tsx
+++ b/packages/neo-one-website/src/components/home/AssetSectionGrid.tsx
@@ -10,7 +10,7 @@ interface Props {
   readonly children: React.ReactNode;
 }
 
-const StyledHeading = styled.h2`
+const StyledHeading = styled.h2<{}, {}>`
   ${prop('theme.fonts.axiformaMedium')};
   ${prop('theme.fontStyles.headline')};
   /* stylelint-disable-next-line */
@@ -18,7 +18,7 @@ const StyledHeading = styled.h2`
   margin: 0;
 `;
 
-const Content = styled(Box)`
+const Content = styled(Box)<{}, {}>`
   display: grid;
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.subheading')};
@@ -40,7 +40,7 @@ const ContentItem = styled(Box)`
   gap: 16;
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-template:
     'content asset' auto

--- a/packages/neo-one-website/src/components/home/ContentWrapperBase.tsx
+++ b/packages/neo-one-website/src/components/home/ContentWrapperBase.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Box } from '@neo-one/react-common';
 import { prop } from 'styled-tools';
 
-export const ContentWrapperBase = styled(Box)`
+export const ContentWrapperBase = styled(Box)<{}, {}>`
   display: grid;
   max-width: 1260px;
   padding-left: 24px;

--- a/packages/neo-one-website/src/components/home/EditorContent.tsx
+++ b/packages/neo-one-website/src/components/home/EditorContent.tsx
@@ -18,7 +18,7 @@ const InnerEditorWrapper = styled(ContentWrapperBase)`
   justify-content: stretch;
 `;
 
-const TextWrapper = styled(ContentWrapperBase)`
+const TextWrapper = styled(ContentWrapperBase)<{}, {}>`
   grid-gap: 24px;
   border-bottom: 1px solid ${prop('theme.gray2')};
   padding-bottom: 32px;
@@ -31,19 +31,19 @@ const InnerTextWrapper = styled(Box)`
   grid-gap: 24px;
 `;
 
-const StyledHeading = styled(H2)`
+const StyledHeading = styled(H2)<{}, {}>`
   ${prop('theme.fontStyles.headline')};
   ${prop('theme.fonts.axiformaBold')};
   color: ${prop('theme.gray1')};
 `;
 
-const Text = styled(Box)`
+const Text = styled(Box)<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
   ${prop('theme.fonts.axiformaRegular')};
   color: ${prop('theme.gray1')};
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   padding-top: 64px;
   background-color: ${prop('theme.black')};
@@ -56,7 +56,8 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const StyledLink = StyledRouterLink;
+// tslint:disable-next-line: no-any
+const StyledLink = styled(StyledRouterLink)<any>``;
 
 export const EditorContent = () => (
   <Wrapper>

--- a/packages/neo-one-website/src/components/home/Home.tsx
+++ b/packages/neo-one-website/src/components/home/Home.tsx
@@ -10,7 +10,8 @@ import { EditorContent } from './EditorContent';
 import { Proof } from './Proof';
 import { Testing } from './Testing';
 
-const StyledBackground = styled(Background)`
+// tslint:disable-next-line: no-any
+const StyledBackground = styled(Background)<any>`
   display: grid;
   place-content: center;
   place-items: center;
@@ -28,7 +29,7 @@ const StyledLineLogoPrimary = styled(LineLogoPrimary)`
   }
 `;
 
-const Headline = styled(Box)`
+const Headline = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.display1')};
   text-align: center;
@@ -41,12 +42,14 @@ const ButtonWrapper = styled(Box)`
   grid-gap: 24px;
 `;
 
-const LinkButton = Button.withComponent(StyledRouterLinkBase);
-const StyledLinkButton = styled(LinkButton)`
+// tslint:disable-next-line: no-any
+const LinkButton = Button.withComponent<any>(StyledRouterLinkBase);
+const StyledLinkButton = styled(LinkButton)<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
 `;
 
-const StyledLink = styled(StyledRouterLinkBase)`
+// tslint:disable-next-line: no-any
+const StyledLink = styled(StyledRouterLinkBase)<any>`
   ${prop('theme.fontStyles.subheading')};
   color: ${prop('theme.accent')};
 
@@ -60,7 +63,7 @@ const CenterContentWrapper = styled(ContentWrapperBase)`
   justify-content: center;
 `;
 
-const ProofsWrapper = styled(Box)`
+const ProofsWrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
   padding-top: 64px;
@@ -73,7 +76,7 @@ const ProofsWrapper = styled(Box)`
   }
 `;
 
-const ProofsInnerWrapper = styled(Box)`
+const ProofsInnerWrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: column;
 
@@ -83,7 +86,7 @@ const ProofsInnerWrapper = styled(Box)`
   }
 `;
 
-const FeaturesWrapper = styled(Box)`
+const FeaturesWrapper = styled(Box)<{}, {}>`
   display: grid;
   padding-top: 64px;
   padding-bottom: 64px;

--- a/packages/neo-one-website/src/components/home/Proof.tsx
+++ b/packages/neo-one-website/src/components/home/Proof.tsx
@@ -3,7 +3,7 @@ import { Box } from '@neo-one/react-common';
 import * as React from 'react';
 import { prop } from 'styled-tools';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   margin-left: 8px;
   margin-right: 24px;
@@ -17,14 +17,14 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const Title = styled.h2`
+const Title = styled.h2<{}, {}>`
   ${prop('theme.fonts.axiformaThin')};
   ${prop('theme.fontStyles.headline')};
   color: ${prop('theme.gray5')};
   margin: 0;
 `;
 
-const Line = styled.p`
+const Line = styled.p<{}, {}>`
   ${prop('theme.fonts.axiformaRegular')};
   ${prop('theme.fontStyles.subheading')};
   color: ${prop('theme.black')};

--- a/packages/neo-one-website/src/components/reference/ReferenceLink.tsx
+++ b/packages/neo-one-website/src/components/reference/ReferenceLink.tsx
@@ -12,7 +12,8 @@ interface Props {
   readonly type: ReferenceType;
 }
 
-const StyledLink = styled(StyledRouterLink)`
+// tslint:disable-next-line: no-any
+const StyledLink = styled(StyledRouterLink)<any>`
   ${prop('theme.fontStyles.subheading')};
   ${prop('theme.fonts.axiformaRegular')};
 `;

--- a/packages/neo-one-website/src/components/reference/TypeFilterOption.tsx
+++ b/packages/neo-one-website/src/components/reference/TypeFilterOption.tsx
@@ -9,7 +9,7 @@ interface Props {
   readonly type: TypeFilterOptions;
 }
 
-const StyledBox = styled(Box)`
+const StyledBox = styled(Box)<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
   ${prop('theme.fonts.axiformaRegular')};
 `;

--- a/packages/neo-one-website/src/components/reference/common/Example.tsx
+++ b/packages/neo-one-website/src/components/reference/common/Example.tsx
@@ -10,7 +10,7 @@ interface Props {
   readonly className?: string;
 }
 
-const PreWrapper = styled(Box.withComponent('pre'))`
+const PreWrapper = styled(Box.withComponent('pre'))<{}, {}>`
   background-color: ${prop('theme.gray6')};
   ${prop('theme.fontStyles.subheading')};
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
@@ -18,7 +18,7 @@ const PreWrapper = styled(Box.withComponent('pre'))`
   border-radius: 4px;
 `;
 
-const CodeWrapper = styled(Box.withComponent('code'))`
+const CodeWrapper = styled(Box.withComponent('code'))<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 `;

--- a/packages/neo-one-website/src/components/reference/common/Text.tsx
+++ b/packages/neo-one-website/src/components/reference/common/Text.tsx
@@ -5,7 +5,7 @@ import { prop } from 'styled-tools';
 import { WordTokens } from '../types';
 import { buildText } from './utils';
 
-export const StyledText = styled(Box)`
+export const StyledText = styled(Box)<{}, {}>`
   ${prop('theme.fontStyles.subheading')};
   ${prop('theme.fonts.axiformaRegular')};
 `;

--- a/packages/neo-one-website/src/components/reference/common/TextSection.tsx
+++ b/packages/neo-one-website/src/components/reference/common/TextSection.tsx
@@ -6,7 +6,7 @@ import { WordTokens } from '../types';
 import { Text } from './Text';
 import { Title } from './Title';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;

--- a/packages/neo-one-website/src/components/reference/common/Title.tsx
+++ b/packages/neo-one-website/src/components/reference/common/Title.tsx
@@ -2,7 +2,7 @@
 import styled from '@emotion/styled';
 import { H2, ifProp, prop } from '@neo-one/react-common';
 
-export const Title = styled(H2)<{ readonly subheading?: boolean }>`
+export const Title = styled(H2)<{ readonly subheading?: boolean }, { readonly subheading?: boolean }>`
   ${prop('theme.fonts.axiformaBold')};
   ${ifProp('subheading', prop('theme.fontStyles.headline'), prop('theme.fontStyles.display1'))};
 `;

--- a/packages/neo-one-website/src/components/reference/common/TypeIcon.tsx
+++ b/packages/neo-one-website/src/components/reference/common/TypeIcon.tsx
@@ -10,12 +10,14 @@ interface Props {
   readonly fullIcon?: boolean;
 }
 
+// tslint:disable-next-line: no-unused
 interface StyledIconBoxProps {
   readonly bg: TypeFilterOptions;
   readonly fullIcon: boolean;
 }
 
-const IconBox = styled<typeof Box, StyledIconBoxProps>(Box)`
+// tslint:disable-next-line: no-any
+const IconBox = styled(Box)<any>`
   background-color: ${switchProp('bg', {
     All: 'transparent',
     Class: prop('theme.primary'),

--- a/packages/neo-one-website/src/components/reference/common/utils.tsx
+++ b/packages/neo-one-website/src/components/reference/common/utils.tsx
@@ -12,7 +12,8 @@ const checkPunctuation = (idx: number, example: WordTokens, value: string) =>
     ? `${value}`
     : `${value} `;
 
-const StyledReferenceLink = styled<typeof StyledRouterLink, { readonly code?: boolean }>(StyledRouterLink)`
+// tslint:disable-next-line: no-any
+const StyledReferenceLink = styled(StyledRouterLink)<any>`
   font-family: ${ifProp('code', "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace")};
   ${prop('theme.fontStyles.subheading')};
 `;

--- a/packages/neo-one-website/src/components/reference/components/Extra.tsx
+++ b/packages/neo-one-website/src/components/reference/components/Extra.tsx
@@ -6,7 +6,7 @@ import { prop } from 'styled-tools';
 import { Example, Text, Title } from '../common';
 import { ExtraData } from '../types';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;

--- a/packages/neo-one-website/src/components/reference/components/InterfaceClassItems.tsx
+++ b/packages/neo-one-website/src/components/reference/components/InterfaceClassItems.tsx
@@ -14,7 +14,7 @@ export interface Props {
   readonly data: ClassData | InterfaceData;
 }
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 40px;

--- a/packages/neo-one-website/src/components/reference/components/MethodItem.tsx
+++ b/packages/neo-one-website/src/components/reference/components/MethodItem.tsx
@@ -12,7 +12,7 @@ export interface Props {
   readonly method: Method;
 }
 
-const Layout = styled(Box)`
+const Layout = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 16px;
@@ -24,7 +24,7 @@ const Layout = styled(Box)`
   }
 `;
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 16px;
@@ -35,7 +35,7 @@ const Wrapper = styled(Box)`
   }
 `;
 
-const StyledTitle = styled(Title)`
+const StyledTitle = styled(Title)<{}, {}>`
   background-color: ${prop('theme.gray1')};
   padding: 16px 32px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.3);

--- a/packages/neo-one-website/src/components/reference/components/MethodList.tsx
+++ b/packages/neo-one-website/src/components/reference/components/MethodList.tsx
@@ -6,7 +6,7 @@ import { Title } from '../common';
 import { Method } from '../types';
 import { MethodItem } from './MethodItem';
 
-const ParameterLayout = styled(Box)`
+const ParameterLayout = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;

--- a/packages/neo-one-website/src/components/reference/components/ParameterPropertyItem.tsx
+++ b/packages/neo-one-website/src/components/reference/components/ParameterPropertyItem.tsx
@@ -16,7 +16,7 @@ const ParameterLayout = styled(Box)`
   border-bottom: 1px solid rgba(0, 0, 0, 0.3);
 `;
 
-const Name = styled(Box)`
+const Name = styled(Box)<{}, {}>`
   ${prop('theme.fonts.axiformaBold')};
   ${prop('theme.fontStyles.body1')};
 `;

--- a/packages/neo-one-website/src/components/reference/components/ParameterPropertyList.tsx
+++ b/packages/neo-one-website/src/components/reference/components/ParameterPropertyList.tsx
@@ -6,7 +6,7 @@ import { Title } from '../common';
 import { Parameter, Property } from '../types';
 import { ParameterPropertyItem } from './ParameterPropertyItem';
 
-const ParameterLayout = styled(Box)`
+const ParameterLayout = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;

--- a/packages/neo-one-website/src/components/reference/components/ParameterReturns.tsx
+++ b/packages/neo-one-website/src/components/reference/components/ParameterReturns.tsx
@@ -13,7 +13,7 @@ export interface Props {
   readonly subheading?: boolean;
 }
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-auto-flow: row;
   grid-gap: 32px;

--- a/packages/neo-one-website/src/components/reference/components/ReferenceHeader.tsx
+++ b/packages/neo-one-website/src/components/reference/components/ReferenceHeader.tsx
@@ -11,7 +11,7 @@ interface Props {
   readonly definition: WordTokens;
 }
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   display: grid;
   grid-gap: 16px;
 

--- a/packages/neo-one-website/src/components/reference/components/ReferencePage.tsx
+++ b/packages/neo-one-website/src/components/reference/components/ReferencePage.tsx
@@ -14,7 +14,7 @@ export interface Props {
   readonly content: ReferenceItem;
 }
 
-const PageLayout = styled(Box)`
+const PageLayout = styled(Box)<{}, {}>`
   display: grid;
   grid-gap: 32px;
 

--- a/packages/neo-one-website/src/layout/CoreLayout.tsx
+++ b/packages/neo-one-website/src/layout/CoreLayout.tsx
@@ -19,7 +19,7 @@ const StyledHeadroom = styled(Headroom)`
   z-index: 9999;
 `;
 
-const Content = styled(Box)`
+const Content = styled(Box)<{}, {}>`
   width: 100%;
   background-color: ${prop('theme.gray0')};
 `;

--- a/packages/neo-one-website/src/layout/CourseLayout.tsx
+++ b/packages/neo-one-website/src/layout/CourseLayout.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { prop } from 'styled-tools';
 import { CourseHeader } from '../components';
 
-const Wrapper = styled(Box)`
+const Wrapper = styled(Box)<{}, {}>`
   &&& {
     display: flex;
     flex-direction: column;

--- a/packages/neo-one-website/src/loaders/coursesLoader.ts
+++ b/packages/neo-one-website/src/loaders/coursesLoader.ts
@@ -56,7 +56,7 @@ const getCourse = async (courseDir: string): Promise<Course> => {
   const [config, lessonDirs] = await Promise.all([
     fs.readFile(path.resolve(coursePath, CONFIG), 'utf8'),
     getDirectories(coursePath),
-  ]);
+  ] as const);
   const lessons = await Promise.all(lessonDirs.map(async (dir) => getLesson(courseDir, dir)));
 
   const configParsed = JSON.parse(config);
@@ -75,7 +75,7 @@ const getLesson = async (courseDir: string, lesson: string): Promise<Lesson> => 
     fs.readFile(path.resolve(lessonPath, CONFIG), 'utf8'),
     fs.readFile(path.resolve(lessonPath, LESSON), 'utf8'),
     getDirectories(lessonPath),
-  ]);
+  ] as const);
   const chapters = await Promise.all(chapterDirs.map(async (dir) => getChapter(courseDir, lesson, dir)));
 
   return {
@@ -128,7 +128,7 @@ const getChapterFile = async (dir: string, initial: string | undefined, solution
   const [initialContent, solutionContent] = await Promise.all([
     initial === undefined ? Promise.resolve(undefined) : readFile(initial),
     readFile(solution),
-  ]);
+  ] as const);
 
   return {
     path: initial === undefined ? solution : initial,

--- a/packages/neo-one-website/src/utils/getDocs.ts
+++ b/packages/neo-one-website/src/utils/getDocs.ts
@@ -33,7 +33,7 @@ export const getDocs = async (): Promise<readonly DocsProps[]> => {
   const [docFileLists, docSectionConfigs] = await Promise.all([
     Promise.all(docSections.map(getDocSection)),
     getDocSectionConfigs(docSections),
-  ]);
+  ] as const);
   const docsBare = _.flatten(docFileLists);
   const docs = addAdjacent(docsBare);
 


### PR DESCRIPTION
### Description of the Change

Upgrades TS to v3.8.1-rc. Makes a few changes to make TS v3.8.1-rc compatible with our stuff. Additions to our compiler for supporting new language features will come in another PR.

I split this into two commits for a good reason. The TS upgrade apparently wreaks havoc on the types for `@emotion`, which is used all throughout these packages: `neo-one-developer-tools-frame`, `neo-one-editor`, `neo-one-react-core`, `neo-one-react-common`, and `neo-one-website`. This forced me to go through and change A LOT of generics, many of which I seemingly couldn't do anything besides pass in an `any` type. It looks like this problem has been recognized and fixed in the `@emotion` GitHub. See [here](https://github.com/emotion-js/emotion/pull/1501). But it looks like that won't be deployed until the release of Emotion v11. See [here](https://github.com/emotion-js/emotion/milestone/1). So ideally they release that fix in the near future, then we can upgrade, then easily revert all these weird generics/`any` types and add back the lost type-safety in these packages using `git revert`

### Test Plan
- `rush test`
- `rush e2e`

### Alternate Designs

As a note, there was a breaking change in their code that caused us to have to change some code in `symbol.ts -> getAliasedSymbol()`. It's very difficult to tell where their changed happened that caused this breaking change, as they don't mention anything related to it, and none of the related `TypeChecker` methods or `Type` properties changed. I believe it's the original construction of the `aliasSymbol` property that caused this breaking change for us. See the commit [here](https://github.com/microsoft/TypeScript/commit/fd8f9904490ec7cf93e1010604e7a4bec2a56756). Mostly just for future note.

### Benefits

- We get to use the latest TS features in our own code from here on.

### Possible Drawbacks

- Prettier doesn't support TS v3.8 yet. They have an issue open for this [here](https://github.com/prettier/prettier/issues/7263). They are waiting for TS 3.8 support in `typescript-eslint` fo the new AST [here](https://github.com/typescript-eslint/typescript-eslint/pull/1465). It only affects one place in our code, so I think it's easy to ignore for now.
- Possibly unforeseen errors

### Applicable Issues

#1889 
