### PR TITLE
fix(compiler): fix number mismatches in SetStorage, ArrayStorage, MapStorage

### DIFF
--- a/common/changes/@neo-one/smart-contract-compiler/fix-arraystorage_2020-07-16-02-18.json
+++ b/common/changes/@neo-one/smart-contract-compiler/fix-arraystorage_2020-07-16-02-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler",
+      "comment": "Fix number mismatches in ArrayStorage, SetStorage, MapStorage.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/arrayStorage.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/arrayStorage.test.ts
@@ -14,6 +14,7 @@ describe('ArrayStorage', () => {
       const test = (storage: ArrayStorage<string>) => {
         assertEqual(storage instanceof ArrayStorage, true);
         assertEqual(storage.length, 0);
+        assertEqual(storage.length, 1 - 1);
 
         storage[0] = '10';
         assertEqual(storage[0], '10');
@@ -56,6 +57,271 @@ describe('ArrayStorage', () => {
         assertEqual(storageLike[0] as string | undefined, undefined);
         assertEqual(storageLike['length'], 0);
         storageLike[Symbol.iterator]();
+      }
+
+      export class StorageContract extends SmartContract {
+        public readonly properties = {
+          codeVersion: '1.0',
+          author: 'dicarlo2',
+          email: 'alex.dicarlo@neotracker.io',
+          description: 'StorageContract',
+        };
+        private readonly storage = ArrayStorage.for<string>();
+
+        public run(): void {
+          test(this.storage);
+        }
+      }
+    `);
+
+    await node.executeString(`
+      import { Address, SmartContract } from '@neo-one/smart-contract';
+
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
+    `);
+  });
+
+  test('get index by hardcoded and computed values', async () => {
+    const node = await helpers.startNode();
+
+    const contract = await node.addContract(`
+      import { ArrayStorage, SmartContract } from '@neo-one/smart-contract';
+
+      const test = (storage: ArrayStorage<string>) => {
+        storage[0] = '10';
+        assertEqual(storage[0], '10');
+        assertEqual(storage[1 - 1], '10');
+        assertEqual(storage[0 + 0], '10');
+        assertEqual(storage[9 * 0], '10');
+        assertEqual(storage[0 / 9], '10');
+        storage[1] = '100';
+        assertEqual(storage[1], '100');
+        assertEqual(storage[2 - 1], '100');
+        assertEqual(storage[0 + 1], '100');
+        assertEqual(storage[1 / 1], '100');
+        assertEqual(storage[1 * 1], '100');
+        storage[18] = '18';
+        assertEqual(storage[18], '18');
+        assertEqual(storage[36 - 18], '18');
+        assertEqual(storage[13 + 5], '18');
+        assertEqual(storage[36 / 2], '18');
+        assertEqual(storage[3 * 6], '18');
+      }
+
+      export class StorageContract extends SmartContract {
+        public readonly properties = {
+          codeVersion: '1.0',
+          author: 'dicarlo2',
+          email: 'alex.dicarlo@neotracker.io',
+          description: 'StorageContract',
+        };
+        private readonly storage = ArrayStorage.for<string>();
+
+        public run(): void {
+          test(this.storage);
+        }
+      }
+    `);
+
+    await node.executeString(`
+      import { Address, SmartContract } from '@neo-one/smart-contract';
+
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
+    `);
+  });
+
+  test('set index by subtracted values', async () => {
+    const node = await helpers.startNode();
+
+    const contract = await node.addContract(`
+      import { ArrayStorage, SmartContract } from '@neo-one/smart-contract';
+
+      const test = (storage: ArrayStorage<string>) => {
+        storage[1 - 1] = '10';
+        assertEqual(storage[0], '10');
+        assertEqual(storage[2 - 2], '10');
+        assertEqual(storage[0 + 0], '10');
+        assertEqual(storage[9 * 0], '10');
+        assertEqual(storage[0 / 9], '10');
+        storage[2 - 1] = '100';
+        assertEqual(storage[1], '100');
+        assertEqual(storage[2 - 1], '100');
+        assertEqual(storage[0 + 1], '100');
+        assertEqual(storage[1 / 1], '100');
+        assertEqual(storage[1 * 1], '100');
+        storage[19 - 1] = '18';
+        assertEqual(storage[18], '18');
+        assertEqual(storage[36 - 18], '18');
+        assertEqual(storage[13 + 5], '18');
+        assertEqual(storage[36 / 2], '18');
+        assertEqual(storage[3 * 6], '18');
+      }
+
+      export class StorageContract extends SmartContract {
+        public readonly properties = {
+          codeVersion: '1.0',
+          author: 'dicarlo2',
+          email: 'alex.dicarlo@neotracker.io',
+          description: 'StorageContract',
+        };
+        private readonly storage = ArrayStorage.for<string>();
+
+        public run(): void {
+          test(this.storage);
+        }
+      }
+    `);
+
+    await node.executeString(`
+      import { Address, SmartContract } from '@neo-one/smart-contract';
+
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
+    `);
+  });
+
+  test('set index by added values', async () => {
+    const node = await helpers.startNode();
+
+    const contract = await node.addContract(`
+      import { ArrayStorage, SmartContract } from '@neo-one/smart-contract';
+
+      const test = (storage: ArrayStorage<string>) => {
+        storage[0 + 0] = '10';
+        assertEqual(storage[0], '10');
+        assertEqual(storage[2 - 2], '10');
+        assertEqual(storage[0 + 0], '10');
+        assertEqual(storage[9 * 0], '10');
+        assertEqual(storage[0 / 9], '10');
+        storage[1 + 0] = '100';
+        assertEqual(storage[1], '100');
+        assertEqual(storage[2 - 1], '100');
+        assertEqual(storage[0 + 1], '100');
+        assertEqual(storage[1 / 1], '100');
+        assertEqual(storage[1 * 1], '100');
+        storage[17 + 1] = '18';
+        assertEqual(storage[18], '18');
+        assertEqual(storage[36 - 18], '18');
+        assertEqual(storage[13 + 5], '18');
+        assertEqual(storage[36 / 2], '18');
+        assertEqual(storage[3 * 6], '18');
+      }
+
+      export class StorageContract extends SmartContract {
+        public readonly properties = {
+          codeVersion: '1.0',
+          author: 'dicarlo2',
+          email: 'alex.dicarlo@neotracker.io',
+          description: 'StorageContract',
+        };
+        private readonly storage = ArrayStorage.for<string>();
+
+        public run(): void {
+          test(this.storage);
+        }
+      }
+    `);
+
+    await node.executeString(`
+      import { Address, SmartContract } from '@neo-one/smart-contract';
+
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
+    `);
+  });
+
+  test('set index by multiplied values', async () => {
+    const node = await helpers.startNode();
+
+    const contract = await node.addContract(`
+      import { ArrayStorage, SmartContract } from '@neo-one/smart-contract';
+
+      const test = (storage: ArrayStorage<string>) => {
+        storage[0 * 9] = '10';
+        assertEqual(storage[0], '10');
+        assertEqual(storage[2 - 2], '10');
+        assertEqual(storage[0 + 0], '10');
+        assertEqual(storage[9 * 0], '10');
+        assertEqual(storage[0 / 9], '10');
+        storage[1 * 1] = '100';
+        assertEqual(storage[1], '100');
+        assertEqual(storage[2 - 1], '100');
+        assertEqual(storage[0 + 1], '100');
+        assertEqual(storage[1 / 1], '100');
+        assertEqual(storage[1 * 1], '100');
+        storage[6 * 3] = '18';
+        assertEqual(storage[18], '18');
+        assertEqual(storage[36 - 18], '18');
+        assertEqual(storage[13 + 5], '18');
+        assertEqual(storage[36 / 2], '18');
+        assertEqual(storage[3 * 6], '18');
+      }
+
+      export class StorageContract extends SmartContract {
+        public readonly properties = {
+          codeVersion: '1.0',
+          author: 'dicarlo2',
+          email: 'alex.dicarlo@neotracker.io',
+          description: 'StorageContract',
+        };
+        private readonly storage = ArrayStorage.for<string>();
+
+        public run(): void {
+          test(this.storage);
+        }
+      }
+    `);
+
+    await node.executeString(`
+      import { Address, SmartContract } from '@neo-one/smart-contract';
+
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
+    `);
+  });
+
+  test('set index by divided values', async () => {
+    const node = await helpers.startNode();
+
+    const contract = await node.addContract(`
+      import { ArrayStorage, SmartContract } from '@neo-one/smart-contract';
+
+      const test = (storage: ArrayStorage<string>) => {
+        storage[0 / 9] = '10';
+        assertEqual(storage[0], '10');
+        assertEqual(storage[2 - 2], '10');
+        assertEqual(storage[0 + 0], '10');
+        assertEqual(storage[9 * 0], '10');
+        assertEqual(storage[0 / 9], '10');
+        storage[1 / 1] = '100';
+        assertEqual(storage[1], '100');
+        assertEqual(storage[2 - 1], '100');
+        assertEqual(storage[0 + 1], '100');
+        assertEqual(storage[1 / 1], '100');
+        assertEqual(storage[1 * 1], '100');
+        storage[36 / 2] = '18';
+        assertEqual(storage[18], '18');
+        assertEqual(storage[36 - 18], '18');
+        assertEqual(storage[13 + 5], '18');
+        assertEqual(storage[36 / 2], '18');
+        assertEqual(storage[3 * 6], '18');
       }
 
       export class StorageContract extends SmartContract {
@@ -127,6 +393,15 @@ describe('ArrayStorage', () => {
             count += 1;
             indices += idx;
             keys += key;
+          });
+          storage.forEach((key, idx) => {
+            assertEqual(idx, idx + 0)
+            if (idx === 0) {
+              assertEqual(idx, 1 - 1);
+            }
+            if (idx === 1) {
+              assertEqual(idx, 2 - 1);
+            }
           });
           assertEqual(count, 4);
           assertEqual(indices, 6);

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ArrayLiteralExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ArrayLiteralExpressionCompiler.test.ts
@@ -22,6 +22,10 @@ describe('ArrayLiteralExpressionCompiler', () => {
         throw 'Failure';
       }
 
+      if (x[1 - 1] !== 1) {
+        throw 'Failure';
+      }
+
       if (x[1] !== 2) {
         throw 'Failure';
       }

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ElementAccessExpressionCompiler.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/expression/ElementAccessExpressionCompiler.test.ts
@@ -17,6 +17,7 @@ describe('ElementAccessExpressionCompiler', () => {
       assertEqual(y[length], 3);
       assertEqual(y.length, 3);
       assertEqual(y[0], 0);
+      assertEqual(y[1 - 1], 0);
       assertEqual(y[1] as number | undefined, undefined);
       assertEqual(y[2], 2);
       assertEqual(y[2] += 1, 3);

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/arrayStorage/pop.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/arrayStorage/pop.ts
@@ -77,6 +77,8 @@ export class ArrayStoragePop extends BuiltinInstanceMemberCall {
           sb.emitOp(node, 'TUCK');
           // [idx, val, idx, val]
           sb.emitOp(node, 'OVER');
+          // [idx, val, idx, val]
+          sb.emitHelper(node, options, sb.helpers.coerceToInt);
           // [idxVal, val, idx, val]
           sb.emitHelper(node, options, sb.helpers.wrapNumber);
           if (optionsIn.pushValue) {

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/arrayStorage/push.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/arrayStorage/push.ts
@@ -36,6 +36,8 @@ export class ArrayStoragePush extends BuiltinInstanceMemberCall {
       sb.emitOp(node, 'TUCK');
       // [idx, val, idx, val]
       sb.emitOp(node, 'OVER');
+      // [idx, val, idx, val]
+      sb.emitHelper(node, options, sb.helpers.coerceToInt);
       // [idxVal, val, idx, val]
       sb.emitHelper(node, options, sb.helpers.wrapNumber);
       // [valueVal, idxVal, val, idx, val]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/mapStorage/get.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/mapStorage/get.ts
@@ -34,6 +34,14 @@ export class MapStorageGet extends BuiltinInstanceMemberCall {
     const type = sb.context.analysis.getType(arg);
     // [keyVal, val]
     sb.visit(arg, options);
+    if (arg.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(arg, options, sb.helpers.wrapNumber);
+    }
     // [val]
     sb.emitHelper(node, optionsIn, sb.helpers.getStructuredStorage({ type: Types.MapStorage, keyType: type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/mapStorage/set.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/mapStorage/set.ts
@@ -39,6 +39,14 @@ export class MapStorageSet extends BuiltinInstanceMemberCall {
     }
     // [keyVal, val]
     sb.visit(key, options);
+    if (key.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(key, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(key, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(key, options, sb.helpers.wrapNumber);
+    }
     // [valVal, keyVal, val]
     sb.visit(tsUtils.argumented.getArguments(node)[1], options);
     // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/setStorage/add.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/setStorage/add.ts
@@ -39,6 +39,14 @@ export class SetStorageAdd extends BuiltinInstanceMemberCall {
     }
     // [keyVal, val]
     sb.visit(key, options);
+    if (key.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(key, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(key, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(key, options, sb.helpers.wrapNumber);
+    }
     // [value, keyVal, val]
     sb.emitPushBoolean(node, true);
     // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/at.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/at.ts
@@ -38,6 +38,14 @@ export class StorageAt extends BuiltinInstanceMemberCall {
     const type = sb.context.analysis.getType(arg);
     // [keyVal, val]
     sb.visit(arg, options);
+    if (arg.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(arg, options, sb.helpers.wrapNumber);
+    }
     // [val]
     sb.emitHelper(node, optionsIn, sb.helpers.atStructuredStorage({ type: this.type, keyType: type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/delete.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/delete.ts
@@ -38,6 +38,14 @@ export class StorageDelete extends BuiltinInstanceMemberCall {
     const type = sb.context.analysis.getType(arg);
     // [keyVal, val]
     sb.visit(arg, options);
+    if (arg.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(arg, options, sb.helpers.wrapNumber);
+    }
     // [val]
     sb.emitHelper(node, optionsIn, sb.helpers.deleteStructuredStorage({ type: this.type, keyType: type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/has.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/storage/has.ts
@@ -38,6 +38,14 @@ export class StorageHas extends BuiltinInstanceMemberCall {
     const type = sb.context.analysis.getType(arg);
     // [keyVal, val]
     sb.visit(arg, options);
+    if (arg.kind === ts.SyntaxKind.NumericLiteral) {
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.unwrapNumber);
+      // [number, val]
+      sb.emitHelper(arg, options, sb.helpers.coerceToInt);
+      // [keyVal, val]
+      sb.emitHelper(arg, options, sb.helpers.wrapNumber);
+    }
     // [val]
     sb.emitHelper(node, optionsIn, sb.helpers.hasStructuredStorage({ type: this.type, keyType: type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/expression/ElementAccessExpressionCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/expression/ElementAccessExpressionCompiler.ts
@@ -289,6 +289,8 @@ export class ElementAccessExpressionCompiler extends NodeCompiler<ts.ElementAcce
       const handleNumber = (innerInnerOptions: VisitOptions) => {
         // [number, objectVal]
         sb.emitHelper(prop, innerInnerOptions, sb.helpers.unwrapNumber);
+        // [number, objectVal]
+        sb.emitHelper(prop, innerInnerOptions, sb.helpers.coerceToInt);
         handleNumberBase(innerInnerOptions);
       };
 

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -276,6 +276,7 @@ import {
 import {
   ArrayLengthHelper,
   BufferLengthHelper,
+  CoerceToIntHelper,
   ConcatBufferHelper,
   CreateArrayHelper,
   CreateObjectHelper,
@@ -529,6 +530,7 @@ export interface Helpers {
   readonly invokeConstruct: (options?: InvokeConstructHelperOptions) => InvokeConstructHelper;
   readonly new: (options?: NewHelperOptions) => NewHelper;
   readonly parameters: (options: ParametersHelperOptions) => ParametersHelper;
+  readonly coerceToInt: CoerceToIntHelper;
 
   readonly forLoop: (options: ForLoopHelperOptions) => ForLoopHelper;
   readonly if: (options: IfHelperOptions) => IfHelper;
@@ -979,6 +981,7 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     invokeConstruct: (options?) => new InvokeConstructHelper(options),
     new: (options?) => new NewHelper(options),
     parameters: (options) => new ParametersHelper(options),
+    coerceToInt: new CoerceToIntHelper(),
 
     forLoop: (options) => new ForLoopHelper(options),
     if: (options) => new IfHelper(options),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/number/CoerceToIntHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/number/CoerceToIntHelper.ts
@@ -1,0 +1,16 @@
+import ts from 'typescript';
+import { Helper } from '../../../../compile/helper/Helper';
+import { ScriptBuilder } from '../../../sb';
+import { VisitOptions } from '../../../types';
+
+// Input: [number]
+// Output: [number]
+export class CoerceToIntHelper extends Helper {
+  // We add 0 to input number to coerce it to an IntegerStackItem
+  public emit(sb: ScriptBuilder, node: ts.Node, _options: VisitOptions) {
+    // [0, number]
+    sb.emitPushInt(node, 0);
+    // [number]
+    sb.emitOp(node, 'ADD');
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/number/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/number/index.ts
@@ -1,3 +1,4 @@
+export * from './CoerceToIntHelper';
 export * from './WrapNumberHelper';
 export * from './UnwrapNumberHelper';
 export * from './IsNumberHelper';


### PR DESCRIPTION
### Description of the Change

Fixes #2016.

I poked around for several days learning the nature of the problem. And realized that index values between 1 and 15 (inclusive) would have no issues whether the index was computed or hardcoded, because when 1-15 are used as hardcoded values they are pushed onto the stack as `IntegerStackItem`s. But 0 and 16+ are pushed onto the stack as `BufferStackItem`s. But then ANY computed value is computed and then pushed onto the stack as `IntegerStackItem`s, no matter what value. Thus I needed to find a way to either make all `ArrayStorage` index values be Buffers or all be Integers. You can see in the section below that I initially tried to coerce all index values to Buffers but came up short. It then struck me that I could just add 0 to every index value before getting/setting in order to coerce any index value from Integer OR Buffer to an `IntegerStackItem`. So you'll see that's what I did below. I create a `CoerceToInt` helper which can be used anywhere to take a number from the stack, in the form of an Integer or Buffer, and always return an Integer representation of that number.

I then dug a bit deeper and saw that this issue applies to all getters/setters for `ArrayStorage`, `MapStorage`, and `SetStorage`. And so I added the `CoerceToIntHelper` call wherever needed for those objects as well.

### Test Plan

- `rush test`
- Added PLENTY of test coverage for this issue, which would not have passed before but passes now.

### Alternate Designs

The first main solution I tried was to use the SysCall `Neo.Runtime.Serialize` to serialize any incoming `BufferStackItem` OR `IntegerStackItem` before that index number was "wrapped" so that it would always be a `BufferStackItem`. But, unfortunately, the `BufferStackItem` and `IntegerStackItem` representing the same number would be serialized differently (ie. not they wouldn't be identical buffers). So that solution wouldn't work.

### Benefits

`ArrayStorage` works as expected with computed and hardcoded index getting/setting.

### Possible Drawbacks

Slightly more bytecode when compiling contracts that use `ArrayStorage`.

### Applicable Issues

#2016
