### PR TITLE
feat(compiler): add support for outputting compiled contracts

### DIFF
--- a/common/changes/@neo-one/cli/compiler_2020-04-13-22-53.json
+++ b/common/changes/@neo-one/cli/compiler_2020-04-13-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "add 'compile' command to cli",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "danwbyrne@gmail.com"
+}

--- a/packages/neo-one-cli/src/cmd/compile.ts
+++ b/packages/neo-one-cli/src/cmd/compile.ts
@@ -1,0 +1,20 @@
+import { Yarguments } from '@neo-one/utils-node';
+import yargs from 'yargs';
+import { start } from '../common';
+import { createTasks } from '../compile';
+
+export const command = 'compile';
+export const describe = 'compile a project and output code to a local directory';
+export const builder = (yargsBuilder: typeof yargs) =>
+  yargsBuilder
+    .string('outDir')
+    .describe('outDir', 'output code directory')
+    .default('outDir', './')
+    .string('path')
+    .describe('path', 'contract directory');
+
+export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
+  start(async (_cmd, config) => {
+    await createTasks(argv.path ? argv.path : config.contracts.path, argv.outDir).run();
+  });
+};

--- a/packages/neo-one-cli/src/cmd/index.ts
+++ b/packages/neo-one-cli/src/cmd/index.ts
@@ -1,5 +1,6 @@
 import yargs from 'yargs';
 import * as build from './build';
+import * as compile from './compile';
 import * as consoleCmd from './console';
 import * as convert from './convert';
 import * as deploy from './deploy';
@@ -21,4 +22,5 @@ export const builder = (yargsBuilder: typeof yargs) =>
     .command(consoleCmd)
     .command(deploy)
     .command(info)
+    .command(compile)
     .command(init);

--- a/packages/neo-one-cli/src/compile/compileContract.ts
+++ b/packages/neo-one-cli/src/compile/compileContract.ts
@@ -1,0 +1,37 @@
+import { common, crypto, scriptHashToAddress, SourceMaps } from '@neo-one/client-common';
+import { compileContract as compileContractInternal, LinkedContracts } from '@neo-one/smart-contract-compiler';
+import { createCompilerHost } from '@neo-one/smart-contract-compiler-node';
+import { DiagnosticCategory } from 'typescript';
+
+export const compileContract = async (
+  filePath: string,
+  name: string,
+  linked: LinkedContracts,
+  sourceMaps: SourceMaps,
+) => {
+  const contract = compileContractInternal(filePath, name, createCompilerHost(), linked);
+  if (contract.diagnostics.some((diagnostic) => diagnostic.category === DiagnosticCategory.Error)) {
+    throw new Error('Compilation error.');
+  }
+
+  const address = scriptHashToAddress(
+    common.uInt160ToString(crypto.toScriptHash(Buffer.from(contract.contract.script, 'hex'))),
+  );
+  const sourceMap = await contract.sourceMap;
+  const nextSourceMaps = {
+    ...sourceMaps,
+    [address]: sourceMap,
+  };
+
+  return {
+    contract,
+    sourceMap,
+    sourceMaps: nextSourceMaps,
+    linked: {
+      ...linked,
+      [filePath]: {
+        [name]: address,
+      },
+    },
+  };
+};

--- a/packages/neo-one-cli/src/compile/createTasks.ts
+++ b/packages/neo-one-cli/src/compile/createTasks.ts
@@ -1,0 +1,45 @@
+// tslint:disable no-object-mutation
+import { Contracts } from '@neo-one/smart-contract-compiler';
+import Listr from 'listr';
+import { compileContract } from './compileContract';
+import { findContracts } from './findContracts';
+import { writeContract } from './writeContract';
+
+export const createTasks = (path: string, outDir: string) =>
+  new Listr([
+    {
+      title: 'Find Contracts',
+      task: async (ctx) => {
+        const contracts = await findContracts(path);
+
+        ctx.foundContracts = contracts;
+      },
+    },
+    {
+      title: 'Compile Contracts',
+      task: (ctx) => {
+        ctx.linked = {};
+        ctx.sourceMaps = {};
+        ctx.contracts = [];
+
+        return new Listr(
+          (ctx.foundContracts as Contracts).map((contract) => ({
+            title: `Compile ${contract.name}`,
+            task: async (innerCtx) => {
+              const { linked, sourceMaps, contract: result } = await compileContract(
+                contract.filePath,
+                contract.name,
+                innerCtx.linked,
+                innerCtx.sourceMaps,
+              );
+
+              await writeContract(result, outDir);
+
+              innerCtx.linked = linked;
+              innerCtx.sourceMaps = sourceMaps;
+            },
+          })),
+        );
+      },
+    },
+  ]);

--- a/packages/neo-one-cli/src/compile/findContracts.ts
+++ b/packages/neo-one-cli/src/compile/findContracts.ts
@@ -1,0 +1,4 @@
+import { Contracts, scan } from '@neo-one/smart-contract-compiler';
+import { createCompilerHost } from '@neo-one/smart-contract-compiler-node';
+
+export const findContracts = async (path: string): Promise<Contracts> => scan(path, createCompilerHost());

--- a/packages/neo-one-cli/src/compile/index.ts
+++ b/packages/neo-one-cli/src/compile/index.ts
@@ -1,0 +1,1 @@
+export * from './createTasks';

--- a/packages/neo-one-cli/src/compile/writeContract.ts
+++ b/packages/neo-one-cli/src/compile/writeContract.ts
@@ -1,0 +1,12 @@
+import { CompileContractResult } from '@neo-one/smart-contract-compiler';
+import fs from 'fs-extra';
+import path from 'path';
+
+export const writeContract = async (contract: CompileContractResult, outDir: string) => {
+  await fs.ensureDir(outDir);
+  const outputPath = path.resolve(outDir, `${contract.contract.name}.contract.json`);
+
+  const contractJSON = JSON.stringify(contract, undefined, 2);
+
+  return fs.writeFile(outputPath, contractJSON);
+};


### PR DESCRIPTION
### Description of the Change

Adds support for outputting compiled contract information to file. The new cli command is `compile` and has 2 flags `--path` the directory of source contracts and `--outDir` to output.

### Test Plan

You can test this by running
```
rush build
node packages/neo-one-cli/bin/neo-one compile --path <testContractDir> --outDir ./testDir
```
there are example contract projects in the `__data__` folder of `neo-one-cli`.

### Alternate Designs
Right now we just output the result of our compilation to a `.json` file but we could change the format of the output depending on what the community needs.

### Benefits

Should make the typescript compiler more usable for third parties that don't require the entire `neo-one` suite.