### PR TITLE
feat(NEOONEDataProvider 3.0): Convert NEOONEDataProvider to work with 3.0 + official node

### DIFF
--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -1,10 +1,8 @@
-import { AssetTypeModel } from './AssetTypeModel';
 import { ContractParameterTypeModel } from './ContractParameterTypeModel';
 import { RelayResultReasonModel } from './RelayResultReasonModel';
 import { StateDescriptorTypeModel } from './StateDescriptorTypeModel';
 import { StorageFlagsModel } from './StorageFlagsModel';
 import { AttributeUsageModel } from './transaction';
-import { VMState } from './vm';
 import { WitnessScopeModel } from './WitnessScopeModel';
 
 export interface ContractParameterDeclarationJSON {
@@ -174,16 +172,16 @@ export type AttributeUsageJSON = keyof typeof AttributeUsageModel;
 
 export type RelayResultReasonJSON = keyof typeof RelayResultReasonModel;
 
-export interface InvocationDataJSON {
-  readonly result: InvocationResultJSON;
-  readonly asset?: AssetJSON;
-  readonly contracts: readonly ContractJSON[];
-  readonly deletedContractHashes: readonly string[];
-  readonly migratedContractHashes: ReadonlyArray<readonly [string, string]>;
-  readonly voteUpdates: ReadonlyArray<readonly [string, ReadonlyArray<string>]>;
-  readonly actions: readonly ActionJSON[];
-  readonly storageChanges: readonly StorageChangeJSON[];
-}
+// export interface InvocationDataJSON {
+//   readonly result: InvocationResultJSON;
+//   readonly asset?: AssetJSON;
+//   readonly contracts: readonly ContractJSON[];
+//   readonly deletedContractHashes: readonly string[];
+//   readonly migratedContractHashes: ReadonlyArray<readonly [string, string]>;
+//   readonly voteUpdates: ReadonlyArray<readonly [string, ReadonlyArray<string>]>;
+//   readonly actions: readonly ActionJSON[];
+//   readonly storageChanges: readonly StorageChangeJSON[];
+// }
 
 export interface TransactionJSON {
   readonly hash: string;
@@ -219,6 +217,8 @@ export interface TransactionReceiptJSON {
 
 export interface ConfirmedTransactionJSON extends TransactionJSON, TransactionReceiptJSON {}
 
+export type WildcardContainerJSON<T> = readonly T[] | '*';
+
 export interface ContractMethodDescriptorJSON {
   readonly name: string;
   readonly parameters: readonly ContractParameterDeclarationJSON[];
@@ -242,19 +242,19 @@ export interface ContractGroupJSON {
   readonly signature: string;
 }
 
-export type ContractPermissionDescriptorJSON = string | undefined;
+export type ContractPermissionDescriptorJSON = string | '*';
 
 export interface ContractPermissionsJSON {
   readonly contract: ContractPermissionDescriptorJSON;
-  readonly methods: readonly string[];
+  readonly methods: WildcardContainerJSON<string>;
 }
 
 export interface ContractManifestJSON {
   readonly abi: ContractAbiJSON;
   readonly groups: readonly ContractGroupJSON[];
   readonly permissions: readonly ContractPermissionsJSON[];
-  readonly trusts: readonly string[];
-  readonly safeMethods: readonly string[];
+  readonly trusts: WildcardContainerJSON<string>;
+  readonly safeMethods: WildcardContainerJSON<string>;
   readonly features: {
     readonly storage: boolean;
     readonly payable: boolean;
@@ -289,7 +289,7 @@ export interface ConsensusDataJSON {
 export interface HeaderJSON extends BlockBaseJSON {}
 
 export interface BlockJSON extends BlockBaseJSON {
-  readonly tx: readonly TransactionJSON[];
+  readonly tx: readonly ConfirmedTransactionJSON[];
   readonly consensus_data: ConsensusDataJSON;
 }
 

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -322,7 +322,7 @@ export interface Header {
   /**
    * `Block` time persisted.
    */
-  readonly time: number;
+  readonly time: BigNumber;
   /**
    * `Block` index.
    */
@@ -355,7 +355,7 @@ export interface ConsensusData {
   /**
    * Unique number in order to ensure the hash for this `ConsensusData` is unique.
    */
-  readonly nonce: number;
+  readonly nonce: BufferString;
 }
 
 export interface Block extends Header {
@@ -1349,15 +1349,15 @@ export interface ContractMethodDescriptor {
   /**
    * Parameters of the function.
    */
-  readonly parameters: readonly ABIParameter[];
+  readonly parameters: readonly ContractParameterDeclaration[];
   /**
    * Return type of the function.
    */
-  readonly returnType: ABIReturn;
+  readonly returnType: ContractParameterType;
   /**
    * `true` if the function is constant or read-only.
    */
-  readonly constant?: boolean;
+  // readonly constant?: boolean;
 }
 
 /**
@@ -1371,7 +1371,7 @@ export interface ContractEvent {
   /**
    * Parameters of the event.
    */
-  readonly parameters: readonly ABIParameter[];
+  readonly parameters: readonly ContractParameterDeclaration[];
 }
 
 /**
@@ -1387,15 +1387,15 @@ export interface ContractAbi {
   /**
    * Entrypoint is an ABIFunction which describes the entrypoint of the contract.
    */
-  readonly entryPoint: ABIFunction;
+  readonly entryPoint: ContractMethodDescriptor;
   /**
    * Specification of the smart contract functions.
    */
-  readonly methods: readonly ABIFunction[];
+  readonly methods: readonly ContractMethodDescriptor[];
   /**
    * Specification of the smart contract events.
    */
-  readonly events?: readonly ABIEvent[];
+  readonly events: readonly ContractEvent[];
 }
 
 /**
@@ -1436,14 +1436,14 @@ export enum ContractFeatures {
 }
 
 export interface WildcardContainer<T> {
-  readonly data: readonly T[];
+  readonly data?: readonly T[];
 }
 
 export interface ContractPermissionDescriptor {
   readonly hashOrGroup: UInt160 | ECPoint | undefined;
-  readonly isHash: () => boolean;
-  readonly isGroup: () => boolean;
-  readonly isWildcard: () => boolean;
+  // readonly isHash: () => boolean;
+  // readonly isGroup: () => boolean;
+  // readonly isWildcard: () => boolean;
 }
 
 /**
@@ -1452,7 +1452,7 @@ export interface ContractPermissionDescriptor {
 export interface ContractPermissions {
   readonly contract: ContractPermissionDescriptor;
   readonly methods: WildcardContainer<string>;
-  readonly isAllowed: (manifest: ContractManifest, method: string) => boolean;
+  // readonly isAllowed: (manifest: ContractManifest, method: string) => boolean;
 }
 
 /**
@@ -1463,15 +1463,15 @@ export interface ContractManifest {
   /**
    * Max length for a valid Contract Manifest
    */
-  readonly maxLength: 2048;
-  /**
-   * Size of serialized contract
-   */
-  readonly size: () => number;
-  /**
-   * Contract hash
-   */
-  readonly hash: () => UInt160;
+  // readonly maxLength: 2048;
+  // /**
+  //  * Size of serialized contract
+  //  */
+  // readonly size: () => number;
+  // /**
+  //  * Contract hash
+  //  */
+  // readonly hash: () => UInt160;
   /**
    * Set of mutually trusted contracts
    */
@@ -1479,7 +1479,10 @@ export interface ContractManifest {
   /**
    * The features field describes what features are available for the contract.
    */
-  readonly features: ContractFeatures;
+  readonly features: {
+    readonly storage: boolean;
+    readonly payable: boolean;
+  };
   /**
    * Full specification of the functions and events of a smart contract. Used by the client APIs to generate the smart contract interface.
    */
@@ -1603,73 +1606,6 @@ export type Return =
   | ContractParameter;
 
 /**
- * Constants that describe the type of `Asset`.
- *
- * The two most important ones are `'Governing'` and `'Utility'` which are reserved for NEO and GAS respectively.
- */
-export type AssetType = 'Credit' | 'Duty' | 'Governing' | 'Utility' | 'Currency' | 'Share' | 'Invoice' | 'Token';
-
-/**
- * Attributes of a first class asset.
- *
- * Users will typically only interact with the NEO and GAS `Asset`s.
- *
- * @example
- *
- * const asset = readClient.getAsset(Hash256.NEO);
- * const neoAmount = asset.amount;
- *
- */
-export interface Asset {
-  /**
-   * `Hash256String` of this `Asset`.
-   */
-  readonly hash: Hash256String;
-  /**
-   * Type of the `Asset`
-   *
-   * @see AssetType
-   */
-  readonly type: AssetType;
-  /**
-   * User configurable name of the `Asset`
-   */
-  readonly name: string;
-  /**
-   * Total possible supply of the `Asset`
-   */
-  readonly amount: BigNumber;
-  /**
-   * Amount currently available of the `Asset`
-   */
-  readonly available: BigNumber;
-  /**
-   * Precision (number of decimal places) of the `Asset`
-   */
-  readonly precision: number;
-  /**
-   * Owner of the `Asset`.
-   */
-  readonly owner: PublicKeyString;
-  /**
-   * Admin of the `Asset`.
-   */
-  readonly admin: AddressString;
-  /**
-   * Issuer of the `Asset`.
-   */
-  readonly issuer: AddressString;
-  /**
-   * Unix timestamp of when the `Asset` must be renewed by or it expires.
-   */
-  readonly expiration: number;
-  /**
-   * `true` if no transfers are allowed with the `Asset`.
-   */
-  readonly frozen: boolean;
-}
-
-/**
  * Attributes of a deployed smart contract.
  */
 export interface Contract {
@@ -1689,13 +1625,18 @@ export interface Contract {
 
 /* BEGIN LOW-LEVEL API */
 
+export interface ContractParameterDeclaration {
+  readonly type: ContractParameter['type'];
+  readonly name: string;
+}
+
 /**
  * Invocation stack item for a `Signature`.
  *
  * @see ContractParameter
  * @see SignatureString
  */
-export interface SignatureContractParameter {
+export interface SignatureContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `SignatureContractParameter` from other `ContractParameter` object types.
    */
@@ -1711,7 +1652,7 @@ export interface SignatureContractParameter {
  *
  * @see ContractParameter
  */
-export interface BooleanContractParameter {
+export interface BooleanContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `BooleanContractParameter` from other `ContractParameter` object types.
    */
@@ -1730,7 +1671,7 @@ export interface BooleanContractParameter {
  *
  * @see ContractParameter
  */
-export interface IntegerContractParameter {
+export interface IntegerContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `IntegerContractParameter` from other `ContractParameter` object types.
    */
@@ -1747,7 +1688,7 @@ export interface IntegerContractParameter {
  * @see ContractParameter
  * @see AddressString
  */
-export interface AddressContractParameter {
+export interface AddressContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `AddressContractParameter` from other `ContractParameter` object types.
    */
@@ -1764,7 +1705,7 @@ export interface AddressContractParameter {
  * @see ContractParameter
  * @see UInt160
  */
-export interface Hash160ContractParameter {
+export interface Hash160ContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `Hash160ContractParameter` from other `ContractParameter` object types.
    */
@@ -1781,7 +1722,7 @@ export interface Hash160ContractParameter {
  * @see ContractParameter
  * @see Hash256String
  */
-export interface Hash256ContractParameter {
+export interface Hash256ContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `Hash256ContractParameter` from other `ContractParameter` object types.
    */
@@ -1798,7 +1739,7 @@ export interface Hash256ContractParameter {
  * @see ContractParameter
  * @see BufferString
  */
-export interface BufferContractParameter {
+export interface BufferContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `BufferContractParameter` from other `ContractParameter` object types.
    */
@@ -1815,7 +1756,7 @@ export interface BufferContractParameter {
  * @see ContractParameter
  * @see PublicKeyString
  */
-export interface PublicKeyContractParameter {
+export interface PublicKeyContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `PublicKeyContractParameter` from other `ContractParameter` object types.
    */
@@ -1831,7 +1772,7 @@ export interface PublicKeyContractParameter {
  *
  * @see ContractParameter
  */
-export interface StringContractParameter {
+export interface StringContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `StringContractParameter` from other `ContractParameter` object types.
    */
@@ -1847,7 +1788,7 @@ export interface StringContractParameter {
  *
  * @see ContractParameter
  */
-export interface ArrayContractParameter {
+export interface ArrayContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `ArrayContractParameter` from other `ContractParameter` object types.
    */
@@ -1863,7 +1804,7 @@ export interface ArrayContractParameter {
  *
  * @see ContractParameter
  */
-export interface MapContractParameter {
+export interface MapContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `MapContractParameter` from other `ContractParameter` object types.
    */
@@ -1881,7 +1822,7 @@ export interface MapContractParameter {
  *
  * @see ContractParameter
  */
-export interface InteropInterfaceContractParameter {
+export interface InteropInterfaceContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `InteropInterfaceContractParameter` from other `ContractParameter` object types.
    */
@@ -1893,7 +1834,7 @@ export interface InteropInterfaceContractParameter {
  *
  * @see ContractParameter
  */
-export interface VoidContractParameter {
+export interface VoidContractParameter extends ContractParameterDeclaration {
   /**
    * `type` distinguishes `VoidContractParameter` from other `ContractParameter` object types.
    */

--- a/packages/neo-one-client-core/src/__tests__/provider/__snapshots__/NEOONEDataProvider.test.ts.snap
+++ b/packages/neo-one-client-core/src/__tests__/provider/__snapshots__/NEOONEDataProvider.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`NEOONEDataProvider getInvocationData - missing transaction data 1`] = `[Error [MISSING_TRANSACTION_DATA]: Missing transaction data for transaction 0xb50034d97ba8c836758de1124b6c77d38bc772abc9a8f22c85e7389014e75234]`;

--- a/packages/neo-one-client-core/src/errors.ts
+++ b/packages/neo-one-client-core/src/errors.ts
@@ -130,6 +130,11 @@ export const NEOONEOneDataProviderSetRPCURLError = makeErrorWithCode(
   'INVALID_SET_RPC_URL_CALL',
   () => 'Cannot set rpcURL for NEOONEOneDataProvider',
 );
+export const InvalidContractPermissionDescriptorError = makeErrorWithCode(
+  'INVALID_CONTRACT_PERMISSION_DESCRIPTOR',
+  (permission: string) =>
+    `Invalid Contract Permission Descriptor. Must be a valid UInt160, ECPoint, or '*'. Instead found, ${permission}`,
+);
 export const InvalidHDAccountPermissionError = makeErrorWithCode(
   'INVALID_HD_ACCOUNT_PERMISSION',
   (account: readonly [number, number, number]) => `Invalid permission for account at path: ${account}`,

--- a/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
@@ -1,71 +1,29 @@
 /// <reference types="@reactivex/ix-es2015-cjs" />
 import {
-  Account,
-  AccountJSON,
   AddressString,
-  Asset,
-  AssetJSON,
-  AssetType,
-  AssetTypeJSON,
-  Attribute,
-  AttributeJSON,
   Block,
-  BlockJSON,
-  common,
+  BufferString,
   ConfirmedTransaction,
   Contract,
-  ContractJSON,
-  ContractParameterType,
-  ContractParameterTypeJSON,
-  DeveloperProvider,
+  ContractParameterJSON,
   GetOptions,
   Hash256String,
-  Input,
-  InputJSON,
-  InputOutput,
-  InvocationDataJSON,
-  InvocationTransactionJSON,
-  InvocationTransactionModel,
   IterOptions,
-  JSONHelper,
-  NetworkSettings,
-  NetworkSettingsJSON,
   NetworkType,
-  Output,
-  OutputJSON,
   Peer,
-  PrivateNetworkSettings,
-  RawAction,
-  RawCallReceipt,
-  RawInvocationData,
-  RawStorageChange,
+  RawInvocationResult,
   RelayTransactionResult,
-  RelayTransactionResultJSON,
-  ScriptBuilderParam,
-  scriptHashToAddress,
-  StorageChangeJSON,
-  StorageItem,
-  StorageItemJSON,
-  Transaction,
-  TransactionBase,
-  TransactionJSON,
-  TransactionReceipt,
-  utils,
-  VerifyTransactionResult,
-  VerifyTransactionResultJSON,
 } from '@neo-one/client-common';
-import { utils as commonUtils } from '@neo-one/utils';
 import { AsyncIterableX } from '@reactivex/ix-es2015-cjs/asynciterable/asynciterablex';
-import { flatMap } from '@reactivex/ix-es2015-cjs/asynciterable/pipe/flatmap';
-import { flatten } from '@reactivex/ix-es2015-cjs/asynciterable/pipe/flatten';
-import { map } from '@reactivex/ix-es2015-cjs/asynciterable/pipe/map';
-import BigNumber from 'bignumber.js';
 import debug from 'debug';
-import _ from 'lodash';
 import { AsyncBlockIterator } from '../AsyncBlockIterator';
-import { clientUtils } from '../clientUtils';
-import { MissingTransactionDataError } from '../errors';
-import { convertAction, convertCallReceipt, convertInvocationResult } from './convert';
+import {
+  convertBlock,
+  convertConfirmedTransaction,
+  convertContract,
+  convertInvocationResult,
+  convertRelayTransactionResult,
+} from './convert';
 import { JSONRPCClient } from './JSONRPCClient';
 import { JSONRPCHTTPProvider } from './JSONRPCHTTPProvider';
 import { JSONRPCProvider, JSONRPCProviderManager } from './JSONRPCProvider';
@@ -82,7 +40,7 @@ export interface NEOONEDataProviderOptions {
 /**
  * Implements the methods required by the `NEOONEProvider` as well as the `DeveloperProvider` interface using a NEO•ONE node.
  */
-export class NEOONEDataProvider implements DeveloperProvider {
+export class NEOONEDataProvider {
   public readonly network: NetworkType;
   private mutableClient: JSONRPCClient;
   private readonly iterBlocksFetchTimeoutMS: number | undefined;
@@ -99,120 +57,38 @@ export class NEOONEDataProvider implements DeveloperProvider {
     this.mutableClient = new JSONRPCClient(new JSONRPCHTTPProvider(rpcURL));
   }
 
-  public async getUnclaimed(
-    address: AddressString,
-  ): Promise<{ readonly unclaimed: readonly Input[]; readonly amount: BigNumber }> {
-    return this.capture(async () => {
-      const account = await this.getAccountInternal(address);
-      const amounts = await Promise.all(
-        account.unclaimed.map(async (input) => this.mutableClient.getClaimAmount(input)),
-      );
+  public async sendTransaction(transaction: string): Promise<RelayTransactionResult> {
+    const result = await this.mutableClient.sendTransaction(transaction);
 
-      return {
-        unclaimed: this.convertInputs(account.unclaimed),
-        amount: amounts.reduce((acc, amount) => acc.plus(amount), utils.ZERO_BIG_NUMBER),
-      };
-    }, 'neo_get_unclaimed');
+    return convertRelayTransactionResult(result);
   }
 
-  public async getClaimAmount(input: Input): Promise<BigNumber> {
-    return this.capture(
-      async () => this.mutableClient.getClaimAmount({ txid: input.hash, vout: input.index }),
-      'neo_get_claim_amount',
-    );
+  public async getTransaction(hash: Hash256String, options?: GetOptions): Promise<ConfirmedTransaction> {
+    const result = await this.mutableClient.getTransaction(hash, options);
+
+    return convertConfirmedTransaction(result);
   }
 
-  public async getUnspentOutputs(address: AddressString): Promise<readonly InputOutput[]> {
-    return this.capture(async () => {
-      const account = await this.getAccountInternal(address);
-      const outputs = await Promise.all(
-        account.unspent.map(
-          async (input): Promise<InputOutput | undefined> => {
-            const outputJSON = await this.mutableClient.getUnspentOutput(input);
+  public async invokeFunction(
+    contract: AddressString,
+    method: string,
+    args: readonly ContractParameterJSON[],
+  ): Promise<RawInvocationResult> {
+    const receipt = await this.mutableClient.invokeFunction(contract, method, args);
 
-            if (outputJSON === undefined) {
-              return undefined;
-            }
-
-            const output = this.convertOutput(outputJSON);
-
-            return {
-              asset: output.asset,
-              value: output.value,
-              address: output.address,
-              hash: input.txid,
-              index: input.vout,
-            };
-          },
-        ),
-      );
-
-      return outputs.filter(commonUtils.notNull);
-    }, 'neo_get_unspent');
+    return convertInvocationResult(receipt);
   }
 
-  public async relayTransaction(transaction: string): Promise<RelayTransactionResult> {
-    const result = await this.mutableClient.relayTransaction(transaction);
+  public async invokeRawScript(script: BufferString): Promise<RawInvocationResult> {
+    const receipt = await this.mutableClient.invokeScript(script);
 
-    return this.convertRelayTransactionResult(result);
-  }
-
-  public async getTransactionReceipt(hash: Hash256String, options?: GetOptions): Promise<TransactionReceipt> {
-    const result = await this.mutableClient.getTransactionReceipt(hash, options);
-
-    return { ...result, globalIndex: new BigNumber(result.globalIndex) };
-  }
-
-  public async getInvocationData(hash: Hash256String): Promise<RawInvocationData> {
-    const [invocationData, transaction] = await Promise.all([
-      this.mutableClient.getInvocationData(hash),
-      this.mutableClient.getTransaction(hash),
-    ]);
-
-    if (transaction.data === undefined) {
-      throw new MissingTransactionDataError(hash);
-    }
-
-    return this.convertInvocationData(
-      invocationData,
-      transaction.data.blockHash,
-      transaction.data.blockIndex,
-      hash,
-      transaction.data.transactionIndex,
-    );
-  }
-
-  public async testInvoke(transaction: string): Promise<RawCallReceipt> {
-    const receipt = await this.mutableClient.testInvocation(transaction);
-
-    return convertCallReceipt(receipt);
-  }
-
-  public async getAccount(address: AddressString): Promise<Account> {
-    const account = await this.getAccountInternal(address);
-
-    return {
-      address,
-      balances: account.balances.reduce<Account['balances']>(
-        (acc, { asset, value }) => ({
-          ...acc,
-          [asset]: new BigNumber(value),
-        }),
-        {},
-      ),
-    };
-  }
-
-  public async getAsset(hash: Hash256String): Promise<Asset> {
-    const asset = await this.mutableClient.getAsset(hash);
-
-    return this.convertAsset(asset);
+    return convertInvocationResult(receipt);
   }
 
   public async getBlock(hashOrIndex: Hash256String | number, options?: GetOptions): Promise<Block> {
     const block = await this.mutableClient.getBlock(hashOrIndex, options);
 
-    return this.convertBlock(block);
+    return convertBlock(block);
   }
 
   public iterBlocks(options: IterOptions = {}): AsyncIterable<Block> {
@@ -237,504 +113,15 @@ export class NEOONEDataProvider implements DeveloperProvider {
   public async getContract(address: AddressString): Promise<Contract> {
     const contract = await this.mutableClient.getContract(address);
 
-    return this.convertContract(contract);
+    return convertContract(contract);
   }
 
   public async getMemPool(): Promise<readonly Hash256String[]> {
     return this.mutableClient.getMemPool();
   }
 
-  public async getTransaction(hash: Hash256String): Promise<Transaction> {
-    const transaction = await this.mutableClient.getTransaction(hash);
-
-    return this.convertTransaction(transaction);
-  }
-
-  public async getOutput(input: Input): Promise<Output> {
-    const output = await this.mutableClient.getOutput({
-      txid: input.hash,
-      vout: input.index,
-    });
-
-    return this.convertOutput(output);
-  }
-
   public async getConnectedPeers(): Promise<readonly Peer[]> {
     return this.mutableClient.getConnectedPeers();
-  }
-
-  public async getNetworkSettings(): Promise<NetworkSettings> {
-    const settings = await this.mutableClient.getNetworkSettings();
-
-    return this.convertNetworkSettings(settings);
-  }
-
-  public iterActionsRaw(options: IterOptions = {}): AsyncIterable<RawAction> {
-    return AsyncIterableX.from(this.iterBlocks(options)).pipe<RawAction>(
-      flatMap(async (block) => {
-        const actions = _.flatten(
-          block.transactions.map((transaction) => {
-            if (transaction.type === 'InvocationTransaction') {
-              return [...transaction.invocationData.actions];
-            }
-
-            return [];
-          }),
-        );
-
-        return AsyncIterableX.of(...actions);
-      }),
-    );
-  }
-
-  public async call(
-    contract: AddressString,
-    method: string,
-    params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  ): Promise<RawCallReceipt> {
-    const testTransaction = new InvocationTransactionModel({
-      version: 1,
-      gas: common.TEN_THOUSAND_FIXED8,
-      script: clientUtils.getInvokeMethodScript({
-        address: contract,
-        method,
-        params,
-      }),
-    });
-
-    return this.testInvoke(testTransaction.serializeWire().toString('hex'));
-  }
-
-  public async runConsensusNow(): Promise<void> {
-    return this.mutableClient.runConsensusNow();
-  }
-
-  public async updateSettings(options: Partial<PrivateNetworkSettings>): Promise<void> {
-    return this.mutableClient.updateSettings(options);
-  }
-
-  public async getSettings(): Promise<PrivateNetworkSettings> {
-    return this.mutableClient.getSettings();
-  }
-
-  public async fastForwardOffset(seconds: number): Promise<void> {
-    return this.mutableClient.fastForwardOffset(seconds);
-  }
-
-  public async fastForwardToTime(seconds: number): Promise<void> {
-    return this.mutableClient.fastForwardToTime(seconds);
-  }
-
-  public async reset(): Promise<void> {
-    return this.mutableClient.reset();
-  }
-
-  public async getNEOTrackerURL(): Promise<string | undefined> {
-    return this.mutableClient.getNEOTrackerURL();
-  }
-
-  public async resetProject(): Promise<void> {
-    return this.mutableClient.resetProject();
-  }
-
-  public iterStorage(address: AddressString): AsyncIterable<StorageItem> {
-    return AsyncIterableX.from(this.mutableClient.getAllStorage(address).then((res) => AsyncIterableX.from(res))).pipe(
-      // tslint:disable-next-line no-any
-      flatten<StorageItem>() as any,
-      map<StorageItemJSON, StorageItem>((storageItem) => this.convertStorageItem(storageItem)),
-    );
-  }
-
-  private convertStorageItem(storageItem: StorageItemJSON): StorageItem {
-    return {
-      address: scriptHashToAddress(storageItem.hash),
-      key: storageItem.key,
-      value: storageItem.value,
-    };
-  }
-
-  private convertBlock(block: BlockJSON): Block {
-    return {
-      version: block.version,
-      hash: block.hash,
-      previousBlockHash: block.previousblockhash,
-      merkleRoot: block.merkleroot,
-      time: block.time,
-      index: block.index,
-      nonce: block.nonce,
-      nextConsensus: block.nextconsensus,
-      script: block.script,
-      size: block.size,
-      transactions: block.tx.map((transaction) => this.convertConfirmedTransaction(transaction)),
-    };
-  }
-
-  private convertTransaction(transaction: TransactionJSON): Transaction {
-    return this.convertTransactionBase(
-      transaction,
-      (invocation, transactionBase) => ({
-        ...transactionBase,
-        type: 'InvocationTransaction',
-        script: invocation.script,
-        gas: new BigNumber(invocation.gas),
-      }),
-      /* istanbul ignore next */
-      (converted) => converted,
-    );
-  }
-
-  private convertConfirmedTransaction(transaction: TransactionJSON): ConfirmedTransaction {
-    if (transaction.data === undefined) {
-      /* istanbul ignore next */
-      throw new Error('Unexpected undefined data');
-    }
-    const data = {
-      blockHash: transaction.data.blockHash,
-      blockIndex: transaction.data.blockIndex,
-      transactionIndex: transaction.data.transactionIndex,
-      globalIndex: JSONHelper.readUInt64(transaction.data.globalIndex),
-    };
-
-    return this.convertTransactionBase(
-      transaction,
-      (invocation, transactionBase) => {
-        /* istanbul ignore next */
-        if (invocation.invocationData === undefined || transaction.data === undefined) {
-          throw new Error('Unexpected undefined data');
-        }
-
-        const invocationData = this.convertInvocationData(
-          invocation.invocationData,
-          transaction.data.blockHash,
-          transaction.data.blockIndex,
-          transaction.txid,
-          transaction.data.transactionIndex,
-        );
-
-        return {
-          ...transactionBase,
-          type: 'InvocationTransaction',
-          script: invocation.script,
-          gas: new BigNumber(invocation.gas),
-          receipt: data,
-          invocationData,
-        };
-      },
-      // tslint:disable-next-line no-any
-      (converted) => ({ ...converted, receipt: data } as any),
-    );
-  }
-
-  private convertTransactionBase<Result extends Transaction | ConfirmedTransaction>(
-    transaction: TransactionJSON,
-    convertInvocation: (invocation: InvocationTransactionJSON, transactionBase: TransactionBase) => Result,
-    convertTransaction: (transaction: Transaction) => Result,
-  ): Result {
-    const transactionBase = {
-      hash: transaction.txid,
-      size: transaction.size,
-      version: transaction.version,
-      attributes: this.convertAttributes(transaction.attributes),
-      inputs: this.convertInputs(transaction.vin),
-      outputs: this.convertOutputs(transaction.vout),
-      scripts: transaction.scripts,
-      systemFee: new BigNumber(transaction.sys_fee),
-      networkFee: new BigNumber(transaction.net_fee),
-    };
-
-    let converted: Transaction;
-    switch (transaction.type) {
-      case 'ClaimTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'ClaimTransaction',
-          claims: this.convertInputs(transaction.claims),
-        };
-        break;
-      case 'ContractTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'ContractTransaction',
-        };
-        break;
-      case 'EnrollmentTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'EnrollmentTransaction',
-          publicKey: transaction.pubkey,
-        };
-        break;
-      case 'InvocationTransaction':
-        return convertInvocation(transaction, transactionBase);
-      case 'IssueTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'IssueTransaction',
-        };
-        break;
-      case 'MinerTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'MinerTransaction',
-          nonce: transaction.nonce,
-        };
-        break;
-      case 'PublishTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'PublishTransaction',
-          contract: this.convertContract(transaction.contract),
-        };
-        break;
-      case 'RegisterTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'RegisterTransaction',
-          asset: {
-            type: this.convertAssetType(transaction.asset.type),
-            name: Array.isArray(transaction.asset.name)
-              ? /* istanbul ignore next */ transaction.asset.name[0].name
-              : transaction.asset.name,
-            amount: new BigNumber(transaction.asset.amount),
-            precision: transaction.asset.precision,
-            owner: transaction.asset.owner,
-            admin: transaction.asset.admin,
-          },
-        };
-        break;
-      case 'StateTransaction':
-        converted = {
-          ...transactionBase,
-          type: 'StateTransaction',
-        };
-        break;
-      /* istanbul ignore next */
-      default:
-        commonUtils.assertNever(transaction);
-        throw new Error('For TS');
-    }
-
-    return convertTransaction(converted);
-  }
-
-  private convertAttributes(attributes: readonly AttributeJSON[]): readonly Attribute[] {
-    return attributes.map((attribute) => ({
-      // tslint:disable-next-line no-any
-      usage: attribute.usage as any,
-      data: attribute.usage === 'Script' ? scriptHashToAddress(attribute.data) : attribute.data,
-    }));
-  }
-
-  private convertInputs(inputs: readonly InputJSON[]): readonly Input[] {
-    return inputs.map((input) => this.convertInput(input));
-  }
-
-  private convertInput(input: InputJSON): Input {
-    return {
-      hash: input.txid,
-      index: input.vout,
-    };
-  }
-
-  private convertOutputs(outputs: readonly OutputJSON[]): readonly Output[] {
-    return outputs.map((output) => this.convertOutput(output));
-  }
-
-  private convertOutput(output: OutputJSON): Output {
-    return {
-      asset: output.asset,
-      address: output.address,
-      value: new BigNumber(output.value),
-    };
-  }
-
-  private convertContract(contract: ContractJSON): Contract {
-    return {
-      version: contract.version,
-      address: scriptHashToAddress(contract.hash),
-      script: contract.script,
-      parameters: contract.parameters.map((param) => this.convertContractParameterType(param)),
-      returnType: this.convertContractParameterType(contract.returntype),
-      name: contract.name,
-      codeVersion: contract.code_version,
-      author: contract.author,
-      email: contract.email,
-      description: contract.description,
-      storage: contract.properties.storage,
-      dynamicInvoke: contract.properties.dynamic_invoke,
-      payable: contract.properties.payable,
-    };
-  }
-
-  private convertContractParameterType(param: ContractParameterTypeJSON): ContractParameterType {
-    switch (param) {
-      case 'Signature':
-        return 'Signature';
-      case 'Boolean':
-        return 'Boolean';
-      case 'Integer':
-        return 'Integer';
-      case 'Hash160':
-        return 'Address';
-      case 'Hash256':
-        return 'Hash256';
-      case 'ByteArray':
-        return 'Buffer';
-      case 'PublicKey':
-        return 'PublicKey';
-      case 'String':
-        return 'String';
-      case 'Array':
-        return 'Array';
-      case 'Map':
-        return 'Map';
-      case 'InteropInterface':
-        return 'InteropInterface';
-      case 'Void':
-        return 'Void';
-      /* istanbul ignore next */
-      default:
-        commonUtils.assertNever(param);
-        throw new Error('For TS');
-    }
-  }
-
-  private convertInvocationData(
-    data: InvocationDataJSON,
-    blockHash: string,
-    blockIndex: number,
-    transactionHash: string,
-    transactionIndex: number,
-  ): RawInvocationData {
-    return {
-      result: convertInvocationResult(data.result),
-      asset: data.asset === undefined ? data.asset : this.convertAsset(data.asset),
-      contracts: data.contracts.map((contract) => this.convertContract(contract)),
-      deletedContractAddresses: data.deletedContractHashes.map(scriptHashToAddress),
-      migratedContractAddresses: data.migratedContractHashes.map<readonly [AddressString, AddressString]>(
-        ([hash0, hash1]) => [scriptHashToAddress(hash0), scriptHashToAddress(hash1)] as const,
-      ),
-      actions: data.actions.map((action, idx) =>
-        convertAction(blockHash, blockIndex, transactionHash, transactionIndex, idx, action),
-      ),
-      storageChanges: data.storageChanges.map((storageChange) => this.convertStorageChange(storageChange)),
-    };
-  }
-
-  private convertStorageChange(storageChange: StorageChangeJSON): RawStorageChange {
-    if (storageChange.type === 'Add') {
-      return {
-        type: 'Add',
-        address: scriptHashToAddress(storageChange.hash),
-        key: storageChange.key,
-        value: storageChange.value,
-      };
-    }
-
-    if (storageChange.type === 'Modify') {
-      return {
-        type: 'Modify',
-        address: scriptHashToAddress(storageChange.hash),
-        key: storageChange.key,
-        value: storageChange.value,
-      };
-    }
-
-    return {
-      type: 'Delete',
-      address: scriptHashToAddress(storageChange.hash),
-      key: storageChange.key,
-    };
-  }
-
-  private convertAsset(asset: AssetJSON): Asset {
-    const assetName = asset.name;
-    let name;
-    if (Array.isArray(assetName)) {
-      const enName = assetName.find(({ lang }) => lang === 'en');
-      name = enName === undefined ? assetName[0].name : enName.name;
-    } else {
-      name = assetName;
-    }
-
-    return {
-      hash: asset.id,
-      type: this.convertAssetType(asset.type),
-      name,
-      amount: new BigNumber(asset.amount),
-      available: new BigNumber(asset.available),
-      precision: asset.precision,
-      owner: asset.owner,
-      admin: asset.admin,
-      issuer: asset.issuer,
-      expiration: asset.expiration,
-      frozen: asset.frozen,
-    };
-  }
-
-  private convertAssetType(assetType: AssetTypeJSON): AssetType {
-    switch (assetType) {
-      case 'CreditFlag':
-        return 'Credit';
-      case 'DutyFlag':
-        return 'Duty';
-      case 'GoverningToken':
-        return 'Governing';
-      case 'UtilityToken':
-        return 'Utility';
-      case 'Currency':
-        return 'Currency';
-      case 'Share':
-        return 'Share';
-      case 'Invoice':
-        return 'Invoice';
-      case 'Token':
-        return 'Token';
-      default:
-        /* istanbul ignore next */
-        commonUtils.assertNever(assetType);
-        /* istanbul ignore next */
-        throw new Error('For TS');
-    }
-  }
-
-  private async getAccountInternal(address: AddressString): Promise<AccountJSON> {
-    return this.mutableClient.getAccount(address);
-  }
-
-  private convertNetworkSettings(settings: NetworkSettingsJSON): NetworkSettings {
-    return {
-      issueGASFee: new BigNumber(settings.issueGASFee),
-    };
-  }
-
-  private convertRelayTransactionResult(result: RelayTransactionResultJSON): RelayTransactionResult {
-    const transaction = this.convertTransaction(result.transaction);
-    const verifyResult =
-      result.verifyResult === undefined ? undefined : this.convertVerifyResult(transaction.hash, result.verifyResult);
-
-    return { transaction, verifyResult };
-  }
-
-  /* istanbul ignore next */
-  private convertVerifyResult(transactionHash: string, result: VerifyTransactionResultJSON): VerifyTransactionResult {
-    return {
-      verifications: result.verifications.map((verification) => ({
-        failureMessage: verification.failureMessage,
-        witness: verification.witness,
-        address: scriptHashToAddress(verification.hash),
-        actions: verification.actions.map((action, idx) =>
-          convertAction(
-            common.uInt256ToString(common.bufferToUInt256(Buffer.alloc(32, 0))),
-            -1,
-            transactionHash,
-            -1,
-            idx,
-            action,
-          ),
-        ),
-      })),
-    };
   }
 
   private async capture<T>(func: () => Promise<T>, title: string): Promise<T> {
@@ -748,4 +135,68 @@ export class NEOONEDataProvider implements DeveloperProvider {
       throw error;
     }
   }
+
+  // public async getNetworkSettings(): Promise<NetworkSettings> {
+  //   const settings = await this.mutableClient.getNetworkSettings();
+
+  //   return this.convertNetworkSettings(settings);
+  // }
+
+  // public iterActionsRaw(options: IterOptions = {}): AsyncIterable<RawAction> {
+  //   return AsyncIterableX.from(this.iterBlocks(options)).pipe<RawAction>(
+  //     flatMap(async (block) => {
+  //       const actions = _.flatten(
+  //         block.transactions.map((transaction) => {
+  //           if (transaction.type === 'InvocationTransaction') {
+  //             return [...transaction.invocationData.actions];
+  //           }
+
+  //           return [];
+  //         }),
+  //       );
+
+  //       return AsyncIterableX.of(...actions);
+  //     }),
+  //   );
+  // }
+
+  // public async runConsensusNow(): Promise<void> {
+  //   return this.mutableClient.runConsensusNow();
+  // }
+
+  // public async updateSettings(options: Partial<PrivateNetworkSettings>): Promise<void> {
+  //   return this.mutableClient.updateSettings(options);
+  // }
+
+  // public async getSettings(): Promise<PrivateNetworkSettings> {
+  //   return this.mutableClient.getSettings();
+  // }
+
+  // public async fastForwardOffset(seconds: number): Promise<void> {
+  //   return this.mutableClient.fastForwardOffset(seconds);
+  // }
+
+  // public async fastForwardToTime(seconds: number): Promise<void> {
+  //   return this.mutableClient.fastForwardToTime(seconds);
+  // }
+
+  // public async reset(): Promise<void> {
+  //   return this.mutableClient.reset();
+  // }
+
+  // public async getNEOTrackerURL(): Promise<string | undefined> {
+  //   return this.mutableClient.getNEOTrackerURL();
+  // }
+
+  // public async resetProject(): Promise<void> {
+  //   return this.mutableClient.resetProject();
+  // }
+
+  // public iterStorage(address: AddressString): AsyncIterable<StorageItem> {
+  //   return AsyncIterableX.from(this.mutableClient.getAllStorage(address).then((res) => AsyncIterableX.from(res))).pipe(
+  //     // tslint:disable-next-line no-any
+  //     flatten<StorageItem>() as any,
+  //     map<StorageItemJSON, StorageItem>((storageItem) => this.convertStorageItem(storageItem)),
+  //   );
+  // }
 }

--- a/packages/neo-one-client-core/src/provider/convert.ts
+++ b/packages/neo-one-client-core/src/provider/convert.ts
@@ -1,18 +1,324 @@
 import {
   ActionJSON,
+  Attribute,
+  AttributeJSON,
+  Block,
+  BlockJSON,
   CallReceiptJSON,
+  common,
+  ConfirmedTransaction,
+  ConfirmedTransactionJSON,
+  Contract,
+  ContractAbi,
+  ContractAbiJSON,
+  ContractEvent,
+  ContractEventJSON,
+  ContractGroup,
+  ContractGroupJSON,
+  ContractJSON,
+  ContractManifest,
+  ContractManifestJSON,
+  ContractMethodDescriptor,
+  ContractMethodDescriptorJSON,
   ContractParameter,
+  ContractParameterDeclaration,
+  ContractParameterDeclarationJSON,
   ContractParameterJSON,
+  ContractParameterType,
+  ContractParameterTypeJSON,
+  ContractPermissionDescriptor,
+  ContractPermissionDescriptorJSON,
+  ContractPermissions,
+  ContractPermissionsJSON,
+  Cosigner,
+  CosignerJSON,
   InvocationResultJSON,
   JSONHelper,
+  NetworkSettings,
+  NetworkSettingsJSON,
   RawAction,
   RawCallReceipt,
   RawInvocationResult,
+  RawStorageChange,
+  RelayTransactionResult,
+  RelayTransactionResultJSON,
   scriptHashToAddress,
+  StorageChangeJSON,
+  StorageItem,
+  StorageItemJSON,
+  Transaction,
+  TransactionJSON,
+  UInt160,
+  VerifyTransactionResult,
+  VerifyTransactionResultJSON,
+  WildcardContainer,
+  WildcardContainerJSON,
 } from '@neo-one/client-common';
 import { utils } from '@neo-one/utils';
 import BigNumber from 'bignumber.js';
 import { BN } from 'bn.js';
+import { InvalidContractPermissionDescriptorError } from '../errors';
+export function convertStorageItem(storageItem: StorageItemJSON): StorageItem {
+  return {
+    address: scriptHashToAddress(storageItem.hash),
+    key: storageItem.key,
+    value: storageItem.value,
+  };
+}
+
+export function convertAttributes(attributes: readonly AttributeJSON[]): readonly Attribute[] {
+  return attributes.map((attribute) => ({
+    // tslint:disable-next-line no-any
+    usage: attribute.usage as any,
+    data: attribute.usage === 'Script' ? scriptHashToAddress(attribute.data) : attribute.data,
+  }));
+}
+
+export function convertCosigners(cosigners: readonly CosignerJSON[]): readonly Cosigner[] {
+  return cosigners.map((cosigner) => ({
+    account: cosigner.account,
+    scopes: cosigner.scopes,
+    allowedContracts: cosigner.allowedContracts,
+    allowedGroups:
+      cosigner.allowedGroups === undefined
+        ? undefined
+        : cosigner.allowedGroups.map((group) => common.hexToECPoint(group)),
+  }));
+}
+
+export function convertTransaction(transaction: TransactionJSON): Transaction {
+  return {
+    hash: transaction.hash,
+    size: transaction.size,
+    version: transaction.version,
+    nonce: transaction.nonce,
+    sender: transaction.sender,
+    systemFee: new BigNumber(transaction.sys_fee),
+    networkFee: new BigNumber(transaction.net_fee),
+    validUntilBlock: transaction.valid_until_block,
+    attributes: convertAttributes(transaction.attributes),
+    witnesses: transaction.witnesses,
+    cosigners: convertCosigners(transaction.cosigners),
+    script: transaction.script,
+  };
+}
+
+export function convertConfirmedTransaction(transaction: ConfirmedTransactionJSON): ConfirmedTransaction {
+  return {
+    ...convertTransaction(transaction),
+    blockHash: transaction.blockHash,
+    blockTime: transaction.blockTime,
+    transactionHash: transaction.hash,
+    confirmations: transaction.confirmations,
+  };
+}
+
+export function convertBlock(block: BlockJSON): Block {
+  return {
+    version: block.version,
+    hash: block.hash,
+    previousBlockHash: block.previousblockhash,
+    merkleRoot: block.merkleroot,
+    time: new BigNumber(block.time),
+    index: block.index,
+    nextConsensus: block.nextconsensus,
+    size: block.size,
+    transactions: block.tx.map(convertConfirmedTransaction),
+    witnesses: block.witnesses,
+    confirmations: block.confirmations,
+    nextBlockHash: block.nextblockhash,
+    consensusData: {
+      primaryIndex: block.consensus_data.primary,
+      nonce: block.consensus_data.nonce,
+    },
+  };
+}
+
+export function convertContractEvent(event: ContractEventJSON): ContractEvent {
+  return {
+    name: event.name,
+    parameters: event.parameters.map(convertContractParameterDeclaration),
+  };
+}
+
+export function convertContractMethodDescriptor(method: ContractMethodDescriptorJSON): ContractMethodDescriptor {
+  return {
+    name: method.name,
+    parameters: method.parameters.map(convertContractParameterDeclaration),
+    returnType: convertContractParameterType(method.returnType),
+  };
+}
+
+export function convertContractAbi(abi: ContractAbiJSON): ContractAbi {
+  return {
+    hash: common.hexToUInt160(abi.hash),
+    entryPoint: convertContractMethodDescriptor(abi.entryPoint),
+    methods: abi.methods.map(convertContractMethodDescriptor),
+    events: abi.events.map(convertContractEvent),
+  };
+}
+
+export function convertContractGroup(group: ContractGroupJSON): ContractGroup {
+  return {
+    publicKey: common.hexToECPoint(group.publicKey),
+    signature: group.signature,
+  };
+}
+
+export function convertContractPermissionDescriptor(
+  permissionDescriptor: ContractPermissionDescriptorJSON,
+): ContractPermissionDescriptor {
+  if (permissionDescriptor === '*') {
+    return { hashOrGroup: undefined };
+  }
+
+  try {
+    return { hashOrGroup: common.hexToUInt160(permissionDescriptor) };
+  } catch {
+    // do nothing
+  }
+
+  try {
+    return { hashOrGroup: common.hexToECPoint(permissionDescriptor) };
+  } catch {
+    // do nothing
+  }
+
+  throw new InvalidContractPermissionDescriptorError(permissionDescriptor);
+}
+
+export function convertWildcardContainer<T, U>(
+  wildcard: WildcardContainerJSON<T>,
+  conversion: (data: T) => U,
+): WildcardContainer<U> {
+  return wildcard === '*' ? { data: undefined } : { data: wildcard.map(conversion) };
+}
+
+export function convertContractPermissions(permission: ContractPermissionsJSON): ContractPermissions {
+  return {
+    contract: convertContractPermissionDescriptor(permission.contract),
+    methods: convertWildcardContainer<string, string>(permission.methods, (data) => data),
+  };
+}
+
+export function convertContractManifest(manifest: ContractManifestJSON): ContractManifest {
+  return {
+    abi: convertContractAbi(manifest.abi),
+    groups: manifest.groups.map(convertContractGroup),
+    permissions: manifest.permissions.map(convertContractPermissions),
+    trusts: convertWildcardContainer<string, UInt160>(manifest.trusts, common.hexToUInt160),
+    safeMethods: convertWildcardContainer<string, string>(manifest.safeMethods, (data) => data),
+    features: manifest.features,
+  };
+}
+
+export function convertContract(contract: ContractJSON): Contract {
+  return {
+    address: scriptHashToAddress(contract.hash),
+    script: contract.script,
+    manifest: convertContractManifest(contract.manifest),
+  };
+}
+
+export function convertContractParameterType(param: ContractParameterTypeJSON): ContractParameterType {
+  switch (param) {
+    case 'Signature':
+      return 'Signature';
+    case 'Boolean':
+      return 'Boolean';
+    case 'Integer':
+      return 'Integer';
+    case 'Hash160':
+      return 'Address';
+    case 'Hash256':
+      return 'Hash256';
+    case 'ByteArray':
+      return 'Buffer';
+    case 'PublicKey':
+      return 'PublicKey';
+    case 'String':
+      return 'String';
+    case 'Array':
+      return 'Array';
+    case 'Map':
+      return 'Map';
+    case 'InteropInterface':
+      return 'InteropInterface';
+    case 'Void':
+      return 'Void';
+    /* istanbul ignore next */
+    default:
+      utils.assertNever(param);
+      throw new Error('For TS');
+  }
+}
+
+export function convertContractParameterDeclaration(
+  param: ContractParameterDeclarationJSON,
+): ContractParameterDeclaration {
+  return {
+    type: convertContractParameterType(param.type),
+    name: param.name,
+  };
+}
+
+export function convertStorageChange(storageChange: StorageChangeJSON): RawStorageChange {
+  if (storageChange.type === 'Add') {
+    return {
+      type: 'Add',
+      address: scriptHashToAddress(storageChange.hash),
+      key: storageChange.key,
+      value: storageChange.value,
+    };
+  }
+
+  if (storageChange.type === 'Modify') {
+    return {
+      type: 'Modify',
+      address: scriptHashToAddress(storageChange.hash),
+      key: storageChange.key,
+      value: storageChange.value,
+    };
+  }
+
+  return {
+    type: 'Delete',
+    address: scriptHashToAddress(storageChange.hash),
+    key: storageChange.key,
+  };
+}
+
+export function convertRelayTransactionResult(result: RelayTransactionResultJSON): RelayTransactionResult {
+  const transaction = convertTransaction(result.transaction);
+  const verifyResult =
+    result.verifyResult === undefined ? undefined : convertVerifyResult(transaction.hash, result.verifyResult);
+
+  return { transaction, verifyResult };
+}
+
+/* istanbul ignore next */
+export function convertVerifyResult(
+  transactionHash: string,
+  result: VerifyTransactionResultJSON,
+): VerifyTransactionResult {
+  return {
+    verifications: result.verifications.map((verification) => ({
+      failureMessage: verification.failureMessage,
+      witness: verification.witness,
+      address: scriptHashToAddress(verification.hash),
+      actions: verification.actions.map((action, idx) =>
+        convertAction(
+          common.uInt256ToString(common.bufferToUInt256(Buffer.alloc(32, 0))),
+          -1,
+          transactionHash,
+          -1,
+          idx,
+          action,
+        ),
+      ),
+    })),
+  };
+}
 
 export function convertCallReceipt(receipt: CallReceiptJSON): RawCallReceipt {
   return {
@@ -86,6 +392,7 @@ export function convertContractParameter(parameter: ContractParameterJSON): Cont
       return {
         type: 'Array',
         value: convertContractParameters(parameter.value),
+        name: parameter.name,
       };
     case 'Boolean':
       return parameter;
@@ -93,11 +400,13 @@ export function convertContractParameter(parameter: ContractParameterJSON): Cont
       return {
         type: 'Buffer',
         value: parameter.value,
+        name: parameter.name,
       };
     case 'Hash160':
       return {
         type: 'Address',
         value: scriptHashToAddress(parameter.value),
+        name: parameter.name,
       };
     case 'Hash256':
       return parameter;
@@ -105,6 +414,7 @@ export function convertContractParameter(parameter: ContractParameterJSON): Cont
       return {
         type: 'Integer',
         value: new BN(parameter.value, 10),
+        name: parameter.name,
       };
     case 'InteropInterface':
       return parameter;
@@ -114,6 +424,7 @@ export function convertContractParameter(parameter: ContractParameterJSON): Cont
         value: parameter.value.map<readonly [ContractParameter, ContractParameter]>(
           ([key, val]) => [convertContractParameter(key), convertContractParameter(val)] as const,
         ),
+        name: parameter.name,
       };
     case 'PublicKey':
       return parameter;
@@ -128,4 +439,10 @@ export function convertContractParameter(parameter: ContractParameterJSON): Cont
       utils.assertNever(parameter);
       throw new Error('For TS');
   }
+}
+
+export function convertNetworkSettings(settings: NetworkSettingsJSON): NetworkSettings {
+  return {
+    issueGASFee: new BigNumber(settings.issueGASFee),
+  };
 }


### PR DESCRIPTION
### Description of the Change
Convert NEOONEDataProvider to work with the new JSONRPCClient updated for neo 3.0 + the official node.  This really only includes support for the basic methods.  We will need to find ways to better support Invocation Data, Actions, and Storage/Storage iteration.  Easy support for NEO & GAS will come with a more generic refactor of how the client supports nep-5 contracts. 

### Test Plan
Added unit tests.  Also performed simple tests with the neo 3.0 testnet

### Benefits
3.0 + official node compatibility.

### Possible Drawbacks
Loss of invocation data & easy access to storage iteration.  Loss of developer client methods.
