### PR TITLE
fix(node): fix 'receive' invocations when relaying transactions to a live network

### DIFF
--- a/common/changes/@neo-one/client-core/node-debug_2020-07-14-23-23.json
+++ b/common/changes/@neo-one/client-core/node-debug_2020-07-14-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-core",
+      "comment": "fixup utxo invocation transactions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-core",
+  "email": "danwbyrne@gmail.com"
+}

--- a/common/changes/@neo-one/node-core/node-debug_2020-07-14-23-23.json
+++ b/common/changes/@neo-one/node-core/node-debug_2020-07-14-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-core",
+      "comment": "fixup utxo invocation transactions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-core",
+  "email": "danwbyrne@gmail.com"
+}

--- a/common/changes/@neo-one/node-protocol/node-debug_2020-07-14-23-23.json
+++ b/common/changes/@neo-one/node-protocol/node-debug_2020-07-14-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-protocol",
+      "comment": "fixup utxo invocation transactions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-protocol",
+  "email": "danwbyrne@gmail.com"
+}

--- a/common/changes/@neo-one/node-rpc-handler/node-debug_2020-07-14-23-23.json
+++ b/common/changes/@neo-one/node-rpc-handler/node-debug_2020-07-14-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-rpc-handler",
+      "comment": "fixup utxo invocation transactions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-rpc-handler",
+  "email": "danwbyrne@gmail.com"
+}

--- a/common/changes/@neo-one/smart-contract-compiler/node-debug_2020-07-14-23-23.json
+++ b/common/changes/@neo-one/smart-contract-compiler/node-debug_2020-07-14-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-compiler",
+      "comment": "fixup utxo invocation transactions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-compiler",
+  "email": "danwbyrne@gmail.com"
+}

--- a/packages/neo-one-client-core/src/provider/DataProviderBase.ts
+++ b/packages/neo-one-client-core/src/provider/DataProviderBase.ts
@@ -126,6 +126,14 @@ export abstract class DataProviderBase implements DataProvider {
     return this.executeRelayTransaction(transaction, networkFee);
   }
 
+  public async relayStrippedTransaction(
+    verificationTransaction: InvocationTransactionModel,
+    relayTransaction: InvocationTransactionModel,
+    networkFee?: BigNumber,
+  ): Promise<RelayTransactionResult> {
+    return this.executeRelayStrippedTransaction(verificationTransaction, relayTransaction, networkFee);
+  }
+
   public async getTransactionReceipt(hash: Hash256String, options?: GetOptions): Promise<TransactionReceipt> {
     return this.executeGetTransactionReceipt(hash, options);
   }
@@ -250,6 +258,12 @@ export abstract class DataProviderBase implements DataProvider {
 
   protected abstract async executeRelayTransaction(
     transaction: TransactionBaseModel,
+    networkFee?: BigNumber,
+  ): Promise<RelayTransactionResult>;
+
+  protected abstract async executeRelayStrippedTransaction(
+    verificationTransaction: InvocationTransactionModel,
+    relayTransaction: InvocationTransactionModel,
     networkFee?: BigNumber,
   ): Promise<RelayTransactionResult>;
 

--- a/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
+++ b/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
@@ -151,6 +151,24 @@ export class JSONRPCClient {
     );
   }
 
+  public async relayStrippedTransaction(verificationTransaction: BufferString, relayTransaction: BufferString) {
+    return this.withInstance(async (provider) =>
+      provider
+        .request({
+          method: 'relaystrippedtransaction',
+          params: [verificationTransaction, relayTransaction],
+        })
+        .catch((error) => {
+          const [message, code]: [string, string] = error.message.split(':');
+          if (error.code === 'JSON_RPC' && code === '-110') {
+            throw new RelayTransactionError(message);
+          }
+
+          throw error;
+        }),
+    );
+  }
+
   public async sendRawTransaction(value: BufferString): Promise<boolean> {
     return this.withInstance(async (provider) =>
       provider

--- a/packages/neo-one-client-core/src/provider/NEODataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEODataProvider.ts
@@ -190,6 +190,15 @@ export class NEODataProvider extends DataProviderBase {
 
     throw new NeoNotImplementedError('Transaction types besides Claim & Invocation are');
   }
+
+  protected async executeRelayStrippedTransaction(
+    verificationTransaction: InvocationTransactionModel,
+    _relayTransaction: InvocationTransactionModel,
+    networkFee?: BigNumber,
+  ): Promise<RelayTransactionResult> {
+    return this.executeRelayTransaction(verificationTransaction, networkFee);
+  }
+
   protected async executeGetUnspentOutputs(address: AddressString): Promise<readonly InputOutput[]> {
     const unspents = await this.mutableClient.getUnspents(address);
 

--- a/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEDataProvider.ts
@@ -175,6 +175,19 @@ export class NEOONEDataProvider extends DataProviderBase implements DeveloperPro
     return convertRelayTransactionResult(result);
   }
 
+  protected async executeRelayStrippedTransaction(
+    verificationTransaction: InvocationTransactionModel,
+    relayTransaction: InvocationTransactionModel,
+    _networkFee?: BigNumber,
+  ): Promise<RelayTransactionResult> {
+    const result = await this.mutableClient.relayStrippedTransaction(
+      verificationTransaction.serializeWire().toString('hex'),
+      relayTransaction.serializeWire().toString('hex'),
+    );
+
+    return convertRelayTransactionResult(result);
+  }
+
   protected async executeGetTransactionReceipt(hash: Hash256String, options?: GetOptions): Promise<TransactionReceipt> {
     const result = await this.mutableClient.getTransactionReceipt(hash, options);
 

--- a/packages/neo-one-client-core/src/provider/ProviderBase.ts
+++ b/packages/neo-one-client-core/src/provider/ProviderBase.ts
@@ -71,6 +71,15 @@ export abstract class ProviderBase<TDataProvider extends DataProviderBase> imple
     return this.getProvider(network).relayTransaction(transaction, networkFee);
   }
 
+  public async relayStrippedTransaction(
+    network: NetworkType,
+    verificationTransaction: InvocationTransactionModel,
+    relayTransaction: InvocationTransactionModel,
+    networkFee?: BigNumber,
+  ): Promise<RelayTransactionResult> {
+    return this.getProvider(network).relayStrippedTransaction(verificationTransaction, relayTransaction, networkFee);
+  }
+
   public async getTransactionReceipt(
     network: NetworkType,
     hash: Hash256String,

--- a/packages/neo-one-node-core/src/Node.ts
+++ b/packages/neo-one-node-core/src/Node.ts
@@ -24,6 +24,11 @@ export interface Node {
     transaction: Transaction,
     options?: { readonly throwVerifyError?: boolean; readonly forceAdd?: boolean },
   ) => Promise<RelayTransactionResult>;
+  readonly relayStrippedTransaction: (
+    verificationTransaction: Transaction,
+    relayTransaction: Transaction,
+    options?: { readonly throwVerifyError?: boolean; readonly forceAdd?: boolean },
+  ) => Promise<RelayTransactionResult>;
   readonly relayConsensusPayload: (payload: ConsensusPayload) => void;
   readonly relayBlock: (block: Block) => Promise<void>;
   readonly connectedPeers: readonly Endpoint[];

--- a/packages/neo-one-node-protocol/src/errors.ts
+++ b/packages/neo-one-node-protocol/src/errors.ts
@@ -13,3 +13,13 @@ export const AlreadyConnectedError = makeErrorWithCode(
   'ALREADY_CONNECTED',
   (reason: string) => `Negotiation failed: ${reason}`,
 );
+
+export const InvalidRelayStrippedTransactionType = makeErrorWithCode(
+  'INVALID_TRANSACTION_TYPE_FOR_STRIPPED_RELAY',
+  (type: number) => `tried to use relayStrippedTransaction on a ${type} transaction`,
+);
+
+export const RelayStrippedTransactionMismatch = makeErrorWithCode(
+  'RELAY_STRIPPED_TRANSACTION_MISMATCH',
+  () => "verificationTransaction and relayTransaction weren't identical transactions",
+);


### PR DESCRIPTION
### Description
`@receive` tagged invocation transactions were not able to be verified by other non-NEO•ONE nodes on the testnet. While this problem could be affecting other transaction types this is the only known issue. 

After comparing the transaction we create with the transaction `neon-js` creates I was able to see the differences in the transactions, namely that our transaction attached and relayed an additional verification script along with several other attributes that weren't accepted using the neon-js API.

### Solution
Since we don't want to spend all of our time looking at a Neo 2.x issue that will undoubtedly get changed in the Neo 3.x migration this is a hotfix. Because of how the NEO•ONE node handles test invocations we create a new function called `relayStrippedTransaction` which takes in 2 invocation transactions. 1 which has the 'bad' witness attached to it for verifying on the NEO•ONE node, and another transaction which is stripped of the bad verification and gets relayed to the rest of the blockchain after verifying the partner transaction.

### Additional Comments
While this could present unknown side affects it is a working solution that still passes all tests. We should review this carefully when migrating to Neo 3.x but I suspect we will changing a lot of the transaction creation anyway.