### PR TITLE
chore(prettier): update prettier for TS v3.8 support

### DIFF
--- a/common/changes/@neo-one/cli/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/cli/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-common/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/client-common/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/client-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-core/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/client-core/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/client-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-switch/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/client-switch/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-switch",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/client-switch",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-blockchain/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/node-blockchain/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-blockchain",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-blockchain",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-consensus/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/node-consensus/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-consensus",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-consensus",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-core/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/node-core/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-rpc-handler/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/node-rpc-handler/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-rpc-handler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-rpc-handler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-vm/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/node-vm/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-vm",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-vm",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-codegen/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/smart-contract-codegen/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-codegen",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-codegen",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-compiler/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/smart-contract-compiler/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/typescript-concatenator/prettier_2020-03-22-23-31.json
+++ b/common/changes/@neo-one/typescript-concatenator/prettier_2020-03-22-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/typescript-concatenator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/typescript-concatenator",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/config/rush/yarn.lock
+++ b/common/config/rush/yarn.lock
@@ -2715,6 +2715,24 @@
     rxjs "^6.5.3"
     tslib "^1.10.0"
 
+"@rush-temp/node-tools@file:./projects/node-tools.tgz":
+  version "0.0.0"
+  resolved "file:./projects/node-tools.tgz#8f9fcb3b0a684e82162358d7141e2382de2f4616"
+  dependencies:
+    "@google-cloud/storage" "^4.3.2"
+    "@types/fs-extra" "^8.0.0"
+    "@types/rc" "^1.1.0"
+    "@types/yargs" "^13.0.3"
+    execa "^3.2.0"
+    fs-extra "^8.1.0"
+    gulp "~4.0.2"
+    import-local "^3.0.2"
+    rc "^1.2.8"
+    semver "^6.3.0"
+    source-map-support "^0.5.13"
+    tslib "^1.10.0"
+    yargs "^14.2.0"
+
 "@rush-temp/node-vm@file:./projects/node-vm.tgz":
   version "0.0.0"
   resolved "file:./projects/node-vm.tgz"
@@ -2798,7 +2816,7 @@
     "@types/prettier" "^1.18.2"
     gulp "~4.0.2"
     lodash "^4.17.15"
-    prettier "^1.18.2"
+    prettier "^2.0.1"
     safe-stable-stringify "^1.1.0"
     source-map "^0.7.3"
     tslib "^1.10.0"
@@ -16163,6 +16181,11 @@ prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"

--- a/packages/neo-one-cli/src/bin/neo-one.ts
+++ b/packages/neo-one-cli/src/bin/neo-one.ts
@@ -3,9 +3,4 @@ import yargs from 'yargs';
 import * as cmd from '../cmd';
 
 // tslint:disable-next-line no-unused-expression
-cmd
-  .builder(yargs)
-  .usage(cmd.describe)
-  .demandCommand()
-  .scriptName(cmd.command)
-  .help('help').argv;
+cmd.builder(yargs).usage(cmd.describe).demandCommand().scriptName(cmd.command).help('help').argv;

--- a/packages/neo-one-cli/src/cmd/build.ts
+++ b/packages/neo-one-cli/src/cmd/build.ts
@@ -6,10 +6,7 @@ import { start } from '../common';
 export const command = 'build';
 export const describe = 'Builds the project and deploys it to the local development network.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder
-    .boolean('reset')
-    .describe('reset', 'Reset the local project.')
-    .default('reset', false);
+  yargsBuilder.boolean('reset').describe('reset', 'Reset the local project.').default('reset', false);
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
     await createTasks(cmd, config, argv.reset).run();

--- a/packages/neo-one-cli/src/cmd/convert/index.ts
+++ b/packages/neo-one-cli/src/cmd/convert/index.ts
@@ -8,9 +8,4 @@ import * as wif from './wif';
 export const command = 'convert';
 export const describe = 'Convert values.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder
-    .command(address)
-    .command(privateKey)
-    .command(publicKey)
-    .command(scriptHash)
-    .command(wif);
+  yargsBuilder.command(address).command(privateKey).command(publicKey).command(scriptHash).command(wif);

--- a/packages/neo-one-cli/src/cmd/deploy.ts
+++ b/packages/neo-one-cli/src/cmd/deploy.ts
@@ -6,10 +6,7 @@ import { deploy } from '../deploy';
 export const command = 'deploy';
 export const describe = 'Deploys the project using the migration file.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder
-    .string('network')
-    .describe('network', 'Network to run the migration on.')
-    .default('network', 'test');
+  yargsBuilder.string('network').describe('network', 'Network to run the migration on.').default('network', 'test');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
     await deploy(cmd, config, argv.network);

--- a/packages/neo-one-cli/src/cmd/start/neotracker.ts
+++ b/packages/neo-one-cli/src/cmd/start/neotracker.ts
@@ -10,10 +10,7 @@ import { writePidFile } from './writePidFile';
 export const command = 'neotracker';
 export const describe = 'Start a NEO tracker instance using the project configuration.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder
-    .boolean('reset')
-    .describe('reset', 'Reset the NEO tracker database.')
-    .default('reset', false);
+  yargsBuilder.boolean('reset').describe('reset', 'Reset the NEO tracker database.').default('reset', false);
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const running = await isRunning(config.neotracker.port);

--- a/packages/neo-one-cli/src/utils/writeFile.ts
+++ b/packages/neo-one-cli/src/utils/writeFile.ts
@@ -9,9 +9,7 @@ export const writeFile = async (filePath: string, contents?: string) => {
   }
 
   const exists = await fs.pathExists(filePath);
-  const hash = createHash('md5')
-    .update(contents)
-    .digest('hex');
+  const hash = createHash('md5').update(contents).digest('hex');
   if (exists) {
     const currentContents = await fs.readFile(filePath, 'utf8');
     const match = hashRegex.exec(currentContents);

--- a/packages/neo-one-client-common/src/crypto.ts
+++ b/packages/neo-one-client-common/src/crypto.ts
@@ -37,10 +37,7 @@ const ec = () => {
   return ecCache;
 };
 
-const sha1 = (value: Buffer): Buffer =>
-  createHash('sha1')
-    .update(value)
-    .digest();
+const sha1 = (value: Buffer): Buffer => createHash('sha1').update(value).digest();
 
 const sha256 = sha256In;
 
@@ -53,10 +50,7 @@ const hash160 = (value: Buffer): UInt160 => common.bufferToUInt160(rmd160(sha256
 
 const hash256 = (value: Buffer): UInt256 => common.bufferToUInt256(sha256(sha256(value)));
 
-const hmacSha512 = (key: Buffer | string, data: Buffer) =>
-  createHmac('sha512', key)
-    .update(data)
-    .digest();
+const hmacSha512 = (key: Buffer | string, data: Buffer) => createHmac('sha512', key).update(data).digest();
 
 const sign = ({ message, privateKey }: { readonly message: Buffer; readonly privateKey: PrivateKey }): Buffer => {
   const sig = ec().sign(sha256(message), common.privateKeyToBuffer(privateKey));
@@ -143,12 +137,7 @@ const verify = ({
 
   const key = new ECKey({
     crv: 'P-256',
-    publicKey: Buffer.from(
-      ec()
-        .keyFromPublic(publicKey)
-        .getPublic(false, 'hex'),
-      'hex',
-    ),
+    publicKey: Buffer.from(ec().keyFromPublic(publicKey).getPublic(false, 'hex'), 'hex'),
   });
 
   return (key.createVerify('SHA256').update(message) as any).verify(signature);
@@ -723,13 +712,9 @@ const deriveChildKey = (node: HDNode, index: number, hardened: boolean): HDNode 
       version: BIP32_VERSION.private,
     };
   }
-  const parentKey = ec()
-    .keyFromPublic(node.publicKey)
-    .getPublic();
+  const parentKey = ec().keyFromPublic(node.publicKey).getPublic();
 
-  const childKey = ec()
-    .g.mul(shaLeft)
-    .add(parentKey);
+  const childKey = ec().g.mul(shaLeft).add(parentKey);
 
   if (childKey.isInfinity()) {
     return deriveChildKey(node, index + 1, false);

--- a/packages/neo-one-client-common/src/models/vm.ts
+++ b/packages/neo-one-client-common/src/models/vm.ts
@@ -340,10 +340,7 @@ export const assertVMState = (state: number): VMState => {
 
 export type SysCallHash = number & { readonly __uint256: undefined };
 
-export const sha256 = (value: Buffer): Buffer =>
-  createHash('sha256')
-    .update(value)
-    .digest();
+export const sha256 = (value: Buffer): Buffer => createHash('sha256').update(value).digest();
 
 // @ts-ignore
 const mutableCache: { [K in SysCall]: SysCallHash } = {};

--- a/packages/neo-one-client-core/src/__tests__/user/keystore/LocalKeyStore.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/user/keystore/LocalKeyStore.test.ts
@@ -135,10 +135,7 @@ describe('LocalKeyStore', () => {
   });
 
   test('getWallet$', async () => {
-    const result = await keystore
-      .getWallet$(lockedWallet.userAccount.id)
-      .pipe(take(1))
-      .toPromise();
+    const result = await keystore.getWallet$(lockedWallet.userAccount.id).pipe(take(1)).toPromise();
 
     expect(result).toEqual(lockedWallet);
   });

--- a/packages/neo-one-client-switch/src/common/createConsoleLogMessages.ts
+++ b/packages/neo-one-client-switch/src/common/createConsoleLogMessages.ts
@@ -57,10 +57,7 @@ const inspect = (value: any, wrapString = false): any => {
 
 // tslint:disable-next-line no-any
 const extractValueFromStackItem = (stackItem: StackItem): any => {
-  const type = stackItem
-    .asArray()[0]
-    .asBigIntegerUnsafe()
-    .toNumber();
+  const type = stackItem.asArray()[0].asBigIntegerUnsafe().toNumber();
 
   switch (type) {
     case 1:
@@ -75,35 +72,18 @@ const extractValueFromStackItem = (stackItem: StackItem): any => {
     case 5:
       return `Symbol(${stackItem.asArray()[1].asString()})`;
     case 6:
-      return stackItem
-        .asArray()[1]
-        .asBigIntegerUnsafe()
-        .toString(10);
+      return stackItem.asArray()[1].asBigIntegerUnsafe().toString(10);
     case 7:
       return _.fromPairs(
         utils.zip(
-          stackItem
-            .asArray()[1]
-            .asArray()[0]
-            .asArray()
-            .map(extractValueFromStackItem),
-          stackItem
-            .asArray()[1]
-            .asArray()[1]
-            .asArray()
-            .map(extractValueFromStackItem),
+          stackItem.asArray()[1].asArray()[0].asArray().map(extractValueFromStackItem),
+          stackItem.asArray()[1].asArray()[1].asArray().map(extractValueFromStackItem),
         ),
       );
     case 8:
-      return stackItem
-        .asArray()[1]
-        .asArray()
-        .map(extractValueFromStackItem);
+      return stackItem.asArray()[1].asArray().map(extractValueFromStackItem);
     case 9:
-      return stackItem
-        .asArray()[1]
-        .asBuffer()
-        .toString('hex');
+      return stackItem.asArray()[1].asBuffer().toString('hex');
     case 10:
       // tslint:disable-next-line no-any
       return new Map<any, any>(
@@ -114,12 +94,7 @@ const extractValueFromStackItem = (stackItem: StackItem): any => {
           .map<any>((value) => value.asArray().map(extractValueFromStackItem)),
       );
     case 11:
-      return new Set(
-        stackItem
-          .asArray()[1]
-          .asArray()
-          .map(extractValueFromStackItem),
-      );
+      return new Set(stackItem.asArray()[1].asArray().map(extractValueFromStackItem));
     default:
       return `<unknown type ${type}>`;
   }
@@ -132,9 +107,7 @@ const extractMessageFromStackItem = (stackItem: StackItem): string => {
 };
 
 const extractMessage = (value: Buffer): string => {
-  const stackItems = deserializeStackItem(value)
-    .asArray()[1]
-    .asArray();
+  const stackItems = deserializeStackItem(value).asArray()[1].asArray();
 
   const messages = stackItems.map(extractMessageFromStackItem);
 

--- a/packages/neo-one-client-switch/src/node/tracing.ts
+++ b/packages/neo-one-client-switch/src/node/tracing.ts
@@ -1,7 +1,7 @@
 // tslint:disable: no-let no-any
 import type { Config, Measure, Span, Stats, StatsEventListener, TracerBase } from '@opencensus/core';
-import type {  JaegerTraceExporter, JaegerTraceExporterOptions } from '@opencensus/exporter-jaeger';
-import type { PrometheusExporterOptions,  PrometheusStatsExporter } from '@opencensus/exporter-prometheus';
+import type { JaegerTraceExporter, JaegerTraceExporterOptions } from '@opencensus/exporter-jaeger';
+import type { PrometheusExporterOptions, PrometheusStatsExporter } from '@opencensus/exporter-prometheus';
 import type { TraceContextFormat } from '@opencensus/propagation-tracecontext';
 
 const noOp = (..._args: readonly any[]): any => {
@@ -39,12 +39,12 @@ let tracer: TracerBase = {
 
 // enums copied from types directly
 enum MeasureUnit {
-  UNIT = "1",
-  BYTE = "by",
-  KBYTE = "kb",
-  SEC = "s",
-  MS = "ms",
-  NS = "ns",
+  UNIT = '1',
+  BYTE = 'by',
+  KBYTE = 'kb',
+  SEC = 's',
+  MS = 'ms',
+  NS = 'ns',
 }
 
 enum AggregationType {
@@ -60,7 +60,9 @@ enum SpanKind {
   CLIENT = 2,
 }
 
-let globalStatsCache: Omit<Stats, 'registerExporter'> & {readonly registerExporter?: (listener: StatsEventListener) => void} = {
+let globalStatsCache: Omit<Stats, 'registerExporter'> & {
+  readonly registerExporter?: (listener: StatsEventListener) => void;
+} = {
   createView: noOp,
   registerView: noOp,
   createMeasureDouble: noOp,
@@ -75,7 +77,9 @@ let globalStatsCache: Omit<Stats, 'registerExporter'> & {readonly registerExport
 };
 
 let coreImportCache: Promise<typeof import('@opencensus/core')> | undefined;
-const globalStats: Omit<Stats, 'registerExporter'> & {readonly registerExporter: (listener: StatsEventListener) => Promise<void>}= {
+const globalStats: Omit<Stats, 'registerExporter'> & {
+  readonly registerExporter: (listener: StatsEventListener) => Promise<void>;
+} = {
   createView: globalStatsCache.createView,
   registerView: globalStatsCache.registerView,
   createMeasureDouble: globalStatsCache.createMeasureDouble,
@@ -85,7 +89,7 @@ const globalStats: Omit<Stats, 'registerExporter'> & {readonly registerExporter:
   getMetrics: globalStatsCache.getMetrics,
   registerExporter: async (listener: StatsEventListener) => {
     if (coreImportCache === undefined) {
-      coreImportCache = import('@opencensus/core')
+      coreImportCache = import('@opencensus/core');
     }
 
     if (globalStatsCache.registerExporter === undefined) {
@@ -102,9 +106,7 @@ const globalStats: Omit<Stats, 'registerExporter'> & {readonly registerExporter:
   unregisterExporter: globalStatsCache.unregisterExporter,
   withTagContext: globalStatsCache.withTagContext,
   getCurrentTagContext: globalStatsCache.getCurrentTagContext,
-}
-
-
+};
 
 let TracingBaseCache: Promise<typeof import('@opencensus/nodejs-base')> | undefined;
 const startTracing = async (config: Config) => {
@@ -126,7 +128,6 @@ const startTracing = async (config: Config) => {
   };
 };
 
-
 let TraceContextFormatCache: Promise<typeof import('@opencensus/propagation-tracecontext')> | undefined;
 const getNewPropagation = async (): Promise<TraceContextFormat> => {
   if (TraceContextFormatCache === undefined) {
@@ -138,7 +139,7 @@ const getNewPropagation = async (): Promise<TraceContextFormat> => {
 };
 
 let JaegerTraceExporterCache: Promise<typeof import('@opencensus/exporter-jaeger')> | undefined;
-const getJaegerTraceExporter = async (options: JaegerTraceExporterOptions ): Promise<JaegerTraceExporter> => {
+const getJaegerTraceExporter = async (options: JaegerTraceExporterOptions): Promise<JaegerTraceExporter> => {
   if (JaegerTraceExporterCache === undefined) {
     JaegerTraceExporterCache = import('@opencensus/exporter-jaeger');
   }
@@ -146,28 +147,28 @@ const getJaegerTraceExporter = async (options: JaegerTraceExporterOptions ): Pro
   const { JaegerTraceExporter: ImportedJaegerTraceExporter } = await JaegerTraceExporterCache;
 
   return new ImportedJaegerTraceExporter(options);
-}
+};
 
 let PrometheusExporterCache: Promise<typeof import('@opencensus/exporter-prometheus')> | undefined;
-const getPrometheusExporter = async (options: PrometheusExporterOptions ): Promise<PrometheusStatsExporter> => {
+const getPrometheusExporter = async (options: PrometheusExporterOptions): Promise<PrometheusStatsExporter> => {
   if (PrometheusExporterCache === undefined) {
     PrometheusExporterCache = import('@opencensus/exporter-prometheus');
   }
 
-  const { PrometheusStatsExporter: PrometheusExporter } = await PrometheusExporterCache
+  const { PrometheusStatsExporter: PrometheusExporter } = await PrometheusExporterCache;
 
   return new PrometheusExporter(options);
-}
+};
 
 const getTagMap = async () => {
   if (coreImportCache === undefined) {
-    coreImportCache = import('@opencensus/core')
-  };
+    coreImportCache = import('@opencensus/core');
+  }
 
   const { TagMap: ImportTagMap } = await coreImportCache;
 
   return new ImportTagMap();
-}
+};
 
 export {
   AggregationType,

--- a/packages/neo-one-developer-tools-frame/src/ClientHook.tsx
+++ b/packages/neo-one-developer-tools-frame/src/ClientHook.tsx
@@ -59,9 +59,7 @@ class Hooker {
           id: transaction.hash,
           title: <span data-test="neo-one-transaction-toast-title">Transaction Confirmed</span>,
           message:
-            this.mutableNEOTrackerURL === undefined ? (
-              undefined
-            ) : (
+            this.mutableNEOTrackerURL === undefined ? undefined : (
               <span data-test="neo-one-transaction-toast-message">
                 View on&nbsp;
                 <Link

--- a/packages/neo-one-editor-server/src/resolvePackage.ts
+++ b/packages/neo-one-editor-server/src/resolvePackage.ts
@@ -31,12 +31,7 @@ const getTarballURL = (name: string, version: string) => {
   return `${REGISTRY}${escapedName}/-/${scopelessName}-${version}.tgz`;
 };
 
-const getPath = (path: string) =>
-  nodePath.sep +
-  path
-    .split(nodePath.sep)
-    .slice(1)
-    .join(nodePath.sep);
+const getPath = (path: string) => nodePath.sep + path.split(nodePath.sep).slice(1).join(nodePath.sep);
 
 interface Files {
   readonly [path: string]: Buffer | undefined;
@@ -180,11 +175,7 @@ const getAdditionalStarts = (files: Files, start: string, packageJSON: any) => {
     .filter(
       (file) =>
         file !== start &&
-        ((nodePath.basename(file) === 'index.js' &&
-          !nodePath
-            .dirname(file)
-            .slice(1)
-            .includes('/')) ||
+        ((nodePath.basename(file) === 'index.js' && !nodePath.dirname(file).slice(1).includes('/')) ||
           (!file.slice(1).includes('/') && file.endsWith('.js'))) &&
         nodePath.dirname(file) !== '/src',
     )

--- a/packages/neo-one-editor/src/error/ReactErrorOverlay.ts
+++ b/packages/neo-one-editor/src/error/ReactErrorOverlay.ts
@@ -117,7 +117,7 @@ function update() {
   isLoadingIframe = true;
   const loadingIframe = window.document.createElement('iframe');
   applyStyles(loadingIframe, iframeStyle);
-  loadingIframe.onload = function() {
+  loadingIframe.onload = function () {
     const iframeDocument = loadingIframe.contentDocument;
     if (iframeDocument != null && iframeDocument.body != null) {
       iframe = loadingIframe;

--- a/packages/neo-one-editor/src/error/containers/StackFrameCodeBlock.tsx
+++ b/packages/neo-one-editor/src/error/containers/StackFrameCodeBlock.tsx
@@ -28,7 +28,7 @@ export function StackFrameCodeBlock(props: StackFrameCodeBlockPropsType) {
   const { lines, lineNum, columnNum, contextSize, main } = props;
   const sourceCode: any[] = [];
   let whiteSpace = Infinity;
-  lines.forEach(function(e) {
+  lines.forEach(function (e) {
     const { content: text } = e;
     const m = text.match(/^\s*/);
     if (text === '') {
@@ -40,7 +40,7 @@ export function StackFrameCodeBlock(props: StackFrameCodeBlockPropsType) {
       whiteSpace = 0;
     }
   });
-  lines.forEach(function(e) {
+  lines.forEach(function (e) {
     let { content: text } = e;
     const { lineNumber: line } = e;
 

--- a/packages/neo-one-editor/src/error/map.ts
+++ b/packages/neo-one-editor/src/error/map.ts
@@ -36,14 +36,7 @@ export async function map(
   });
   await Promise.all(
     mutableFiles.map(async (fileName) => {
-      const mod = engine.tryGetModule(
-        fileName.startsWith('http')
-          ? fileName
-              .split('/')
-              .slice(3)
-              .join('/')
-          : fileName,
-      );
+      const mod = engine.tryGetModule(fileName.startsWith('http') ? fileName.split('/').slice(3).join('/') : fileName);
       if (mod !== undefined && mod instanceof TranspiledModule) {
         if (mod.sourceMap !== undefined) {
           const consumer = await new SourceMapConsumer(mod.sourceMap);

--- a/packages/neo-one-editor/src/error/parse.ts
+++ b/packages/neo-one-editor/src/error/parse.ts
@@ -64,10 +64,7 @@ function parseStack(stack: readonly string[]): readonly StackFrame[] {
       if (e.indexOf('(at ') !== -1) {
         e = e.replace(/\(at /, '(');
       }
-      const dataOuter = e
-        .trim()
-        .split(/\s+/g)
-        .slice(1);
+      const dataOuter = e.trim().split(/\s+/g).slice(1);
       // tslint:disable-next-line no-array-mutation
       const lastOuter = dataOuter.pop();
 

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -813,10 +813,7 @@ export class Blockchain {
       .toPromise()
       .then((values) => values.map((value) => value.input));
   private readonly getUnspent = async (hash: UInt160): Promise<readonly Input[]> => {
-    const unspent = await this.accountUnspent
-      .getAll$({ hash })
-      .pipe(toArray())
-      .toPromise();
+    const unspent = await this.accountUnspent.getAll$({ hash }).pipe(toArray()).toPromise();
 
     return unspent.map((value) => value.input);
   };

--- a/packages/neo-one-node-consensus/src/common.ts
+++ b/packages/neo-one-node-consensus/src/common.ts
@@ -335,9 +335,9 @@ export const addTransaction = async ({
   readonly transaction: Transaction;
   readonly verify: boolean;
   readonly consensusContext: ConsensusContext;
-}): Promise<Result<
-  RequestReceivedContext | InitialContext | ViewChangingContext | SignatureSentContext | BlockSentContext
->> => {
+}): Promise<
+  Result<RequestReceivedContext | InitialContext | ViewChangingContext | SignatureSentContext | BlockSentContext>
+> => {
   let context = contextIn;
   const { blockchain } = node;
   const tx = await blockchain.transaction.tryGet({ hash: transaction.hash });

--- a/packages/neo-one-node-core/src/utils/utils.ts
+++ b/packages/neo-one-node-core/src/utils/utils.ts
@@ -128,10 +128,7 @@ function weightedAverage(
     return 0;
   }
 
-  return sumValue
-    .div(sumWeight)
-    .integerValue(BigNumber.ROUND_FLOOR)
-    .toNumber();
+  return sumValue.div(sumWeight).integerValue(BigNumber.ROUND_FLOOR).toNumber();
 }
 
 function weightedFilter<T>(

--- a/packages/neo-one-node-rpc-handler/src/createHandler.ts
+++ b/packages/neo-one-node-rpc-handler/src/createHandler.ts
@@ -534,10 +534,7 @@ export const createHandler = ({
     },
     [RPC_METHODS.getallstorage]: async (args) => {
       const hash = JSONHelper.readUInt160(args[0]);
-      const items = await blockchain.storageItem
-        .getAll$({ hash })
-        .pipe(toArray())
-        .toPromise();
+      const items = await blockchain.storageItem.getAll$({ hash }).pipe(toArray()).toPromise();
 
       return items.map((item) => item.serializeJSON(blockchain.serializeJSONContext));
     },

--- a/packages/neo-one-node-tools/src/cmd.ts
+++ b/packages/neo-one-node-tools/src/cmd.ts
@@ -8,11 +8,7 @@ const start = createStart(createChild(nodeLogger, { service: 'node-restore' }));
 export const command = 'node-restore';
 export const describe = 'restore node data from google bucket';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder
-    .string('path')
-    .string('bucket')
-    .string('folder')
-    .demandOption(['path', 'bucket', 'folder']);
+  yargsBuilder.string('path').string('bucket').string('folder').demandOption(['path', 'bucket', 'folder']);
 export const handler = ({ path, bucket, folder }: Yarguments<ReturnType<typeof builder>>) => {
   start(async () => {
     const restoreFunc = await restore({ path, bucket, folder });

--- a/packages/neo-one-node-tools/src/restore.ts
+++ b/packages/neo-one-node-tools/src/restore.ts
@@ -42,10 +42,7 @@ const getLocalMTime = async (path: string) => {
 const getCloudMTime = async (bucket: string, folder: string) => {
   const storage = new Storage();
 
-  const [metadata] = await storage
-    .bucket(bucket)
-    .file(nodePath.join(folder, 'LOG'))
-    .getMetadata();
+  const [metadata] = await storage.bucket(bucket).file(nodePath.join(folder, 'LOG')).getMetadata();
 
   return new Date(metadata.updated);
 };

--- a/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/opcodes.test.ts
@@ -448,10 +448,7 @@ const OPCODES = ([
         args: [new BN(5), new BN(7)],
         result: [new IntegerStackItem(new BN(5)), new IntegerStackItem(new BN(12))],
         // CALL_I ADD RET ADD RET
-        gas: FEES.ONE.add(FEES.ONE)
-          .add(FEES.ONE)
-          .add(FEES.ONE)
-          .add(FEES.ONE),
+        gas: FEES.ONE.add(FEES.ONE).add(FEES.ONE).add(FEES.ONE).add(FEES.ONE),
       },
 
       {
@@ -463,10 +460,7 @@ const OPCODES = ([
         args: [new BN(5), new BN(7)],
         result: [new IntegerStackItem(new BN(5))],
         // CALL_I ADD RET ADD RET
-        gas: FEES.ONE.add(FEES.ONE)
-          .add(FEES.ONE)
-          .add(FEES.ONE)
-          .add(FEES.ONE),
+        gas: FEES.ONE.add(FEES.ONE).add(FEES.ONE).add(FEES.ONE).add(FEES.ONE),
       },
 
       // RET is tested above

--- a/packages/neo-one-node-vm/src/__tests__/syscalls.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/syscalls.test.ts
@@ -233,10 +233,7 @@ const SYSCALLS = [
     name: 'Neo.Runtime.Serialize',
     result: [
       new BufferStackItem(
-        new BinaryWriter()
-          .writeUInt8(StackItemType.ByteArray)
-          .writeVarBytesLE(Buffer.alloc(10, 1))
-          .toBuffer(),
+        new BinaryWriter().writeUInt8(StackItemType.ByteArray).writeVarBytesLE(Buffer.alloc(10, 1)).toBuffer(),
       ),
     ],
 
@@ -248,10 +245,7 @@ const SYSCALLS = [
     name: 'Neo.Runtime.Serialize',
     result: [
       new BufferStackItem(
-        new BinaryWriter()
-          .writeUInt8(StackItemType.ByteArray)
-          .writeVarBytesLE(Buffer.alloc(10, 1))
-          .toBuffer(),
+        new BinaryWriter().writeUInt8(StackItemType.ByteArray).writeVarBytesLE(Buffer.alloc(10, 1)).toBuffer(),
       ),
     ],
 
@@ -265,10 +259,7 @@ const SYSCALLS = [
     name: 'Neo.Runtime.Serialize',
     result: [
       new BufferStackItem(
-        new BinaryWriter()
-          .writeUInt8(StackItemType.Integer)
-          .writeVarBytesLE(Buffer.alloc(1, 1))
-          .toBuffer(),
+        new BinaryWriter().writeUInt8(StackItemType.Integer).writeVarBytesLE(Buffer.alloc(1, 1)).toBuffer(),
       ),
     ],
 
@@ -373,12 +364,7 @@ const SYSCALLS = [
   {
     name: 'Neo.Runtime.Deserialize',
     result: [new BufferStackItem(Buffer.alloc(10, 1))],
-    args: [
-      new BinaryWriter()
-        .writeUInt8(StackItemType.ByteArray)
-        .writeVarBytesLE(Buffer.alloc(10, 1))
-        .toBuffer(),
-    ],
+    args: [new BinaryWriter().writeUInt8(StackItemType.ByteArray).writeVarBytesLE(Buffer.alloc(10, 1)).toBuffer()],
 
     gas: FEES.ONE,
   },
@@ -407,10 +393,7 @@ const SYSCALLS = [
         .writeUInt8(StackItemType.Map)
         .writeVarUIntLE(1)
         .writeBytes(
-          new BinaryWriter()
-            .writeUInt8(StackItemType.ByteArray)
-            .writeVarBytesLE(Buffer.from('key', 'utf8'))
-            .toBuffer(),
+          new BinaryWriter().writeUInt8(StackItemType.ByteArray).writeVarBytesLE(Buffer.from('key', 'utf8')).toBuffer(),
         )
         .writeBytes(
           new BinaryWriter()

--- a/packages/neo-one-node-vm/src/opcodes.ts
+++ b/packages/neo-one-node-vm/src/opcodes.ts
@@ -736,10 +736,7 @@ const OPCODE_PAIRS = ([
           return {
             context: {
               ...context,
-              stack: stack
-                .slice(0, n)
-                .concat([stack[0]])
-                .concat(stack.slice(n)),
+              stack: stack.slice(0, n).concat([stack[0]]).concat(stack.slice(n)),
               stackCount: context.stackCount + stack[0].increment(),
             },
           };

--- a/packages/neo-one-smart-contract-codegen/package.json
+++ b/packages/neo-one-smart-contract-codegen/package.json
@@ -17,7 +17,7 @@
     "@neo-one/client-core": "^2.5.0",
     "@neo-one/utils": "^2.4.0",
     "lodash": "^4.17.15",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.1",
     "safe-stable-stringify": "^1.1.0",
     "source-map": "^0.7.3",
     "tslib": "^1.10.0"

--- a/packages/neo-one-smart-contract-compiler/src/__data__/snippets/import/qux.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__data__/snippets/import/qux.ts
@@ -4,6 +4,6 @@ export function value() {
   return val;
 }
 // tslint:disable-next-line no-default-export
-export default function() {
+export default function () {
   val += 1;
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/sb/BaseScriptBuilder.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/sb/BaseScriptBuilder.ts
@@ -567,32 +567,11 @@ export abstract class BaseScriptBuilder<TScope extends Scope> implements ScriptB
     if (value.length <= Op.PUSHBYTES75) {
       this.emitOpByte(node, value.length, value);
     } else if (value.length < 0x100) {
-      this.emitOp(
-        node,
-        'PUSHDATA1',
-        new ClientScriptBuilder()
-          .emitUInt8(value.length)
-          .emit(value)
-          .build(),
-      );
+      this.emitOp(node, 'PUSHDATA1', new ClientScriptBuilder().emitUInt8(value.length).emit(value).build());
     } else if (value.length < 0x10000) {
-      this.emitOp(
-        node,
-        'PUSHDATA2',
-        new ClientScriptBuilder()
-          .emitUInt16LE(value.length)
-          .emit(value)
-          .build(),
-      );
+      this.emitOp(node, 'PUSHDATA2', new ClientScriptBuilder().emitUInt16LE(value.length).emit(value).build());
     } else if (value.length < 0x100000000) {
-      this.emitOp(
-        node,
-        'PUSHDATA4',
-        new ClientScriptBuilder()
-          .emitUInt32LE(value.length)
-          .emit(value)
-          .build(),
-      );
+      this.emitOp(node, 'PUSHDATA4', new ClientScriptBuilder().emitUInt32LE(value.length).emit(value).build());
     } else {
       throw new Error('Value too large.');
     }

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/entry.ts
@@ -3,7 +3,7 @@ import * as bar from './bar';
 import baz from './baz';
 import { foo } from './foo';
 import { Address, foo as foo2, Foo2SmartContract, SmartContract } from './foo2';
-import type { MyType } from './onlyTypes'
+import type { MyType } from './onlyTypes';
 import incrementValue, { value } from './qux';
 import { FooType } from './type';
 

--- a/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/qux.ts
+++ b/packages/neo-one-typescript-concatenator/src/__data__/snippets/import/qux.ts
@@ -4,6 +4,6 @@ export function value() {
   return val;
 }
 // tslint:disable-next-line no-default-export
-export default function() {
+export default function () {
   val += 1;
 }

--- a/packages/neo-one-website/src/elements/markdownTOC.ts
+++ b/packages/neo-one-website/src/elements/markdownTOC.ts
@@ -1,12 +1,6 @@
 // tslint:disable
 
-const slugify = (s: any) =>
-  encodeURIComponent(
-    String(s)
-      .trim()
-      .toLowerCase()
-      .replace(/\s+/g, '-'),
-  );
+const slugify = (s: any) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'));
 const defaults = {
   includeLevel: [1, 2],
   containerClass: 'table-of-contents',
@@ -49,7 +43,7 @@ export const markdownTOC = (md: any, o: any) => {
     match = tocRegexp.exec(state.src.substr(state.pos));
     match = !match
       ? []
-      : match.filter(function(m: any) {
+      : match.filter(function (m: any) {
           return m;
         });
     if (match.length < 1) {
@@ -76,7 +70,7 @@ export const markdownTOC = (md: any, o: any) => {
     return true;
   }
 
-  md.renderer.rules[open] = function() {
+  md.renderer.rules[open] = function () {
     var tocOpenHtml = `<div class="${options.containerClass}">`;
 
     if (options.containerHeaderHtml) {
@@ -86,7 +80,7 @@ export const markdownTOC = (md: any, o: any) => {
     return tocOpenHtml;
   };
 
-  md.renderer.rules[close] = function() {
+  md.renderer.rules[close] = function () {
     var tocFooterHtml = '';
 
     if (options.containerFooterHtml) {
@@ -96,7 +90,7 @@ export const markdownTOC = (md: any, o: any) => {
     return tocFooterHtml + `</div>`;
   };
 
-  md.renderer.rules[body] = function() {
+  md.renderer.rules[body] = function () {
     if (options.forceFullToc) {
       /*
 
@@ -186,7 +180,7 @@ export const markdownTOC = (md: any, o: any) => {
   }
 
   // Catch all the tokens for iteration later
-  md.core.ruler.push('grab_state', function(state: any) {
+  md.core.ruler.push('grab_state', function (state: any) {
     if (gstate === undefined) {
       gstate = state;
     }

--- a/packages/neo-one-website/src/utils/dgeniSetup.ts
+++ b/packages/neo-one-website/src/utils/dgeniSetup.ts
@@ -27,7 +27,7 @@ const docFiles: readonly string[] = [
 // Configuration of the typescript processor
 (typescript as any)
   // Configure additional jsdoc style tags to be recognized by the processor
-  .config(function(parseTagsProcessor: any) {
+  .config(function (parseTagsProcessor: any) {
     const tagDefs = parseTagsProcessor.tagDefinitions;
     // Register '@example' tags with the processor. Multiple instances allowed.
     tagDefs.push({ name: 'example', multi: true });
@@ -37,7 +37,7 @@ const docFiles: readonly string[] = [
     tagDefs.push({ name: 'internal' });
   })
   // Configure output paths for additional doc types
-  .config(function(computeIdsProcessor: any, computePathsProcessor: any) {
+  .config(function (computeIdsProcessor: any, computePathsProcessor: any) {
     // Configure ID for "getters". Must be manually configured to avoid potential conflict with a property.
     computeIdsProcessor.idTemplates.push({
       docTypes: ['get-accessor-info'],
@@ -75,7 +75,12 @@ export const dgeniSetup = new Package('neo-one-docs', [
   // Register our custom processor for our specific use case.
   .processor(textProcessor)
   // Configure subprocessors from typescript and nunjucks
-  .config(function(readFilesProcessor: any, readTypeScriptModules: any, templateFinder: any, writeFilesProcessor: any) {
+  .config(function (
+    readFilesProcessor: any,
+    readTypeScriptModules: any,
+    templateFinder: any,
+    writeFilesProcessor: any,
+  ) {
     // Register basePath used for resolving paths to typescript files to parse.
     readTypeScriptModules.basePath = path.resolve(__dirname, '../../..');
     // Register basePath used for resolving paths to javascript files to parse. Unused in our case, but needs to exist.

--- a/packages/neo-one-worker/src/comlink.ts
+++ b/packages/neo-one-worker/src/comlink.ts
@@ -180,7 +180,7 @@ export function expose(rootObj: Exposable, endpoint: Endpoint | Window): void {
     throw Error('endpoint does not have all of addEventListener, removeEventListener and postMessage defined');
 
   activateEndpoint(endpoint);
-  attachMessageHandler(endpoint, async function(event: MessageEvent) {
+  attachMessageHandler(endpoint, async function (event: MessageEvent) {
     if (!event.data.id || !event.data.callPath) return;
     let iresult;
     const irequest = event.data as InvocationRequest;
@@ -363,7 +363,7 @@ function pingPongMessage(endpoint: Endpoint, msg: Object, transferables: Transfe
   });
 }
 
-function cbProxy(cb: CBProxyCallback, callPath: PropertyKey[] = [], target = function() {}): Proxy {
+function cbProxy(cb: CBProxyCallback, callPath: PropertyKey[] = [], target = function () {}): Proxy {
   return new Proxy(target, {
     construct(_target, argumentsList, proxy) {
       return cb({


### PR DESCRIPTION
### Description of the Change

We need to upgrade Prettier so that Prettier can support and recognize the latest TS v3.8 and beyond.

### Benefits

We'll resume passing the `rush nit` check.

### Possible Drawbacks

Unfortunately (in my opinion) they changed how single-line method chains are handled. Look at the changes, which were made by running `rush prettier`, and you'll see what I'm talking about. Places where chained methods were stacked are now back to a single line. I personally hate this. It's so bad. I thought something was wrong with my setup. So I dug a bit deeper and apparently some people were actively pushing for this change, which they actually went through with. See [here](https://github.com/prettier/prettier/issues/4125) and [here](https://github.com/prettier/prettier/issues/3107). I didn't dig much deeper than that. Perhaps there are issues open or we want to open an issue to get them to provide an option for this? Perhaps it doesn't matter that much? Note that `rush nit` fails, even if you try to keep the method chains on multiple lines. I think we have to live with it for now.

Another drawback. It seems that the VS Code extension is not yet updated, so it follows old behavior. So the format-on-save will be incorrect until the update the extension, which I can't imagine far behind.

Update: It looks like maybe they're going to work to improve this behavior. [Here](https://github.com/prettier/prettier/pull/6685).

### Applicable Issues

#1889 
