### PR TITLE
feat(ts): add TS v3.7/3.8 language features

### DIFF
--- a/common/changes/@neo-one/smart-contract-compiler/new-ts_2020-02-27-21-52.json
+++ b/common/changes/@neo-one/smart-contract-compiler/new-ts_2020-02-27-21-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@neo-one/smart-contract-compiler",
-      "comment": "Upgrade TS to v3.8.1-rc. Add support for Nullish Coalescing.",
+      "comment": "Add support for new language features in TS v3.7, v3.8",
       "type": "minor"
     }
   ],

--- a/common/changes/@neo-one/typescript-concatenator/new-ts_2020-02-27-21-52.json
+++ b/common/changes/@neo-one/typescript-concatenator/new-ts_2020-02-27-21-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@neo-one/typescript-concatenator",
-      "comment": "Upgrade TS to v3.8.1-rc. Add support for namespace exports.",
+      "comment": "Add support for new language features in TS v3.7, v3.8",
       "type": "minor"
     }
   ],

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/TypeAliasDeclarationCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/TypeAliasDeclarationCompiler.test.ts
@@ -14,4 +14,26 @@ describe('TypeAliasDeclarationCompiler', () => {
       }
     `);
   });
+
+  test('recursive type alias does not emit', async () => {
+    await helpers.executeString(`
+      type Json =
+        | string
+        | number
+        | boolean
+        | null
+        | { [property: string]: Json }
+        | Json[];
+
+      type VirtualNode =
+        | string
+        | [string, { [key: string]: any }, ...VirtualNode[]];
+
+      const myNode: VirtualNode =
+        ["div", { id: "parent" },
+          ["div", { id: "first-child" }, "I'm the first child"],
+          ["div", { id: "second-child" }, "I'm the second child"]
+        ];
+    `);
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/__snapshots__/ClassDeclarationCompiler.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/__snapshots__/ClassDeclarationCompiler.test.ts.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ClassDeclarationCompiler ECMAScript private member, no private modifier allowed 1`] = `
+"snippetCode.ts (3,9): An accessibility modifier cannot be used with a private identifier.
+
+      1 | 
+      2 |       class Foo {
+    > 3 |         private #x: string = 'bar';
+        |         ^
+      4 |       }
+      5 |     
+"
+`;
+
+exports[`ClassDeclarationCompiler ECMAScript private member, no public modifier allowed 1`] = `
+"snippetCode.ts (3,9): An accessibility modifier cannot be used with a private identifier.
+
+      1 | 
+      2 |       class Foo {
+    > 3 |         public #x: string = 'bar';
+        |         ^
+      4 |       }
+      5 |     
+"
+`;
+
+exports[`ClassDeclarationCompiler basic class with ECMAScript private member, inaccessible 1`] = `
+"snippetCode.ts (11,9): Property '#x' is not accessible outside class 'Foo' because it has a private identifier.
+
+       9 | 
+      10 |       const f = new Foo();
+    > 11 |       f.#x;
+         |         ^
+      12 |     
+"
+`;
+
 exports[`ClassDeclarationCompiler decorators 1`] = `
 "snippetCode.ts (7,9): Custom decorators are not supported
 

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/AwaitExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/AwaitExpressionCompiler.test.ts
@@ -9,4 +9,15 @@ describe('AwaitFunctionCompiler', () => {
       { type: 'error' },
     );
   });
+
+  test('await', async () => {
+    helpers.compileString(
+      `
+      await 2;
+
+      export {};
+    `,
+      { type: 'error' },
+    );
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/CallExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/CallExpressionCompiler.test.ts
@@ -79,6 +79,21 @@ describe('CallExpressionCompiler', () => {
     `);
   });
 
+  test('nested property call', async () => {
+    await helpers.executeString(`
+      const foo = {
+        x: 1,
+        y: {
+          z(): number {
+            return 13;
+          }
+        }
+      };
+
+      assertEqual(foo.y.z(), 13);
+    `);
+  });
+
   test('method call', async () => {
     await helpers.executeString(`
       class Foo {
@@ -263,5 +278,239 @@ describe('CallExpressionCompiler', () => {
 
       assertEqual(x[Symbol.iterator]() !== undefined, true);
     `);
+  });
+
+  test('optional chain - element access with symbol - undefined', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: undefined } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with symbol - null', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: null } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with symbol - defined', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: () => 10 } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), 10);
+      `);
+  });
+
+  test('optional chain - element access with symbol - nested undefined', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const baz = Symbol.for('world');
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: undefined } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with symbol - nested null', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const baz = Symbol.for('world');
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: null } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with symbol - nested defined', async () => {
+    await helpers.executeString(`
+        const foo = Symbol.for('hello');
+        const baz = Symbol.for('world');
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: () => 10 } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), 10);
+      `);
+  });
+
+  test('optional chain - element access with number - undefined', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: undefined } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with number - null', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: null } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with number - defined', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const bar: { [foo]: (() => number) | null | undefined } = { [foo]: () => 10 } as unknown as { [foo]: (() => number) | null | undefined };
+
+        assertEqual(bar[foo]?.(), 10);
+      `);
+  });
+
+  test('optional chain - element access with number - nested undefined', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const baz = 2;
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: undefined } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with number - nested null', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const baz = 2;
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: null } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with number - nested defined', async () => {
+    await helpers.executeString(`
+        const foo = 0;
+        const baz = 2;
+        const bar: { [foo]: { [baz]: (() => number) | null | undefined } } = { [foo]: { [baz]: () => 10 } } as unknown as { [foo]: { [baz]: (() => number) | null | undefined } };
+
+        assertEqual(bar[foo][baz]?.(), 10);
+      `);
+  });
+
+  test('optional chain - element access with string - undefined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: undefined } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar['foo']?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with string - null', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: null } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar['foo']?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with string - defined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: () => 10 } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar['foo']?.(), 10);
+      `);
+  });
+
+  test('optional chain - element access with string - nested undefined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: undefined } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar['foo']['baz']?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with string - nested null', async () => {
+    await helpers.executeString(`
+    const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: null } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar['foo']['baz']?.(), undefined);
+      `);
+  });
+
+  test('optional chain - element access with string - nested defined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: () => 10 } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar['foo']['baz']?.(), 10);
+      `);
+  });
+
+  test('optional chain - call expression - undefined', async () => {
+    await helpers.executeString(`
+        const bar: (() => number) | null | undefined = null as unknown as (() => number) | null | undefined;
+
+        assertEqual(bar?.(), undefined);
+      `);
+  });
+
+  test('optional chain - call expression - null', async () => {
+    await helpers.executeString(`
+        const bar: (() => number) | null | undefined = undefined as unknown as (() => number) | null | undefined;
+
+        assertEqual(bar?.(), undefined);
+      `);
+  });
+
+  test('optional chain - call expression - defined', async () => {
+    await helpers.executeString(`
+        const bar: (() => number) | null | undefined = (() => 10) as unknown as (() => number) | null | undefined;
+
+        assertEqual(bar?.(), 10);
+      `);
+  });
+
+  test('optional chain - property access - nested undefined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: undefined } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar.foo?.(), undefined);
+      `);
+  });
+
+  test('optional chain - property access - nested null', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: null } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar.foo?.(), undefined);
+      `);
+  });
+
+  test('optional chain - property access - nested defined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: (() => number) | null | undefined } = { foo: () => 10 } as unknown as { foo: (() => number) | null | undefined };
+
+        assertEqual(bar.foo?.(), 10);
+      `);
+  });
+
+  test('optional chain - property access - double nested undefined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: undefined } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar.foo.baz?.(), undefined);
+      `);
+  });
+
+  test('optional chain - property access - double nested null', async () => {
+    await helpers.executeString(`
+    const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: null } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar.foo.baz?.(), undefined);
+      `);
+  });
+
+  test('optional chain - property access - double nested defined', async () => {
+    await helpers.executeString(`
+        const bar: { foo: { baz: (() => number) | null | undefined } } = { foo: { baz: () => 10 } } as unknown as { foo: { baz: (() => number) | null | undefined } };
+
+        assertEqual(bar.foo.baz?.(), 10);
+      `);
   });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ElementAccessExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ElementAccessExpressionCompiler.test.ts
@@ -146,4 +146,28 @@ describe('ElementAccessExpressionCompiler', () => {
       { type: 'error' },
     );
   });
+
+  test('optional element access returns undefined when undefined', async () => {
+    await helpers.executeString(`
+          const bar: { optionalProp: number } | null | undefined = null as { optionalProp: number } | null | undefined;
+
+          assertEqual(bar?.['optionalProp'], undefined);
+        `);
+  });
+
+  test('optional element access returns undefined when null', async () => {
+    await helpers.executeString(`
+          const bar: { optionalProp: number } | null | undefined = undefined as { optionalProp: number } | null | undefined;
+
+          assertEqual(bar?.['optionalProp'], undefined);
+        `);
+  });
+
+  test('optional element access returns property when defined', async () => {
+    await helpers.executeString(`
+          const bar: { optionalProp: number } | null | undefined = { optionalProp: 10 } as { optionalProp: number } | null | undefined;
+
+          assertEqual(bar?.['optionalProp'], 10);
+        `);
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ObjectLiteralExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ObjectLiteralExpressionCompiler.test.ts
@@ -116,4 +116,19 @@ describe('ObjectLiteralExpressionCompiler', () => {
       assertEqual(x.f, 4);
     `);
   });
+
+  test('private field identifier fails outside class', async () => {
+    helpers.compileString(
+      `
+      const y = {
+        a: 0,
+        #b: 10,
+        get f(): number {
+          return 4;
+        },
+      };
+    `,
+      { type: 'error' },
+    );
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PropertyAccessExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PropertyAccessExpressionCompiler.test.ts
@@ -37,4 +37,52 @@ describe('PropertyAccessExpressionCompiler', () => {
       assertEqual(bar.length, 3);
     `);
   });
+
+  test('optional chaining returns undefined when undefined', async () => {
+    await helpers.executeString(`
+      const bar: { optionalProp: number } | null | undefined = null as { optionalProp: number } | null | undefined;
+
+      assertEqual(bar?.optionalProp, undefined);
+    `);
+  });
+
+  test('optional chaining returns undefined when null', async () => {
+    await helpers.executeString(`
+      const bar: { optionalProp: number } | null | undefined = undefined as { optionalProp: number } | null | undefined;
+
+      assertEqual(bar?.optionalProp, undefined);
+    `);
+  });
+
+  test('optional chaining returns property when defined', async () => {
+    await helpers.executeString(`
+      const bar: { optionalProp: number } | null | undefined = { optionalProp: 10 } as { optionalProp: number } | null | undefined;
+
+      assertEqual(bar?.optionalProp, 10);
+    `);
+  });
+
+  test('nested optional chaining returns undefined when null', async () => {
+    await helpers.executeString(`
+      const bar: { first?: { second?: number } | null } | null | undefined = { first: null } as { first?: { second?: number } | null } | null | undefined;
+
+      assertEqual(bar?.first?.second, undefined);
+    `);
+  });
+
+  test('nested optional chaining returns undefined when undefined', async () => {
+    await helpers.executeString(`
+      const bar: { first?: { second?: number } | null } | null | undefined = { first: undefined } as { first?: { second: number } | null } | null | undefined;
+
+      assertEqual(bar?.first?.second, undefined);
+    `);
+  });
+
+  test('nested optional chaining returns property when defined', async () => {
+    await helpers.executeString(`
+      const bar: { first?: { second?: number } } | null | undefined = { first: { second: 10 } } as { first?: { second: number } } | null | undefined;
+
+      assertEqual(bar?.first?.second, 10);
+    `);
+  });
 });

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/AwaitExpressionCompiler.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/AwaitExpressionCompiler.test.ts.snap
@@ -9,3 +9,15 @@ exports[`AwaitFunctionCompiler await 1`] = `
       3 |     
 "
 `;
+
+exports[`AwaitFunctionCompiler await 2`] = `
+"snippetCode.ts (2,7): Unsupported syntax.
+
+      1 | 
+    > 2 |       await 2;
+        |       ^
+      3 | 
+      4 |       export {};
+      5 |     
+"
+`;

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/ObjectLiteralExpressionCompiler.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/__snapshots__/ObjectLiteralExpressionCompiler.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ObjectLiteralExpressionCompiler private field identifier fails outside class 1`] = `
+"snippetCode.ts (4,9): Private identifiers are not allowed outside class bodies.
+
+      2 |       const y = {
+      3 |         a: 0,
+    > 4 |         #b: 10,
+        |         ^
+      5 |         get f(): number {
+      6 |           return 4;
+      7 |         },
+"
+`;

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
@@ -3,6 +3,7 @@ import * as bar from './bar';
 import baz from './baz';
 import { foo } from './foo';
 import { Address, foo as foo2, Foo2SmartContract, SmartContract } from './foo2';
+import type { MyType } from './onlyTypes'
 import incrementValue, { value } from './qux';
 import { FooType } from './type';
 
@@ -83,3 +84,5 @@ export { fizz } from './varDecl';
 // Namespace export
 export * as foo5 from './foo5';
 export * as somethingElse from './foo5';
+// Type-only export
+export type { MyType };

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/onlyTypes.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/onlyTypes.ts
@@ -1,0 +1,3 @@
+type MyType = string;
+// tslint:disable-next-line: export-name
+export type { MyType };

--- a/packages/neo-one-typescript-concatenator/src/__tests__/__snapshots__/concatenate.test.ts.snap
+++ b/packages/neo-one-typescript-concatenator/src/__tests__/__snapshots__/concatenate.test.ts.snap
@@ -22,21 +22,22 @@ class FooType {
 const fooType = 'fooType';
 // tslint:disable-next-line no-let
 let valc1 = 0;
-function value44() {
+function value48() {
     return valc1;
 }
-function default41() {
+function default45() {
     valc1 += 1;
 }
-const default33 = 'baz';
+type MyType = string;
+const default35 = 'baz';
 // tslint:disable-next-line no-let
 let valc2 = 0;
 const x = 3;
-const value48 = () => valc2;
+const value52 = () => valc2;
 const incrementValue = () => {
     valc2 += 1;
 };
-const bar = { value: value48, incrementValue: incrementValue, x: x };
+const bar = { value: value52, incrementValue: incrementValue, x: x };
 if (foo !== 'foo') {
     throw 'Failure';
 }
@@ -50,17 +51,17 @@ bar.incrementValue();
 if (bar.value() !== 1) {
     throw 'Failure';
 }
-if (value44() !== 0) {
+if (value48() !== 0) {
     throw 'Failure';
 }
-default41();
-if (value44() !== 1) {
+default45();
+if (value48() !== 1) {
     throw 'Failure';
 }
 if (bar.x !== 3) {
     throw 'Failure';
 }
-if (default33 !== 'baz') {
+if (default35 !== 'baz') {
     throw 'Failure';
 }
 // tslint:disable-next-line export-name
@@ -81,13 +82,14 @@ export { fooSC as fooSC };
 export { fooSC as barSC };
 export { bar };
 export { bar as bar2 };
-export { default33 as baz };
-export { default33 as baz2 };
+export { default35 as baz };
+export { default35 as baz2 };
 export { FooType as FooType, fooType as fooType };
 export { Address as Address, foo as foo, SmartContract as SmartContract };
 export { SmartContract as SmartContract2Level, default11 as FooSmartContract2Level, foo as foo2level, Address as Address2Level };
 export { fizz as fizz };
 export const foo5 = { one: one, two: two, func: func };
 export const somethingElse = { one: one, two: two, func: func };
+export { MyType as MyType };
 "
 `;


### PR DESCRIPTION
### Description of the Change

Upgrades Smart-Contract compiler to support new TS language features:

Features from TS v3.7:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html
- [x] Optional Chaining
- [x] Nullish Coalescing
  - Added in previous TS PR
- [x] Assertion Functions
  - Not supported
- [x] `never`-Returning Functions
  - No change needed
- [x] Recursive Type Aliases
- [x] Uncalled Function Checks
  - Should be supported in VS Code without change from us

Features from TS v3.8.1-rc:
https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-rc/
- [x] Type-Only Imports and Exports
- [x] ECMAScript Private Fields
- [x] `export * as ns` Syntax
  - Added in previous TS PR
- [x] Top-Level `await`
  - Not supported

### Test Plan

- All Unit Tests
  - `rush test`
  - `rush e2e`
- Optional Chaining
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/CallExpressionCompiler.test.ts`
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ElementAccessExpressionCompiler.test.ts`
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/PropertyAccessExpressionCompiler.test.ts`
- Nullish Coalescing
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ToNullishBooleanHelper.test.ts`
- Recursive Type Aliases
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/TypeAliasDeclarationCompiler.test.ts`
- Type-Only Imports and Exports
  - `rush test -t packages/neo-one-typescript-concatenator/src/__tests__/concatenate.test.ts`
- ECMAScript Private Fields
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/declaration/ClassDeclarationCompiler.test.ts`
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ObjectLiteralExpressionCompiler.test.ts`
- `export * as ns` Syntax
  - `rush test -t packages/neo-one-typescript-concatenator/src/__tests__/concatenate.test.ts`
- Top-Level `await`
  - `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compiler/expression/AwaitExpressionCompiler.test.ts`

### Alternate Designs

None.

### Benefits

- We support the latest language features for writing Smart Contracts in TS.

### Possible Drawbacks

- Prettier doesn't support some TS v3.8 syntax yet, so all Prettier checks will fail on the `neo-one-typescript-concatenator` package until they/we update Prettier. They have an issue open for this [here](https://github.com/prettier/prettier/issues/7263). They are waiting for TS 3.8 support in `typescript-eslint` for the new AST [here](https://github.com/typescript-eslint/typescript-eslint/pull/1465). This is easy to ignore for now.
- Possibly unforeseen problems.

### Applicable Issues

#1889 
