### PR TITLE
fix(cli): update network docs and cli exports

### DIFF
--- a/common/changes/@neo-one/cli-common-node/fix-helper_2020-07-07-04-21.json
+++ b/common/changes/@neo-one/cli-common-node/fix-helper_2020-07-07-04-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli-common-node",
+      "comment": "Export createUserAccountProviderFunc.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli-common-node",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/cli/fix-helper_2020-07-07-04-21.json
+++ b/common/changes/@neo-one/cli/fix-helper_2020-07-07-04-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "Export createUserAccountProviderFunc.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/packages/neo-one-cli-common-node/src/networks.ts
+++ b/packages/neo-one-cli-common-node/src/networks.ts
@@ -2,12 +2,12 @@ import { LocalKeyStore, LocalMemoryStore, NEOONEProvider } from '@neo-one/client
 import { LocalUserAccountProvider } from '@neo-one/client-full-core';
 import prompts from 'prompts';
 
-const createUserAccountProviderFunc = (network: string, rpcURL: string) => async () => {
+export const createUserAccountProviderFunc = (network: string, rpcURL: string) => async () => {
   const keystore = new LocalKeyStore(new LocalMemoryStore());
   const { privateKeys } = await prompts({
     type: 'list',
     name: 'privateKeys',
-    message: `Please enter one or more private keys separated by commas for use on the ${network} network.`,
+    message: `Please enter one or more private keys separated by commas for use on the "${network}" network.`,
     validate: (value) => (value.length > 0 ? true : 'Must enter at least one private key.'),
   });
   await Promise.all(privateKeys.map((privateKey: string) => keystore.addUserAccount({ network, privateKey })));

--- a/packages/neo-one-cli/src/index.ts
+++ b/packages/neo-one-cli/src/index.ts
@@ -5,4 +5,4 @@ import * as cmd from './cmd';
 
 export { cmd };
 
-export { defaultNetworks } from '@neo-one/cli-common-node';
+export { createUserAccountProviderFunc, defaultNetworks } from '@neo-one/cli-common-node';


### PR DESCRIPTION
### Description of the Change

Export the `createUserAccountProviderFunc` from `neo-one-cli-common-node` and `neo-one-cli` for use by users.

Update website documentation on how to use `createUserAccountProviderFunc` and how to create custom network definitions in `.neo-one.config.ts`.

### Test Plan

I think no tests are needed. But here's how the docs look in the website:

<img width="807" alt="Screen Shot 2020-07-06 at 9 16 59 PM" src="https://user-images.githubusercontent.com/29364457/86709694-0c141680-bfcf-11ea-9e3f-24d4dd4ef88d.png">

<img width="807" alt="Screen Shot 2020-07-06 at 9 17 07 PM" src="https://user-images.githubusercontent.com/29364457/86709681-09192600-bfcf-11ea-872e-6dc40f87d490.png">

### Alternate Designs

None.

### Benefits

Easier network creation for users.

### Possible Drawbacks

I'm not sure why we didn't export that in the past and make it available to users, so there might be an unknown reason why we didn't do that already. But it seems to be okay to use. It's also a more advanced API and is unlikely to actually be used any anyone, so we may be just making things more confusing for users by adding this.

### Applicable Issues

#2079