### PR TITLE
fix(tests): update NT dep and website build process

### DIFF
--- a/common/changes/@neo-one/cli/nt-update_2020-07-20-19-17.json
+++ b/common/changes/@neo-one/cli/nt-update_2020-07-20-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "Update NEO Tracker dependency.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/config/rush/yarn.lock
+++ b/common/config/rush/yarn.lock
@@ -1551,13 +1551,13 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@neo-one/client-common@^2.4.0", "@neo-one/client-common@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-common/-/client-common-2.5.0.tgz#dad877f2fa7d08103b63ddd2f158e87ac21eaa7e"
-  integrity sha512-5ltq2nnvgVeHgjOmsztJH6aUswnhx7O4AP+dqMGoM8atRLXLOLgkD2wtw4UFfUG+QImV5rFdVkvJSBGNjd4MWg==
+"@neo-one/client-common@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-common/-/client-common-2.6.0.tgz#bbce2295872e564cd67870a7d4a1a5f093a694a1"
+  integrity sha512-tymMNgzHLc7XDsM4Sl1VZfNc0cvop3m2PTN4YMlMvQSu6TJG/JdadhfODEHFx7qV/j7Oj5wdBH+eNMESo/urKA==
   dependencies:
     "@neo-one/ec-key" "^0.1.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/utils" "^2.5.0"
     bignumber.js "^9.0.0"
     bn.js "^5.0.0"
     bs58 "^4.0.1"
@@ -1572,14 +1572,14 @@
     tslib "^1.10.0"
     wif "^2.0.6"
 
-"@neo-one/client-core@^2.4.0", "@neo-one/client-core@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-core/-/client-core-2.5.0.tgz#ad99bd9553426b6ce6f331061979687a9434b1ee"
-  integrity sha512-8oz3U+uxEseNx5WryOZuAdVXCKw+cSeftxc/yowhyNC8Rblvbt+/naBk9TLSt/qYLmgB4RivMvcGckikqL7ysQ==
+"@neo-one/client-core@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-core/-/client-core-2.6.0.tgz#05d3e3083750f5604cdcd315a816a0f81a7c6a30"
+  integrity sha512-Ayqw/csaP5xeQC3JCkOsdfCfTdk5/WJTsUTQX8rdMxgllVgrylq6KDxJNXbgwb+JG/oPfOqzlcb9rxtse/FIPA==
   dependencies:
-    "@neo-one/client-common" "^2.5.0"
-    "@neo-one/client-switch" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-switch" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     "@reactivex/ix-es2015-cjs" "^2.5.3"
     "@reactivex/ix-esnext-esm" "^2.5.3"
     bignumber.js "^9.0.0"
@@ -1593,75 +1593,69 @@
     tapable "^1.1.3"
     tslib "^1.10.0"
 
-"@neo-one/client-full-common@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-full-common/-/client-full-common-2.4.0.tgz#b21d973ee1044f11cfe66e1fbb8945e8ee0281e8"
-  integrity sha512-A3ZaxCN/ws2MogWTUDX9EZEK+Aezzmnxg7pQE5sKFrgWKXAllw5ahlnzYwtg3/d11drD7tEGGN/D5aGNnD/3IQ==
+"@neo-one/client-full-common@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-full-common/-/client-full-common-2.5.0.tgz#d4a6b0d727a5770f636689a375e932ea36f8fdb7"
+  integrity sha512-G/nUrG4pBH44lyxXiPGrzal2UuKQDkeZ57jo6JVcOjLQcsj1LHZKlEfNeGRlO/RSBX7FW1diRfWUl8Vob4vDCQ==
   dependencies:
-    "@neo-one/client-common" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/utils" "^2.5.0"
     tslib "^1.10.0"
 
-"@neo-one/client-full-core@^2.4.0":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-full-core/-/client-full-core-2.4.1.tgz#77de399663878389c29a84571c076355966f7d96"
-  integrity sha512-OJ/1Ymz2nBJH1Z88Qz72QeHRfAcpD1ZZ1xQ2AbgvjJRBb0SIzX3csLOONC4GcWqPXWVGUiuoxJMJceYW0sKLFQ==
+"@neo-one/client-full-core@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-full-core/-/client-full-core-2.5.0.tgz#f1255fbdb532739f0bf15f47f8cf56286537e55c"
+  integrity sha512-ecqTyrOyI7IhW8Mw0MXldz0qIFDHZeI0hT7RSpz9PQKgtSOLBrk0igmzGCN/mHViNgw1EL4ahWOSY4wqOi8DKg==
   dependencies:
-    "@neo-one/client-common" "^2.5.0"
-    "@neo-one/client-core" "^2.5.0"
-    "@neo-one/client-full-common" "^2.4.0"
-    "@neo-one/client-switch" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-core" "^2.6.0"
+    "@neo-one/client-full-common" "^2.5.0"
+    "@neo-one/client-switch" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     bignumber.js "^9.0.0"
     lodash "^4.17.15"
     tslib "^1.10.0"
 
-"@neo-one/client-full@^2.3.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-full/-/client-full-2.4.0.tgz#479617cb218502eb4d7787748cb06d1f57dac931"
-  integrity sha512-9Y4C1ponYXi4YK0VOlFSGdgR8nQCnsocVuC2fR2m9LbhJiMPd9qwbhSaEwjaOl9wG469kXyeMM92rd6vdy2+Qw==
+"@neo-one/client-full@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-full/-/client-full-2.5.0.tgz#c4dbe00d3f2d3d929a6940bd297311879bf3be65"
+  integrity sha512-fOpBO3abRw5KkmrPIsOx5pH6iaIgiEz5tiWY43N2M3nWb8u2gv6zhDGj79nZN9dOVin9dlkamGnJQ63h0QL2dA==
   dependencies:
-    "@neo-one/client" "^2.4.0"
-    "@neo-one/client-full-core" "^2.4.0"
+    "@neo-one/client" "^2.6.0"
+    "@neo-one/client-full-core" "^2.5.0"
 
-"@neo-one/client-switch@^2.3.0", "@neo-one/client-switch@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client-switch/-/client-switch-2.4.0.tgz#77e9924dc7152652cad63dd58704a51169d6fdb9"
-  integrity sha512-OZssG/itq6dK7SrjHSqD+3PTvpmayN1XaQrCiflw4khUb3+lLuNJYeJSKq819IyiSzZabV0ihBeksOa41o+NGg==
+"@neo-one/client-switch@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client-switch/-/client-switch-2.5.0.tgz#d3bb843d6ef4dbbf9f27fe3c4d3f3385df990eb5"
+  integrity sha512-mTeCd2UIR5Deqfv+rbjSGGzoklnKDzWkSEHppscEQ21E9vA4cRXeKnB7Lk3NAHpvVwdNfWCNKJORzBDm88hoPg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@ledgerhq/hw-transport-u2f" "^4.68.2"
-    "@neo-one/client-common" "^2.4.0"
-    "@neo-one/node-vm" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
-    "@opencensus/core" "^0.0.19"
-    "@opencensus/exporter-jaeger" "^0.0.19"
-    "@opencensus/exporter-prometheus" "^0.0.19"
-    "@opencensus/nodejs-base" "^0.0.19"
-    "@opencensus/propagation-tracecontext" "^0.0.19"
-    "@opencensus/web-core" "^0.0.7"
-    "@opencensus/web-propagation-tracecontext" "^0.0.7"
-    "@opencensus/web-types" "^0.0.7"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/node-vm" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     lodash "^4.17.15"
     regenerator-runtime "^0.13.3"
     source-map "^0.7.3"
     tslib "^1.10.0"
+  optionalDependencies:
+    "@ledgerhq/hw-transport-node-hid" "^4.68.2"
 
-"@neo-one/client@^2.3.0", "@neo-one/client@^2.4.0":
+"@neo-one/client@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/client/-/client-2.6.0.tgz#bc315aaf6c0fe6ca66788798087a2dec48cc6d9d"
+  integrity sha512-4o4JWRG9tS8qGraGADkxlmzZ+GZSABv+k1pee5nrJOXX0h9cTayK/uFZ4Cn2Gn8Qv1A+Tym5go7JrqTd5ojs6g==
+  dependencies:
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-core" "^2.6.0"
+    "@neo-one/developer-tools" "^2.5.0"
+
+"@neo-one/developer-tools@^2.5.0":
   version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/client/-/client-2.5.0.tgz#becf47c9102032bc0eb346d536147980688eded6"
-  integrity sha512-oBW053jFwVH8AAhCFfihNeov2UbJ/LWHrD02jEWGO79pY9gNSC62R7bOsorr+9uQK3ungb/FEK3GqlTs2/JV5Q==
+  resolved "https://registry.yarnpkg.com/@neo-one/developer-tools/-/developer-tools-2.5.0.tgz#6ac5f7b2be2ce14307728e20fab239fafa8b1867"
+  integrity sha512-OmxkroHGbuIRPxYqdWm3nPhn1dWvxfkhxXrUUP8DumBvFmP/hgnQD0IM4aT33F+rBhRf2UgOGWgiQ6xLVdkTow==
   dependencies:
-    "@neo-one/client-common" "^2.5.0"
-    "@neo-one/client-core" "^2.5.0"
-    "@neo-one/developer-tools" "^2.4.0"
-
-"@neo-one/developer-tools@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/developer-tools/-/developer-tools-2.4.0.tgz#0b4e86c3ebcb9a32854ba12aec1f9df8cae5fe2a"
-  integrity sha512-esVo1M2bIvZLpx1NWnSYqucIa2TKYBznbql1WnbgV7Ze1YR9c8yL7AY9Zi5qO7iuKEtv3j4k0Zqe8v9Hz+J/8Q==
-  dependencies:
-    "@neo-one/client-core" "^2.4.0"
+    "@neo-one/client-core" "^2.6.0"
     resize-observer-polyfill "^1.5.0"
     tslib "^1.10.0"
 
@@ -1672,14 +1666,14 @@
   dependencies:
     asn1.js "^1.0.4"
 
-"@neo-one/node-core@^2.3.0", "@neo-one/node-core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/node-core/-/node-core-2.4.0.tgz#68bf91db2bfd451af51fa704175b62eeef1acd13"
-  integrity sha512-r366zoeW2xQRLZOwntrPQxgQKLuauz+A5L5jTdDJz5CMo+Q5E/l5kgoA7PeFZhZ79NDZ+zqEmHBz6b/PD3ExTA==
+"@neo-one/node-core@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/node-core/-/node-core-2.5.0.tgz#9a6b071e4f7c8f5589080634acfe36d02020a2f5"
+  integrity sha512-DbNVUVo+KTlOY4DIaCtjbRrcahad74/GOv81TUhKZkOh1O0NbgUKiRdWxEkLt+ap9XdUEanXZjp34ZXCZFmhgQ==
   dependencies:
-    "@neo-one/client-common" "^2.4.0"
-    "@neo-one/client-full-common" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-full-common" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     bignumber.js "^9.0.0"
     bn.js "^5.0.0"
     lodash "^4.17.15"
@@ -1687,27 +1681,27 @@
     through "^2.3.8"
     tslib "^1.10.0"
 
-"@neo-one/node-neo-settings@^2.3.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/node-neo-settings/-/node-neo-settings-2.4.0.tgz#786499c22c508266be4d772d6ba6e494bccaa1ad"
-  integrity sha512-Wy6bunvOYbOws1oSTKn/0sJDtsKIjbCkclN+1PM/uhVOKnyKfwcC96mdgXmc7xD0ojW8LFzg+v59OJchdkRF8Q==
+"@neo-one/node-neo-settings@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/node-neo-settings/-/node-neo-settings-2.5.0.tgz#f128861d9e58139031cf630aea1dde1109b1b74c"
+  integrity sha512-vyy1NHcM4Op/na8wQ3WoO0xm/Q2I36cxJj5F403PcMkJIGJx1oj8u1yoz5HF7joE4weBptq7Kxe/4RUfMvj3FQ==
   dependencies:
-    "@neo-one/client-common" "^2.4.0"
-    "@neo-one/node-core" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/node-core" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     bn.js "^5.0.0"
     lodash "^4.17.15"
     tslib "^1.10.0"
 
-"@neo-one/node-vm@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/node-vm/-/node-vm-2.4.0.tgz#d4b4cb66fafa92d0e6c7fbdb68174c66b94e76d7"
-  integrity sha512-FThmV53n6EQ1971tqiDTqxHTeK7EfpnwE5HbAU16lfIrJ9yx/5TIJUd4aL9XCFaeSU0BvBvNQiRaKdjbq8aTWA==
+"@neo-one/node-vm@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/node-vm/-/node-vm-2.5.0.tgz#089e9d7ac7166aa6ef2014ba368f70ba25c23a81"
+  integrity sha512-mNhyMGL6AcbtM/Kl5WY9CfR3Eq88q4HhX5NxaflFGO692K0RRGOnVDnmRxge1Lb1RikP1ovAcqixHSvRn61h/g==
   dependencies:
-    "@neo-one/client-common" "^2.4.0"
-    "@neo-one/client-full-common" "^2.4.0"
-    "@neo-one/node-core" "^2.4.0"
-    "@neo-one/utils" "^2.4.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-full-common" "^2.5.0"
+    "@neo-one/node-core" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     "@reactivex/ix-es2015-cjs" "^2.5.3"
     "@reactivex/ix-esnext-esm" "^2.5.3"
     bitwise "^2.0.3"
@@ -1716,28 +1710,28 @@
     rxjs "^6.5.3"
     tslib "^1.10.0"
 
-"@neo-one/utils@^2.3.0", "@neo-one/utils@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@neo-one/utils/-/utils-2.4.0.tgz#433554d96d5dc5aafdc403fcfff8b1477b4fe872"
-  integrity sha512-93abRWilCFOIVljVYoSrUha75tLDFV4BUNksi6QVvpZbtyKRSz3bIplZdU657P+jWrqCbEdELheRE41Y9kSb3A==
+"@neo-one/utils@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@neo-one/utils/-/utils-2.5.0.tgz#76b25753a171283e0d36af5b9aa41bf62ac4345c"
+  integrity sha512-JR7M67RcsIOYQqjzosKRI9aN5X7/juouTyr0ZsVw9RRf/8pPn8PdIm0q59HlGtJwI1Axqbkjcff1qymgXlwjjg==
   dependencies:
     "@types/node" "^12.7.7"
     lodash "^4.17.15"
     rxjs "^6.5.3"
     tslib "^1.10.0"
 
-"@neotracker/core@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@neotracker/core/-/core-1.3.1.tgz#ae85cb951e9ce4328d9a80541231756fe8877a8f"
-  integrity sha512-eIO7LB60bUdYY9nGu/xRSMd3gjYcsIeCz8sZA+7APuhmazcZTmgqnAQJvtRV1jLn5rwp2wq2hBMbC+MwL0P3lQ==
+"@neotracker/core@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@neotracker/core/-/core-1.4.0.tgz#7745677ea391a2fb4cdd11d6fcbc12e70101f32f"
+  integrity sha512-MKJOQCCCMXdsZXy3y+9evBaQuWgeLcC+HGS6dFlsEECH8yKJvPBOYgjZ93hFwOyDf3atyn60sQ2C2K6qlnhqMg==
   dependencies:
     "@material-ui/core" "^3.7.1"
-    "@neo-one/client" "^2.3.0"
-    "@neo-one/client-full" "^2.3.0"
-    "@neo-one/client-switch" "^2.3.0"
-    "@neo-one/node-core" "^2.3.0"
-    "@neo-one/node-neo-settings" "^2.3.0"
-    "@neo-one/utils" "^2.3.0"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-core" "^2.6.0"
+    "@neo-one/client-full" "^2.5.0"
+    "@neo-one/node-core" "^2.5.0"
+    "@neo-one/node-neo-settings" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
     apollo-cache-inmemory "^1.3.10"
     apollo-client "^2.4.6"
     apollo-link "^1.2.3"
@@ -1765,14 +1759,14 @@
     js-sha3 "^0.8.0"
     jss "^9.8.7"
     jss-preset-default "^4.3.0"
-    knex "^0.15.2"
+    knex "0.20.8"
     koa "^2.11.0"
     koa-better-body "^3.1.13"
     koa-compose "^4.1.0"
     koa-compress "^3.0.0"
     koa-convert "^1.2.0"
     koa-cors "^0.0.16"
-    koa-helmet "^4.0.0"
+    koa-helmet "^5.2.0"
     koa-ratelimit-lru "^1.0.2"
     koa-router "^7.4.0"
     locale2 "^2.3.1"
@@ -1782,7 +1776,6 @@
     objection "^1.4.0"
     pg "^7.7.1"
     pino "^5.13.2"
-    pino-pretty "^3.2.1"
     prop-types "^15.6.2"
     qr-image "^3.2.0"
     rc "^1.2.8"
@@ -1811,11 +1804,107 @@
     safe-stable-stringify "^1.1.0"
     scrypt-js "^2.0.4"
     semver "^5.6.0"
-    serialize-javascript "^1.5.0"
+    serialize-javascript "^2.1.2"
     sitemap "^5.0.1"
     source-map-support "^0.5.16"
     sql-summary "^1.0.1"
-    sqlite3 "^4.0.4"
+    sqlite3 "4.0.4"
+    styled-components "^4.1.3"
+    timeago.js "^4.0.0-beta.1"
+    toobusy-js "^0.5.1"
+    ua-parser-js "^0.7.19"
+    uuid "^3.2.1"
+    ws "^6.1.2"
+
+"@neotracker/core@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@neotracker/core/-/core-1.4.1.tgz#eb9d34542ac33df0f709c509250b583c74f09eb7"
+  integrity sha512-vkKmjVvYTf95UlyQLaXr4ioezUzpPckTghEu+qvrUwZxMdVuq4BIy/EBjj7PmbU/lCQRlZzQ45PlbhCAO6MVug==
+  dependencies:
+    "@material-ui/core" "^3.7.1"
+    "@neo-one/client-common" "^2.6.0"
+    "@neo-one/client-core" "^2.6.0"
+    "@neo-one/client-full" "^2.5.0"
+    "@neo-one/node-core" "^2.5.0"
+    "@neo-one/node-neo-settings" "^2.5.0"
+    "@neo-one/utils" "^2.5.0"
+    apollo-cache-inmemory "^1.3.10"
+    apollo-client "^2.4.6"
+    apollo-link "^1.2.3"
+    app-root-dir "^1.0.2"
+    bignumber.js "^9.0.0"
+    bn.js "^4.11.8"
+    change-case "^3.0.2"
+    chokidar "^2.0.3"
+    classnames "^2.2.6"
+    cross-fetch "^3.0.0"
+    cryptocompare "^0.6.0"
+    css.escape "^1.5.1"
+    dataloader "^1.4.0"
+    execa "^3.2.0"
+    fs-extra "^7.0.1"
+    graphql "14.5.8"
+    graphql-tag "^2.10.0"
+    graphql-tools "^4.0.3"
+    headroom.js "^0.9.4"
+    highcharts "^6.2.0"
+    http-errors "^1.7.0"
+    is-running "^2.1.0"
+    iterall "^1.2.2"
+    ix "^2.5.3"
+    js-sha3 "^0.8.0"
+    jss "^9.8.7"
+    jss-preset-default "^4.3.0"
+    knex "0.20.8"
+    koa "^2.11.0"
+    koa-better-body "^3.1.13"
+    koa-compose "^4.1.0"
+    koa-compress "^3.0.0"
+    koa-convert "^1.2.0"
+    koa-cors "^0.0.16"
+    koa-helmet "^5.2.0"
+    koa-ratelimit-lru "^1.0.2"
+    koa-router "^7.4.0"
+    locale2 "^2.3.1"
+    lodash "^4.17.11"
+    lru-cache "^4.1.1"
+    markdown-it "^8.4.2"
+    objection "^1.4.0"
+    pg "^7.7.1"
+    pino "^5.13.2"
+    prop-types "^15.6.2"
+    qr-image "^3.2.0"
+    rc "^1.2.8"
+    react "^16.7.0"
+    react-dom "^16.7.0"
+    react-helmet "^5.2.0"
+    react-jss "^8.6.1"
+    react-known-props "^2.4.0"
+    react-lifecycles-compat "^3.0.4"
+    react-loadable "^5.5.0"
+    react-redux "^5.1.1"
+    react-relay "1.6.2"
+    react-router "4.4.0-beta.1"
+    react-router-config "^4.4.0-beta.6"
+    react-router-dom "4.4.0-beta.1"
+    react-tippy "^1.2.3"
+    react-transition-group "^2.5.0"
+    recompose "^0.30.0"
+    redux "^4.0.1"
+    redux-actions "^2.6.4"
+    relay-compiler "1.6.2"
+    relay-runtime "1.6.2"
+    reselect "^4.0.0"
+    resolve-path "^1.4.0"
+    rxjs "^6.3.3"
+    safe-stable-stringify "^1.1.0"
+    scrypt-js "^2.0.4"
+    semver "^5.6.0"
+    serialize-javascript "^2.1.2"
+    sitemap "^5.0.1"
+    source-map-support "^0.5.16"
+    sql-summary "^1.0.1"
+    sqlite3 "4.0.9"
     styled-components "^4.1.3"
     timeago.js "^4.0.0-beta.1"
     toobusy-js "^0.5.1"
@@ -1848,70 +1937,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@opencensus/core@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@opencensus/core/-/core-0.0.19.tgz#058a2885179bb9f89db7fa93b366a73e51c0c8dc"
-  integrity sha512-Y5QXa7vggMU0+jveLcworfX9jNnztix7x1NraAV0uGkTp4y46HrFl0DnNcnNxUDvBu/cYeWRwlmhiWlr9+adOQ==
-  dependencies:
-    continuation-local-storage "^3.2.1"
-    log-driver "^1.2.7"
-    semver "^6.0.0"
-    shimmer "^1.2.0"
-    uuid "^3.2.1"
-
-"@opencensus/exporter-jaeger@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@opencensus/exporter-jaeger/-/exporter-jaeger-0.0.19.tgz#38abd5e791202b53c127b3e4f1b3d4ee3f1bcbf4"
-  integrity sha512-wlbPfTU8EhU7dhQMzMh8vJeHQ3GelEoAiMnKx53KtPjTi4Kl6jaLwizwxxiIWBc2P0QEANVWLyBR1pmazoQ/Jg==
-  dependencies:
-    "@opencensus/core" "^0.0.19"
-    jaeger-client "~3.17.0"
-
-"@opencensus/exporter-prometheus@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@opencensus/exporter-prometheus/-/exporter-prometheus-0.0.19.tgz#b2f9b3d1a7b8019e3bad9f769b93bc76a2914a6b"
-  integrity sha512-htVWkHPCA7OO00t21MidSNHJ3+blLnXQkxx6P2reARvKg2bRn5d1RAkIK5sBbS6eHrIFkI21VWGGUtcFJlE6Dw==
-  dependencies:
-    "@opencensus/core" "^0.0.19"
-    express "^4.16.3"
-    prom-client "^11.1.1"
-
-"@opencensus/nodejs-base@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@opencensus/nodejs-base/-/nodejs-base-0.0.19.tgz#69aad730543cb740b942928aea9d09c7d7971c13"
-  integrity sha512-pzhvCQv2HPVdhkazPf9U55pC9LU6jTvJjilWHI+3vnHXNOozDTGK/3UwIxvlLcwzi0K2qJ1ubOsHry38sanBtg==
-  dependencies:
-    "@opencensus/core" "^0.0.19"
-    extend "^3.0.2"
-    require-in-the-middle "^4.0.0"
-
-"@opencensus/propagation-tracecontext@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@opencensus/propagation-tracecontext/-/propagation-tracecontext-0.0.19.tgz#9776fd0528dfc3432cd40321cf1589a9733dcdca"
-  integrity sha512-6uO5VA744ESiwSswM5+ADR7NuDaopYHAhgasuKu2sLa4WYOkMHHZzAZ9gRcP+JHSQydwcKDgSlmfBx4QijdB+w==
-  dependencies:
-    "@opencensus/core" "^0.0.19"
-
-"@opencensus/web-core@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@opencensus/web-core/-/web-core-0.0.7.tgz#daa5fed6d5909be867f8eecd4ff88ac818b0aec3"
-  integrity sha512-UHAwQMP2kgWKuLkrEGpH0/NSLeiib4/E2SIMCUdTpqXgDWVEBab2hnBLQDWkfC6TgFLMWNDP7BI13HqIyKhQvQ==
-  dependencies:
-    "@opencensus/web-types" "^0.0.7"
-    "@types/node" "^12.6.9"
-
-"@opencensus/web-propagation-tracecontext@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@opencensus/web-propagation-tracecontext/-/web-propagation-tracecontext-0.0.7.tgz#c037eb5e90964464643bcea55d2a827851c16dce"
-  integrity sha512-nsoftaJ2I4axkBsNertmSlTxSlc34IeW28UVK5sesC6RO3RiWnDHHG3EzTfjoH0f0Vfx53DqhrO0cPjca228fA==
-  dependencies:
-    "@opencensus/web-core" "^0.0.7"
-
-"@opencensus/web-types@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@opencensus/web-types/-/web-types-0.0.7.tgz#4426de1fe5aa8f624db395d2152b902874f0570a"
-  integrity sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g==
 
 "@phenomnomnominal/tsquery@^4.0.0":
   version "4.0.0"
@@ -2122,6 +2147,7 @@
     "@types/yargs" "^13.0.3"
     execa "^3.2.0"
     fs-extra "^8.1.0"
+    glob "^7.1.4"
     gulp "~4.0.2"
     gulp-banner "^0.1.3"
     gulp-filter "^6.0.0"
@@ -2183,7 +2209,7 @@
     "@angular/core" "^8.2.7"
     "@babel/core" "^7.6.2"
     "@babel/register" "^7.5.5"
-    "@neotracker/core" "1.3.1"
+    "@neotracker/core" "1.4.1"
     "@types/bn.js" "^4.11.5"
     "@types/fs-extra" "^8.0.0"
     "@types/jest" "^24.0.18"
@@ -3743,7 +3769,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.12.tgz#bf5d348c4d37c026029ad81e874946fa6ad100ba"
   integrity sha512-iefeBfpmhoYaZfj+gJM5z9H9eiTwhuzhPsJgH/flx4HP2SBI2FNDra1D3vKljqPLGDr9Cazvh9gP9Xszc30ncA==
 
-"@types/node@^12.12.3", "@types/node@^12.6.9", "@types/node@^12.7.7":
+"@types/node@^12.12.3", "@types/node@^12.7.7":
   version "12.12.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.37.tgz#cb4782d847f801fa58316da5b4801ca3a59ae790"
   integrity sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg==
@@ -4407,7 +4433,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abort-controller@3.0.0, abort-controller@^3.0.0:
+abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -4572,11 +4598,6 @@ ansi-align@^3.0.0:
   integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
   dependencies:
     string-width "^3.0.0"
-
-ansi-color@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-color/-/ansi-color-0.2.1.tgz#3e75c037475217544ed763a8db5709fa9ae5bf9a"
-  integrity sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o=
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -5081,14 +5102,6 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async-listener@^0.6.0:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
-  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
-  dependencies:
-    semver "^5.3.0"
-    shimmer "^1.1.0"
 
 async-settle@^1.0.0:
   version "1.0.0"
@@ -5856,11 +5869,6 @@ bindings@^1.4.0, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bintrees@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
-  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
-
 bitbuffer@0.1.x:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/bitbuffer/-/bitbuffer-0.1.3.tgz#780feb1297caaf0fac9e48cfab946d6efd2bd397"
@@ -5916,7 +5924,7 @@ bluebird@3.7.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
   integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
-bluebird@^3.5.1, bluebird@^3.5.5:
+bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6261,16 +6269,6 @@ buffer@^5.2.1, buffer@^5.5.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-bufrw@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bufrw/-/bufrw-1.3.0.tgz#28d6cfdaf34300376836310f5c31d57eeb40c8fa"
-  integrity sha512-jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==
-  dependencies:
-    ansi-color "^0.2.1"
-    error "^7.0.0"
-    hexer "^1.5.0"
-    xtend "^4.0.0"
-
 builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -6549,15 +6547,6 @@ ccount@^1.0.0, ccount@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
-
-chalk@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
-  integrity sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chalk@2.4.1:
   version "2.4.1"
@@ -7008,6 +6997,11 @@ color@^3.0.0, color@^3.1.2:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
+colorette@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
+  integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
+
 colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -7035,7 +7029,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.12.1, commander@^2.16.0, commander@^2.18.0, commander@^2.20.0:
+commander@^2.12.1, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -7045,7 +7039,7 @@ commander@^3.0.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
-commander@^4.0.1:
+commander@^4.0.1, commander@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7251,14 +7245,6 @@ content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-continuation-local-storage@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
-  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
-  dependencies:
-    async-listener "^0.6.0"
-    emitter-listener "^1.1.1"
 
 convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
@@ -7899,13 +7885,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@3.2.6, debug@3.X, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -7919,6 +7898,13 @@ debug@4, debug@4.1.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@=3.1.0, debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -8077,14 +8063,6 @@ deferred-leveldown@~5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz#1642eb18b535dfb2b6ac4d39fb10a9cbcfd13b09"
   integrity sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==
-  dependencies:
-    abstract-leveldown "~6.0.0"
-    inherits "^2.0.3"
-
-deferred-leveldown@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.1.0.tgz#c21e40641a8e48530255a4ad31371cc7fe76b332"
-  integrity sha512-PvDY+BT2ONu2XVRgxHb77hYelLtMYxKSGuWuJJdVRXh9ntqx9GYTFJno/SKAz5xcd+yjQwyQeIZrUPjPvA52mg==
   dependencies:
     abstract-leveldown "~6.0.0"
     inherits "^2.0.3"
@@ -8338,11 +8316,6 @@ dns-packet@^1.3.1:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
 
-dns-prefetch-control@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz#73988161841f3dcc81f47686d539a2c702c88624"
-  integrity sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q==
-
 dns-txt@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
@@ -8593,13 +8566,6 @@ elliptic@^6.0.0, elliptic@^6.5.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emitter-listener@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
-  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
-  dependencies:
-    shimmer "^1.2.0"
-
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -8768,21 +8734,6 @@ error-inject@^1.0.0:
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
   integrity sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
 
-error@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/error/-/error-7.0.2.tgz#a5f75fff4d9926126ddac0ea5dc38e689153cb02"
-  integrity sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=
-  dependencies:
-    string-template "~0.2.1"
-    xtend "~4.0.0"
-
-error@^7.0.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/error/-/error-7.2.1.tgz#eab21a4689b5f684fc83da84a0e390de82d94894"
-  integrity sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==
-  dependencies:
-    string-template "~0.2.1"
-
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstract@^1.17.5:
   version "1.17.5"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
@@ -8894,6 +8845,11 @@ eslint-scope@^4.0.3:
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^2.2.3:
   version "2.2.5"
@@ -9125,11 +9081,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
-
-expect-ct@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.2.0.tgz#3a54741b6ed34cc7a93305c605f63cd268a54a62"
-  integrity sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g==
 
 expect@^24.9.0:
   version "24.9.0"
@@ -9447,14 +9398,6 @@ fetch-cookie@0.7.0:
   dependencies:
     es6-denodeify "^0.1.1"
     tough-cookie "^2.3.1"
-
-fetch-cookie@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-0.7.3.tgz#b8d023f421dd2b2f4a0eca9cd7318a967ed4eed8"
-  integrity sha512-rZPkLnI8x5V+zYAiz8QonAHsTb4BY+iFowFBI1RFn0zrO343AVp9X7/yUj/9wL6Ef/8fLls8b/vGtzUvmyAUGA==
-  dependencies:
-    es6-denodeify "^0.1.1"
-    tough-cookie "^2.3.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -9805,11 +9748,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frameguard@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-3.1.0.tgz#bd1442cca1d67dc346a6751559b6d04502103a22"
-  integrity sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g==
-
 fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -10048,6 +9986,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+getopts@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.5.tgz#67a0fe471cacb9c687d817cab6450b96dde8313b"
+  integrity sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==
 
 getos@3.1.1:
   version "3.1.1"
@@ -10820,23 +10763,19 @@ helmet-csp@2.10.0:
     content-security-policy-builder "2.1.0"
     dasherize "2.0.0"
 
-helmet@^3.15.1:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.22.0.tgz#3a6f11d931799145f0aff15dbc563cff9e13131f"
-  integrity sha512-Xrqicn2nm1ZIUxP3YGuTBmbDL04neKsIT583Sjh0FkiwKDXYCMUqGqC88w3NUvVXtA75JyR2Jn6jw6ZEMOD+ZA==
+helmet@^3.21.1:
+  version "3.23.3"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.23.3.tgz#5ba30209c5f73ded4ab65746a3a11bedd4579ab7"
+  integrity sha512-U3MeYdzPJQhtvqAVBPntVgAvNSOJyagwZwyKsFdyRa8TV3pOKVFljalPOCxbw5Wwf2kncGhmP0qHjyazIdNdSA==
   dependencies:
     depd "2.0.0"
-    dns-prefetch-control "0.2.0"
     dont-sniff-mimetype "1.1.0"
-    expect-ct "0.2.0"
     feature-policy "0.3.0"
-    frameguard "3.1.0"
     helmet-crossdomain "0.4.0"
     helmet-csp "2.10.0"
     hide-powered-by "1.1.0"
     hpkp "2.0.0"
     hsts "2.2.0"
-    ienoopen "1.1.0"
     nocache "2.1.0"
     referrer-policy "1.2.0"
     x-xss-protection "1.3.0"
@@ -10845,16 +10784,6 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
-hexer@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/hexer/-/hexer-1.5.0.tgz#b86ce808598e8a9d1892c571f3cedd86fc9f0653"
-  integrity sha1-uGzoCFmOip0YksVx887dhvyfBlM=
-  dependencies:
-    ansi-color "^0.2.1"
-    minimist "^1.1.0"
-    process "^0.10.0"
-    xtend "^4.0.0"
 
 hide-powered-by@1.1.0:
   version "1.1.0"
@@ -11205,11 +11134,6 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ienoopen@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ienoopen/-/ienoopen-1.1.0.tgz#411e5d530c982287dbdc3bb31e7a9c9e32630974"
-  integrity sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ==
-
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
@@ -11365,7 +11289,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -11426,6 +11350,11 @@ interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+interpret@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
+  integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
 intersection-observer@^0.7.0:
   version "0.7.0"
@@ -12156,17 +12085,6 @@ ix@^2.5.3:
   dependencies:
     "@types/node" "^11.11.6"
     tslib "^1.9.3"
-
-jaeger-client@~3.17.0:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.17.2.tgz#92cf26752c5c66f3e66adf595cdde2f548cc0804"
-  integrity sha512-19YloSidmKbrXHgecLWod8eXo7rm2ieUnsfg0ripTFGRCW5v2OWE96Gte4/tOQG/8N+T39VoLU2nMBdjbdMUJg==
-  dependencies:
-    node-int64 "^0.4.0"
-    opentracing "^0.13.0"
-    thriftrw "^3.5.0"
-    uuid "^3.2.1"
-    xorshift "^0.2.0"
 
 jest-changed-files@^24.9.0:
   version "24.9.0"
@@ -12979,27 +12897,27 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.15.2.tgz#6059b87489605f4cc87599a6d2a9d265709e9340"
-  integrity sha1-YFm4dIlgX0zIdZmm0qnSZXCek0A=
+knex@0.20.8:
+  version "0.20.8"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.8.tgz#b41c72773185e1032f4a77074198413521827860"
+  integrity sha512-fLiSg5PIBisORs0M+UGjg2s1P/E1BrYvb/NkSVk6Y90HJujkqLufSC6ag+hDgXqW73mFAF283M6+q3/NW0TrHw==
   dependencies:
-    babel-runtime "^6.26.0"
-    bluebird "^3.5.1"
-    chalk "2.3.2"
-    commander "^2.16.0"
-    debug "3.1.0"
-    inherits "~2.0.3"
-    interpret "^1.1.0"
-    liftoff "2.5.0"
-    lodash "^4.17.10"
-    minimist "1.2.0"
+    bluebird "^3.7.2"
+    colorette "1.1.0"
+    commander "^4.1.0"
+    debug "4.1.1"
+    esm "^3.2.25"
+    getopts "2.2.5"
+    inherits "~2.0.4"
+    interpret "^2.0.0"
+    liftoff "3.1.0"
+    lodash "^4.17.15"
     mkdirp "^0.5.1"
-    pg-connection-string "2.0.0"
-    tarn "^1.1.4"
-    tildify "1.2.0"
-    uuid "^3.3.2"
-    v8flags "^3.1.1"
+    pg-connection-string "2.1.0"
+    tarn "^2.0.0"
+    tildify "2.0.0"
+    uuid "^3.3.3"
+    v8flags "^3.1.3"
 
 koa-better-body@^3.1.13:
   version "3.3.9"
@@ -13059,12 +12977,12 @@ koa-cors@^0.0.16:
   resolved "https://registry.yarnpkg.com/koa-cors/-/koa-cors-0.0.16.tgz#98107993a7909e34c042986c5ec6156d77f3432e"
   integrity sha1-mBB5k6eQnjTAQphsXsYVbXfzQy4=
 
-koa-helmet@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/koa-helmet/-/koa-helmet-4.2.1.tgz#6f6598aa1dbde501c5f7e92b80a5358690cc13d8"
-  integrity sha512-CzN14/hH/su37Pj4rarXZfR/NQZbbnmCU6cS3WLnEQyvZO3Mp6oMayNVAnR08dKZShhCYpIN8cuJwD5g34oQ/w==
+koa-helmet@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/koa-helmet/-/koa-helmet-5.2.0.tgz#6529f64dd4539261a9bb0a56e201e4976f0200f0"
+  integrity sha512-Q4h4CnpcEo3NuIvD1bBOakkfusPiOvJc/NlOI9M+pG3zeNm2OqFLMbIzCPsvGBz++37KMregUBXZvQiNPDD37w==
   dependencies:
-    helmet "^3.15.1"
+    helmet "^3.21.1"
 
 koa-is-json@^1.0.0:
   version "1.0.0"
@@ -13248,7 +13166,7 @@ level-js@^5.0.0:
     inherits "^2.0.3"
     ltgt "^2.1.2"
 
-level-packager@^5.0.0, level-packager@^5.1.0:
+level-packager@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/level-packager/-/level-packager-5.1.1.tgz#323ec842d6babe7336f70299c14df2e329c18939"
   integrity sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==
@@ -13280,16 +13198,6 @@ level@5.0.1:
     leveldown "^5.0.0"
     opencollective-postinstall "^2.0.0"
 
-level@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/level/-/level-6.0.0.tgz#d216fb9b9c3940bcec15c5880d8da775ca086c5c"
-  integrity sha512-3oAi7gXLLNr7pHj8c4vbI6lHkXf35m8qb7zWMrNTrOax6CXBVggQAwL1xnC/1CszyYrW3BsLXsY5TMgTxtKfFA==
-  dependencies:
-    level-js "^5.0.0"
-    level-packager "^5.1.0"
-    leveldown "^5.4.0"
-    opencollective-postinstall "^2.0.0"
-
 leveldown@5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-5.0.2.tgz#c8edc2308c8abf893ffc81e66ab6536111cae92c"
@@ -13300,16 +13208,7 @@ leveldown@5.0.2:
     napi-macros "~1.8.1"
     node-gyp-build "~3.8.0"
 
-leveldown@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-5.4.1.tgz#83a8fdd9bb52b1ed69be2ef59822b6cdfcdb51ec"
-  integrity sha512-3lMPc7eU3yj5g+qF1qlALInzIYnkySIosR1AsUKFjL9D8fYbTLuENBAeDRZXIG4qeWOAyqRItOoLu2v2avWiMA==
-  dependencies:
-    abstract-leveldown "~6.2.1"
-    napi-macros "~2.0.0"
-    node-gyp-build "~4.1.0"
-
-leveldown@^5.0.0, leveldown@^5.1.1, leveldown@^5.4.0:
+leveldown@^5.0.0, leveldown@^5.1.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-5.6.0.tgz#16ba937bb2991c6094e13ac5a6898ee66d3eee98"
   integrity sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==
@@ -13324,16 +13223,6 @@ levelup@4.0.2:
   integrity sha512-cx9PmLENwbGA3svWBEbeO2HazpOSOYSXH4VA+ahVpYyurvD+SDSfURl29VBY2qgyk+Vfy2dJd71SBRckj/EZVA==
   dependencies:
     deferred-leveldown "~5.0.0"
-    level-errors "~2.0.0"
-    level-iterator-stream "~4.0.0"
-    xtend "~4.0.0"
-
-levelup@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/levelup/-/levelup-4.1.0.tgz#49ab5d3a341731cd102f91c6bc17a1acb1969a17"
-  integrity sha512-+Qhe2/jb5affN7BeFgWUUWVdYoGXO2nFS3QLEZKZynnQyP9xqA+7wgOz3fD8SST2UKpHQuZgjyJjTcB2nMl2dQ==
-  dependencies:
-    deferred-leveldown "~5.1.0"
     level-errors "~2.0.0"
     level-iterator-stream "~4.0.0"
     xtend "~4.0.0"
@@ -13381,21 +13270,7 @@ lie@3.1.1:
   dependencies:
     immediate "~3.0.5"
 
-liftoff@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-2.5.0.tgz#2009291bb31cea861bbf10a7c15a28caf75c31ec"
-  integrity sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=
-  dependencies:
-    extend "^3.0.0"
-    findup-sync "^2.0.0"
-    fined "^1.0.1"
-    flagged-respawn "^1.0.0"
-    is-plain-object "^2.0.4"
-    object.map "^1.0.0"
-    rechoir "^0.6.2"
-    resolve "^1.1.7"
-
-liftoff@^3.1.0:
+liftoff@3.1.0, liftoff@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
   integrity sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
@@ -13811,11 +13686,6 @@ lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log-driver@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
-
 log-symbols@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -13858,11 +13728,6 @@ loglevel@^1.6.6:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
-
-long@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
-  integrity sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8=
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -14446,11 +14311,6 @@ modernizr@^3.7.1:
     requirejs "^2.3.6"
     yargs "^15.3.1"
 
-module-details-from-path@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
-  integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
-
 moment@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
@@ -14572,6 +14432,11 @@ nan@^2.12.1, nan@^2.13.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nan@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
 nanoid@^2.0.3:
   version "2.1.11"
@@ -14774,6 +14639,22 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-pre-gyp@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 node-pre-gyp@^0.11.0:
   version "0.11.0"
@@ -15241,11 +15122,6 @@ opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
-
-opentracing@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.13.0.tgz#6a341442f09d7d866bc11ed03de1e3828e3d6aab"
-  integrity sha1-ajQUQvCdfYZrwR7QPeHjgo49aqs=
 
 opn@^5.5.0:
   version "5.5.0"
@@ -15808,10 +15684,10 @@ pg-connection-string@0.1.3:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
 
-pg-connection-string@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.0.0.tgz#3eefe5997e06d94821e4d502e42b6a1c73f8df82"
-  integrity sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I=
+pg-connection-string@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.1.0.tgz#e07258f280476540b24818ebb5dca29e101ca502"
+  integrity sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -16442,32 +16318,6 @@ pouchdb@7.1.1:
     uuid "3.2.1"
     vuvuzela "1.0.3"
 
-pouchdb@^7.1.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/pouchdb/-/pouchdb-7.2.1.tgz#619e3d5c2463ddd94a4b1bf40d44408c46e9de79"
-  integrity sha512-AoDPdr6tFqj3xs7oiD2oioYj5MMu87c3UemRHZ/p++BwU+ZsKn5jpnL09OvWTLvMvaICGAOufiaUzmM1/KKoKQ==
-  dependencies:
-    abort-controller "3.0.0"
-    argsarray "0.0.1"
-    buffer-from "1.1.0"
-    clone-buffer "1.0.0"
-    double-ended-queue "2.1.0-0"
-    fetch-cookie "0.7.3"
-    immediate "3.0.6"
-    inherits "2.0.4"
-    level "6.0.0"
-    level-codec "9.0.1"
-    level-write-stream "1.0.0"
-    leveldown "5.4.1"
-    levelup "4.1.0"
-    ltgt "2.2.1"
-    node-fetch "2.4.1"
-    readable-stream "1.0.33"
-    spark-md5 "3.0.0"
-    through2 "3.0.1"
-    uuid "3.3.3"
-    vuvuzela "1.0.3"
-
 prebuild-install@^5.3.0, prebuild-install@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"
@@ -16582,11 +16432,6 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
-  integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
-
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -16596,13 +16441,6 @@ progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-prom-client@^11.1.1:
-  version "11.5.3"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.5.3.tgz#5fedfce1083bac6c2b223738e966d0e1643756f8"
-  integrity sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==
-  dependencies:
-    tdigest "^0.1.1"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -17807,15 +17645,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-in-the-middle@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-4.0.1.tgz#9f2828eb280722c911f62c2cb56e749c038619e2"
-  integrity sha512-EfkM2zANyGkrfIExsECMeNn/uzjvHrE9h36yLXSavmrDiH4tgDNvltAmEKnt4PNLbqKPHZz+uszW2wTKrLUX0w==
-  dependencies:
-    debug "^4.1.1"
-    module-details-from-path "^1.0.3"
-    resolve "^1.12.0"
-
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -18295,11 +18124,6 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-serialize-javascript@^1.5.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
 serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
@@ -18438,11 +18262,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shimmer@^1.1.0, shimmer@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
-  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 shorthash@^0.0.2:
   version "0.0.2"
@@ -18840,13 +18659,23 @@ sql-summary@^1.0.1:
   resolved "https://registry.yarnpkg.com/sql-summary/-/sql-summary-1.0.1.tgz#a2dddb5435bae294eb11424a7330dc5bafe09c2b"
   integrity sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww==
 
-sqlite3@^4.0.4:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.2.0.tgz#49026d665e9fc4f922e56fb9711ba5b4c85c4901"
-  integrity sha512-roEOz41hxui2Q7uYnWsjMOTry6TcNUNmp8audCx18gF10P2NknwdpF+E+HKvz/F2NvPKGGBF4NGc+ZPQ+AABwg==
+sqlite3@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.4.tgz#1f75e3ededad6e26f7dd819929460ce44a49dfcd"
+  integrity sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==
+  dependencies:
+    nan "~2.10.0"
+    node-pre-gyp "^0.10.3"
+    request "^2.87.0"
+
+sqlite3@4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.9.tgz#cff74550fa5a1159956815400bdef69245557640"
+  integrity sha512-IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"
+    request "^2.87.0"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -18998,11 +18827,6 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
-
-string-template@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
-  integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -19421,17 +19245,10 @@ tar@^5.0.0:
     mkdirp "^0.5.0"
     yallist "^4.0.0"
 
-tarn@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/tarn/-/tarn-1.1.5.tgz#7be88622e951738b9fa3fb77477309242cdddc2d"
-  integrity sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g==
-
-tdigest@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
-  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
-  dependencies:
-    bintrees "1.0.1"
+tarn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tarn/-/tarn-2.0.0.tgz#c68499f69881f99ae955b4317ca7d212d942fdee"
+  integrity sha512-7rNMCZd3s9bhQh47ksAQd92ADFcJUjjbyOvyFjNLwTPpGieFHMC84S+LOzw0fx1uh6hnDz/19r8CPMnIjJlMMA==
 
 teeny-request@6.0.1:
   version "6.0.1"
@@ -19569,15 +19386,6 @@ thread-loader@^2.1.3:
     loader-utils "^1.1.0"
     neo-async "^2.6.0"
 
-thriftrw@^3.5.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/thriftrw/-/thriftrw-3.12.0.tgz#30857847755e7f036b2e0a79d11c9f55075539d9"
-  integrity sha512-4YZvR4DPEI41n4Opwr4jmrLGG4hndxr7387kzRFIIzxHQjarPusH4lGXrugvgb7TtPrfZVTpZCVe44/xUxowEw==
-  dependencies:
-    bufrw "^1.3.0"
-    error "7.0.2"
-    long "^2.4.0"
-
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -19629,12 +19437,10 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tildify@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
-  integrity sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=
-  dependencies:
-    os-homedir "^1.0.0"
+tildify@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
+  integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
 time-stamp@^1.0.0:
   version "1.1.0"
@@ -20541,10 +20347,17 @@ uuid@^7.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-v8flags@^3.0.1, v8flags@^3.1.1:
+v8flags@^3.0.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
   integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
+v8flags@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
+  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
   dependencies:
     homedir-polyfill "^1.0.1"
 
@@ -21308,11 +21121,6 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
-
-xorshift@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
-  integrity sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=
 
 xregexp@^4.2.4:
   version "4.3.0"

--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -59,7 +59,7 @@
     "@neo-one/build-tools": "^1.0.0",
     "@neo-one/smart-contract": "^2.5.0",
     "@neo-one/smart-contract-test": "^2.5.0",
-    "@neotracker/core": "1.3.1",
+    "@neotracker/core": "1.4.1",
     "@types/bn.js": "^4.11.5",
     "@types/fs-extra": "^8.0.0",
     "@types/jest": "^24.0.18",

--- a/packages/neo-one-cli/src/__e2e__/cmd/start/neotracker.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/start/neotracker.test.ts
@@ -17,8 +17,6 @@ describe('start network', () => {
     });
 
     execAsync('start neotracker');
-    // this allows us to run the e2e tests in parallel, successfully
-    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     await one.until(async () => {
       const live = await isRunning(config.neotracker.port);

--- a/packages/neo-one-cli/src/__e2e__/cmd/stop/neotracker.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/stop/neotracker.test.ts
@@ -17,8 +17,6 @@ describe('start network', () => {
     });
 
     execAsync('start neotracker');
-    // this allows us to run the e2e tests in parallel, successfully
-    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     await one.until(async () => {
       const live = await isRunning(config.neotracker.port);

--- a/packages/neo-one-cli/src/cmd/start/neotracker.ts
+++ b/packages/neo-one-cli/src/cmd/start/neotracker.ts
@@ -30,9 +30,10 @@ export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
       `${config.neotracker.port}`,
       '--nodeRpcUrl',
       `http://localhost:${config.network.port}/rpc`,
-      '--dbFileName',
+      '--db.connection.filename',
       nodePath.resolve(config.neotracker.path, 'db.sqlite'),
     ];
+
     let neotrackerBinPath: string;
     try {
       neotrackerBinPath = require.resolve('@neotracker/core/bin');
@@ -43,13 +44,14 @@ export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
       );
     }
     const proc = execa(
-      nodePath.resolve(neotrackerBinPath, '../', 'neotracker'),
+      nodePath.resolve(neotrackerBinPath, '..', 'neotracker'),
       argv.reset ? args.concat(['--resetDB']) : args,
       {
         cleanup: false,
         stdio: 'ignore',
       },
     );
+
     proc.unref();
 
     await writePidFile('neotracker', proc, config);

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
 
   "eventHooks": {
     "preRushInstall": [],
-    "postRushInstall": ["node ./common/scripts/neo-one-prune.js"],
+    "postRushInstall": [],
     "preRushBuild": [],
     "postRushBuild": []
   },


### PR DESCRIPTION
### Description of the Change

Update neotracker dependency to 1.4.1 to get rid of any traces of opencensus and to keep NT up to date in our E2E tests. Makes NT E2E tests work again.

### Test Plan

- `rush e2e -t neotracker`
- CI checks

### Alternate Designs

We tried a few things to essentially simulate neotracker being a part of this monorepo but everything hit a wall one way or another whether it be dependency resolution or problems rush encountered during its linking when I attempted to just create the correct `@neo-one` symlinks for neotracker myself.

### Benefits

opencensus should never creep up again

### Possible Drawbacks

we are going back to NOT deleting the `@neo-one` dependencies post-install, let neotracker do whatever its going to do in practice it should resolve to whatever version of `@neo-one` the user has installed (which could cause its own problems down the line since we don't explicitly test that interaction like we were trying to do)

### Applicable Issues

#2073 
