### PR TITLE
fix(cli): change default network paths to neotracker/local

### DIFF
--- a/common/changes/@neo-one/cli-common-node/update-networks_2020-05-27-22-10.json
+++ b/common/changes/@neo-one/cli-common-node/update-networks_2020-05-27-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli-common-node",
+      "comment": "update defaultNetworks to live nodes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/cli-common-node",
+  "email": "danwbyrne@gmail.com"
+}

--- a/packages/neo-one-cli-common-node/src/networks.ts
+++ b/packages/neo-one-cli-common-node/src/networks.ts
@@ -21,12 +21,12 @@ const createUserAccountProviderFunc = (network: string, rpcURL: string) => async
 // tslint:disable-next-line export-name
 export const defaultNetworks = {
   main: {
-    userAccountProvider: createUserAccountProviderFunc('main', 'https://main.neo-one.io/rpc'),
+    userAccountProvider: createUserAccountProviderFunc('main', 'https://neotracker.io/rpc'),
   },
   test: {
-    userAccountProvider: createUserAccountProviderFunc('test', 'https://test.neo-one.io/rpc'),
+    userAccountProvider: createUserAccountProviderFunc('test', 'https://testnet.neotracker.io/rpc'),
   },
-  neoOne: {
-    userAccountProvider: createUserAccountProviderFunc('neo-one', 'https://neo-one.neo-one.io/rpc'),
+  local: {
+    userAccountProvider: createUserAccountProviderFunc('neo-one', 'localhost:9040'),
   },
 };


### PR DESCRIPTION
fixes #2033 

new default networks are `main` \ `test` \ `local` for neotracker.io/rpc, testnet.neotracker.io/rpc, localhost:9040 respectively.