### PR TITLE
feat(e2e): add init e2e tests

### DIFF
--- a/common/changes/@neo-one/cli/init-e2e_2020-06-16-23-17.json
+++ b/common/changes/@neo-one/cli/init-e2e_2020-06-16-23-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "Add E2E test for neo-one init command.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/packages/neo-one-build-tests/environments/e2e/jestSetup.js
+++ b/packages/neo-one-build-tests/environments/e2e/jestSetup.js
@@ -11,6 +11,7 @@ jest.retryTimes(2);
 
 const tempConsole = global.console;
 global.console = {
+  // log: console.log, // Use this to debug source code
   log: jest.fn(),
   error: console.error,
   warn: console.warn,

--- a/packages/neo-one-build-tests/environments/test/jestSetup.js
+++ b/packages/neo-one-build-tests/environments/test/jestSetup.js
@@ -10,9 +10,8 @@ jest.setTimeout(120 * 1000);
 
 const tempConsole = global.console;
 global.console = {
+  // log: console.log, // Use this to debug source code
   log: jest.fn(),
-  // uncomment to allow console.log in tests
-  // log: console.log,
   error: console.error,
   warn: console.warn,
   info: jest.fn(),

--- a/packages/neo-one-build-tests/jest/e2e.js
+++ b/packages/neo-one-build-tests/jest/e2e.js
@@ -6,7 +6,9 @@ module.exports = {
   testRunner:
     '<rootDir>/packages/neo-one-build-tests/node_modules/jest-circus/runner',
   testRegex: '^.*/__e2e__/.*\\.test\\.tsx?$',
-  moduleNameMapper: undefined,
+  moduleNameMapper: {
+    '^@neo-one/cli$': '<rootDir>/packages/neo-one-cli/src/index',
+  },
   modulePathIgnorePatterns: [
     '<rootDir>/packages/[a-z-]+/package.json',
     '<rootDir>/common',

--- a/packages/neo-one-build-tools/types/e2e.d.ts
+++ b/packages/neo-one-build-tools/types/e2e.d.ts
@@ -3,14 +3,21 @@ declare interface NodeProject {
   readonly env: any;
 }
 
+declare interface CLIProject {
+  readonly exec: (command: string, options?: object) => Promise<void>;
+  readonly env: any;
+}
+
 declare interface One {
   readonly addCleanup: (callback: () => Promise<void> | void) => void;
   readonly cleanupTest: () => Promise<void>;
   readonly createExec: (project: string) => (command: string, options?: object) => Promise<string>;
   readonly createExecAsync: (project: string) => (command: string, options?: object) => void;
   readonly createNodeProject: (project: string) => NodeProject;
+  readonly createCLIProject: (project: string) => CLIProject;
   readonly until: (func: () => Promise<void>) => Promise<void>;
   readonly measureRequire: (mod: string) => Promise<number>;
   readonly getProjectConfig: (project: string) => any;
+  readonly getProjectDir: (project: string) => string;
 }
 declare const one: One;

--- a/packages/neo-one-cli/src/__e2e__/cmd/init.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/init.test.ts
@@ -1,0 +1,159 @@
+import fs from 'fs-extra';
+// tslint:disable-next-line: match-default-export-name
+import nodePath from 'path';
+
+const getPackage = (dependency: string) => ({
+  name: 'test-project',
+  version: '0.0.0',
+  dependencies: {
+    [dependency]: '0.0.0',
+  },
+});
+
+const getTSConfig = () => ({
+  compilerOptions: {
+    module: 'commonjs',
+    noImplicitAny: true,
+    removeComments: true,
+    preserveConstEnums: true,
+    sourceMap: true,
+  },
+  exclude: [],
+});
+
+const setupAndInitDirectory = async ({
+  dependency = 'none',
+  js = false,
+}: {
+  readonly dependency?: string;
+  readonly js?: boolean;
+} = {}) => {
+  const { exec: execAsync, env } = one.createCLIProject('init');
+
+  const tmpDir = env.NEO_ONE_TMP_DIR === undefined ? process.cwd() : env.NEO_ONE_TMP_DIR;
+
+  await fs.writeJSON(nodePath.join(tmpDir, 'package.json'), getPackage(dependency));
+  if (!js) {
+    await fs.writeJSON(nodePath.join(tmpDir, 'tsconfig.json'), getTSConfig());
+  }
+
+  await execAsync('init');
+
+  await Promise.all([
+    expect(fs.pathExists(nodePath.join(tmpDir, js ? '.neo-one.config.js' : '.neo-one.config.ts'))).resolves.toEqual(
+      true,
+    ),
+    expect(fs.pathExists(nodePath.join(tmpDir, 'neo-one', 'contracts'))).resolves.toEqual(true),
+  ]);
+
+  const [neoConfig, tsConfig] = await Promise.all([
+    import(nodePath.join(tmpDir, js ? '.neo-one.config.js' : '.neo-one.config.ts')),
+    fs.readJSON(nodePath.join(tmpDir, 'tsconfig.json')).catch(() => undefined),
+  ]);
+
+  if (!js) {
+    expect(tsConfig.exclude).toEqual(['neo-one/contracts/*.ts']);
+  }
+
+  return neoConfig;
+};
+
+describe('init command - no framework', () => {
+  it('does not set framework if not implied', async () => {
+    jest.resetModules();
+    jest.doMock('@neo-one/cli', () => ({ defaultNetworks: [] }));
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory();
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'none',
+      browserify: false,
+      codesandbox: false,
+      language: 'typescript',
+    });
+
+    expect(contracts).toEqual({
+      path: 'neo-one/contracts',
+      outDir: 'neo-one/compiled',
+    });
+  });
+});
+
+describe('init command - js', () => {
+  it('creates a .js config when no tsconfig', async () => {
+    await setupAndInitDirectory({
+      js: true,
+    });
+  });
+});
+
+describe('init command - react', () => {
+  it('sets framework to react if package.json has react dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: 'react',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'react',
+      browserify: false,
+      codesandbox: false,
+      language: 'typescript',
+    });
+
+    expect(contracts).toEqual({
+      path: 'neo-one/contracts',
+      outDir: 'neo-one/compiled',
+    });
+  });
+});
+
+describe('init command - vue', () => {
+  it('sets framework to vue if package.json has vue dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: 'vue',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'vue',
+      browserify: false,
+      codesandbox: false,
+      language: 'typescript',
+    });
+
+    expect(contracts).toEqual({
+      path: 'neo-one/contracts',
+      outDir: 'neo-one/compiled',
+    });
+  });
+});
+
+describe('init command - angular', () => {
+  it('sets framework to angular if package.json has angular dependency', async () => {
+    const {
+      default: { codegen, contracts },
+    } = await setupAndInitDirectory({
+      dependency: '@angular/core',
+    });
+
+    expect(codegen).toEqual({
+      path: nodePath.join('src', 'neo-one'),
+      framework: 'angular',
+      browserify: false,
+      codesandbox: false,
+      language: 'typescript',
+    });
+
+    expect(contracts).toEqual({
+      path: 'neo-one/contracts',
+      outDir: 'neo-one/compiled',
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Change

Adds E2E tests for `neo-one init` command. Basically just pulls everything from #1705, which was created pre-RushJS, and makes it work with the current NEO•ONE and RushJS setup.

### Test Plan

`rush e2e -t packages/neo-one-cli/src/__e2e__/cmd/init.test.ts`

### Alternate Designs

None.

### Benefits

E2E test for init command.

### Possible Drawbacks

None.

### Applicable Issues

#1682 
#1705 
