### PR TITLE
fix(nit): NEO tracker to NEO Tracker

### DIFF
--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -211,11 +211,11 @@ ${exportConfig} {
   // Refer to the documentation at https://neo-one.io/docs/configuration for more information.
   networks: defaultNetworks,
   neotracker: {
-    // NEO•ONE will start an instance of NEO tracker using this path for local data. This directory should not be committed.
+    // NEO•ONE will start an instance of NEO Tracker using this path for local data. This directory should not be committed.
     path: '${config.neotracker.path}',
-    // NEO•ONE will start an instance of NEO tracker using this port.
+    // NEO•ONE will start an instance of NEO Tracker using this port.
     port: 9041,
-    // Set to true if you'd like NEO•ONE to skip starting a NEO tracker instance when running 'neo-one build'.
+    // Set to true if you'd like NEO•ONE to skip starting a NEO Tracker instance when running 'neo-one build'.
     skip: false,
   }
 };

--- a/packages/neo-one-cli/src/cmd/start/neotracker.ts
+++ b/packages/neo-one-cli/src/cmd/start/neotracker.ts
@@ -8,9 +8,9 @@ import { findKillProcess } from '../../utils';
 import { writePidFile } from './writePidFile';
 
 export const command = 'neotracker';
-export const describe = 'Start a NEO tracker instance using the project configuration.';
+export const describe = 'Start a NEO Tracker instance using the project configuration.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder.boolean('reset').describe('reset', 'Reset the NEO tracker database.').default('reset', false);
+  yargsBuilder.boolean('reset').describe('reset', 'Reset the NEO Tracker database.').default('reset', false);
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const running = await isRunning(config.neotracker.port);
@@ -18,7 +18,7 @@ export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
       if (argv.reset) {
         await findKillProcess('neotracker', config);
       } else {
-        cliLogger.info('NEO tracker is already running');
+        cliLogger.info('NEO Tracker is already running');
 
         return undefined;
       }

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -929,7 +929,7 @@ export interface DeveloperProvider {
    */
   readonly reset: () => Promise<void>;
   /**
-   * Fetch the NEO tracker URL for the project.
+   * Fetch the NEO Tracker URL for the project.
    */
   readonly getNEOTrackerURL: () => Promise<string | undefined>;
   /**

--- a/packages/neo-one-client-core/src/DeveloperClient.ts
+++ b/packages/neo-one-client-core/src/DeveloperClient.ts
@@ -60,7 +60,7 @@ export class DeveloperClient {
   }
 
   /**
-   * Fetch the NEO tracker URL for the project.
+   * Fetch the NEO Tracker URL for the project.
    */
   public async getNEOTrackerURL(): Promise<string | undefined> {
     return this.developerProvider.getNEOTrackerURL();

--- a/packages/neo-one-website/docs/1-main-concepts/10-testing.md
+++ b/packages/neo-one-website/docs/1-main-concepts/10-testing.md
@@ -155,7 +155,7 @@ describe('Token', () => {
 - `reset(): Promise<void>` - reset the local network to it's initial state starting at the genesis block.
 - `getSettings(): Promise<PrivateNetworkSettings>` - Get the current settings of the private network.
 - `updateSettings(options: Partial<PrivateNetworkSettings>): Promise<void>` - update settings for the private network. Currently only has a property for controlling the seconds per block.
-- `getNEOTrackerURL(): Promise<string | undefined>` - fetches the NEO tracker URL for the project.
+- `getNEOTrackerURL(): Promise<string | undefined>` - fetches the NEO Tracker URL for the project.
 
 Putting it all together, we might test a time dependent ICO contract like so:
 

--- a/packages/neo-one-website/docs/2-advanced-guides/09-configuration-options.md
+++ b/packages/neo-one-website/docs/2-advanced-guides/09-configuration-options.md
@@ -53,11 +53,11 @@ export default {
   // Refer to the documentation at https://neo-one.io/docs/configuration for more information.
   networks: defaultNetworks,
   neotracker: {
-    // NEO•ONE will start an instance of NEO tracker using this path for local data. This directory should not be committed.
+    // NEO•ONE will start an instance of NEO Tracker using this path for local data. This directory should not be committed.
     path: '.neo-one/neotracker',
-    // NEO•ONE will start an instance of NEO tracker using this port.
+    // NEO•ONE will start an instance of NEO Tracker using this port.
     port: 9041,
-    // Set to true if you'd like NEO•ONE to skip starting a NEO tracker instance when running 'neo-one build'.
+    // Set to true if you'd like NEO•ONE to skip starting a NEO Tracker instance when running 'neo-one build'.
     skip: false,
   },
 };


### PR DESCRIPTION
### Description of the Change

Just changes any reference to "NEO tracker" to the correct "NEO Tracker" to keep NEO Tracker branding consistent.