### PR TITLE
fix(cli): make cli command info syntax consistent

### DIFF
--- a/packages/neo-one-cli/src/cmd/compile.ts
+++ b/packages/neo-one-cli/src/cmd/compile.ts
@@ -4,7 +4,7 @@ import { start } from '../common';
 import { createTasks } from '../compile';
 
 export const command = 'compile';
-export const describe = 'compile a project and output code to a local directory';
+export const describe = 'Compiles a project and outputs code to a local directory.';
 export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder
     .string('outDir')

--- a/packages/neo-one-cli/src/cmd/convert/index.ts
+++ b/packages/neo-one-cli/src/cmd/convert/index.ts
@@ -6,6 +6,6 @@ import * as scriptHash from './scriptHash';
 import * as wif from './wif';
 
 export const command = 'convert';
-export const describe = 'Convert values.';
+export const describe = 'Converts values.';
 export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder.command(address).command(privateKey).command(publicKey).command(scriptHash).command(wif);

--- a/packages/neo-one-cli/src/cmd/new/index.ts
+++ b/packages/neo-one-cli/src/cmd/new/index.ts
@@ -2,5 +2,5 @@ import yargs from 'yargs';
 import * as privateKey from './privateKey';
 
 export const command = 'new';
-export const describe = 'Create new resources.';
+export const describe = 'Creates new resources.';
 export const builder = (yargsBuilder: typeof yargs) => yargsBuilder.command(privateKey);

--- a/packages/neo-one-cli/src/cmd/start/index.ts
+++ b/packages/neo-one-cli/src/cmd/start/index.ts
@@ -3,5 +3,5 @@ import * as neotracker from './neotracker';
 import * as network from './network';
 
 export const command = 'start';
-export const describe = 'Start NEO•ONE services.';
+export const describe = 'Starts NEO•ONE services.';
 export const builder = (yargsBuilder: typeof yargs) => yargsBuilder.command(network).command(neotracker);

--- a/packages/neo-one-cli/src/cmd/stop/index.ts
+++ b/packages/neo-one-cli/src/cmd/stop/index.ts
@@ -3,5 +3,5 @@ import * as neotracker from './neotracker';
 import * as network from './network';
 
 export const command = 'stop';
-export const describe = 'Stop NEO•ONE services.';
+export const describe = 'Stops NEO•ONE services.';
 export const builder = (yargsBuilder: typeof yargs) => yargsBuilder.command(network).command(neotracker);


### PR DESCRIPTION
### Description of the Change

Just makes our CLI command descriptions use consistent and correct grammar.
