### PR TITLE
fix(docs): fixup test snapshots / update CI glob path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ aliases:
           at: ./
       - run:
           name: Test
-          command: node common/scripts/install-run-rush.js test-ci --test-path-pattern '$(circleci tests glob packages/*/src/__tests__/**/*.test.ts)' --coverage
+          command: node common/scripts/install-run-rush.js test-ci --test-path-pattern '$(circleci tests glob packages/*/src/__tests__/**.test.ts)' --coverage
       - run:
           name: Upload Unit Test Coverage
           command: node common/scripts/install-run-rush.js upload-coverage -F unit
@@ -118,7 +118,7 @@ aliases:
           at: ./
       - run:
           name: Test
-          command: node common/scripts/install-run-rush.js test-ci --test-path-pattern '$(circleci tests glob packages/*/src/__tests__/**/*.test.ts)' --coverage
+          command: node common/scripts/install-run-rush.js test-ci --test-path-pattern '$(circleci tests glob packages/*/src/__tests__/**.test.ts)' --coverage
       - run:
           name: Upload Unit Test Coverage
           command: node common/scripts/install-run-rush.js upload-coverage -F unit

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonBrowserFiles.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonBrowserFiles.test.ts.snap
@@ -216,7 +216,7 @@ export interface Contracts<TClient extends Client = Client> {
   readonly ico: ICOSmartContract<TClient>;
   readonly token: TokenSmartContract<TClient>;
 }
-
+// Refer to the MigrationSmartContract documentation at https://neo-one.io/docs/deployment for more information.
 export interface MigrationContracts {
   readonly ico: ICOMigrationSmartContract;
   readonly token: TokenMigrationSmartContract;

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/__snapshots__/genCommonFiles.test.ts.snap
@@ -272,7 +272,7 @@ export interface Contracts<TClient extends Client = Client> {
   readonly ico: ICOSmartContract<TClient>;
   readonly token: TokenSmartContract<TClient>;
 }
-
+// Refer to the MigrationSmartContract documentation at https://neo-one.io/docs/deployment for more information.
 export interface MigrationContracts {
   readonly ico: ICOMigrationSmartContract;
   readonly token: TokenMigrationSmartContract;

--- a/packages/neo-one-smart-contract-codegen/src/__tests__/contracts/__snapshots__/genContracts.test.ts.snap
+++ b/packages/neo-one-smart-contract-codegen/src/__tests__/contracts/__snapshots__/genContracts.test.ts.snap
@@ -22,7 +22,7 @@ export interface Contracts<TClient extends Client = Client> {
   readonly ico: ICOSmartContract<TClient>;
   readonly token: TokenSmartContract<TClient>;
 }
-
+// Refer to the MigrationSmartContract documentation at https://neo-one.io/docs/deployment for more information.
 export interface MigrationContracts {
   readonly ico: ICOMigrationSmartContract;
   readonly token: TokenMigrationSmartContract;


### PR DESCRIPTION
fixup snapshots that weren't updated from #2053

Also, the CI test path pattern has been wrong for awhile now, because of the difference in glob patterns `__tests__/**/*.test.ts` resolved to *ONLY* paths that were 1 folder after `__tests__` (d'oh!)