### PR TITLE
fix(CI): update blockchain.test.ts

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
@@ -61,7 +61,7 @@ describe('Blockchain', () => {
       assertEqual(transaction.type, TransactionType.Invocation);
 
       const attributes = transaction.attributes;
-      assertEqual(attributes.length, 3);
+      assertEqual(attributes.length, 4);
 
       const attribute = attributes[0];
 


### PR DESCRIPTION
This is just a test case that needed to be updated after the changes Frag made. InvocationTransactions only had 3 attributes before but now with the recent changes it looks like that has changed to 4. I suspect this is because we didn't need one of the attributes when using just our node solution but the NEOProvider does so it makes more sense to update the whole model.

I tested this externally as well to see how many attributes a simple transaction had using the `HelloWorld` contract and it is definitely 4.