### PR TITLE
fix(compiler): fix switch statement inside SC invocations

### DIFF
--- a/common/changes/@neo-one/smart-contract-compiler/fix-switch_2020-07-09-23-27.json
+++ b/common/changes/@neo-one/smart-contract-compiler/fix-switch_2020-07-09-23-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler",
+      "comment": "Fix broken switch statement inside SmartContract methods.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/statement/SwitchStatementCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/statement/SwitchStatementCompiler.ts
@@ -18,8 +18,10 @@ export class SwitchStatementCompiler extends NodeCompiler<ts.SwitchStatement> {
     sb.withProgramCounter((pc) => {
       const switchExpr = tsUtils.expression.getExpression(node);
       const switchExprType = sb.context.analysis.getType(switchExpr);
-
-      const breakOptions = sb.breakPCOptions(sb.noPushValueOptions(options), pc.getLast());
+      let breakOptions = sb.breakPCOptions(sb.noPushValueOptions(options), pc.getLast());
+      if (breakOptions.finallyPC !== undefined) {
+        breakOptions = sb.finallyPCOptions(breakOptions, pc.getLast());
+      }
 
       const caseBlock = tsUtils.statement.getCaseBlock(node);
       const clauses = tsUtils.statement.getClauses(caseBlock);


### PR DESCRIPTION
### Description of the Change

Switch statements with a `break` statement were not working inside SmartContract methods. The `break` keyword, if inside a switch statement, would break out of the entire function and code after the switch statement would not run. I nailed this behavior down by looking at the unit tests in `SwitchStatementCompiler.test.ts`. In those tests we covered this case, and those tests pass. But the behavior changed slightly when inside a function scope. So I added a switch statement unit test that's called within a SmartContract method to recreate the issue described in #2016. That new test is added in this PR in `SwitchStatementCompiler.test.ts`.

I believe that the `InvokeSmartContractMethodHelper.ts` is the helper that is called for the method invocation. It's there that the `finallyPC` is set, which in the case of the broken switch statement, tells the break statement to break to the end of the function scope, and thus skips the code after the switch statement block. So to fix this we just change how the `finallyPC` is set in the `SwitchStatementCompiler.ts` so that when the compiler hits the `break` statement we jump to the code at the end of the switch statement instead of at the end of the function scope.

### Test Plan

New (and old) unit tests pass.

- `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/statement/BreakStatementCompiler.test.ts`
- `rush test -t packages/neo-one-smart-contract-compiler/src/__tests__/compile/statement/SwitchStatementCompiler.test.ts`
- `rush test`

Also regular CI checks.

### Alternate Designs

None.

### Benefits

Switch statements work as expected inside SmartContract methods.

### Possible Drawbacks

None.

### Applicable Issues

#2016 