### PR TITLE
fix(bug): NEODataProvider with Agency preview contracts

### DIFF
--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -428,3 +428,18 @@ export interface NeoUnspentJSON {
   readonly balance: readonly NeoBalanceJSON[];
   readonly address: string;
 }
+
+export interface NeoPreviewContractJSON {
+  readonly name: string;
+  readonly version: string;
+  readonly author: string;
+  readonly email: string;
+  readonly description: string;
+  readonly code: {
+    readonly hash: string;
+    readonly script: string;
+    readonly parameters: readonly ContractParameterTypeJSON[];
+    readonly returntype: ContractParameterTypeJSON;
+  };
+  readonly needstorage: boolean;
+}

--- a/packages/neo-one-client-core/src/provider/convert.ts
+++ b/packages/neo-one-client-core/src/provider/convert.ts
@@ -24,6 +24,7 @@ import {
   InvocationResultJSON,
   InvocationTransactionJSON,
   JSONHelper,
+  NeoPreviewContractJSON,
   NetworkSettings,
   NetworkSettingsJSON,
   Output,
@@ -287,7 +288,14 @@ export function convertAsset(asset: AssetJSON): Asset {
   };
 }
 
-export function convertContract(contract: ContractJSON): Contract {
+export function convertContract(contractIn: ContractJSON): Contract {
+  let contract = contractIn;
+  // tslint:disable-next-line no-any
+  if (typeof (contract.version as any) === 'string' && (contract.version as any).includes('preview')) {
+    // tslint:disable-next-line no-any
+    contract = convertPreviewContract(contract as any);
+  }
+
   return {
     version: contract.version,
     address: scriptHashToAddress(contract.hash),
@@ -302,6 +310,26 @@ export function convertContract(contract: ContractJSON): Contract {
     storage: contract.properties.storage,
     dynamicInvoke: contract.properties.dynamic_invoke,
     payable: contract.properties.payable,
+  };
+}
+
+export function convertPreviewContract(contract: NeoPreviewContractJSON): ContractJSON {
+  return {
+    version: 0,
+    hash: contract.code.hash,
+    script: contract.code.script,
+    parameters: contract.code.parameters,
+    returntype: contract.code.returntype,
+    name: contract.name,
+    code_version: 'preview',
+    author: contract.author,
+    email: contract.email,
+    description: contract.description,
+    properties: {
+      storage: contract.needstorage,
+      dynamic_invoke: false,
+      payable: false,
+    },
   };
 }
 


### PR DESCRIPTION
### Description of the Change
The first two contracts published to the neo blockchain have a slightly different structure since they were preview versions.  See, the first two contracts here: https://neotracker.io/browse/contract/10 .
Created a special case which converts the preview contract into a standard ContractJSON format.  This should allow the scraper on neotracker to properly scrape these contracts.

### Test Plan
Tested the getBlock method on the blocks which contain the preview contract publishes on blocks: 1,107,681 and 917083.
