### PR TITLE
fix(husky): remove checkout hook

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -9,7 +9,6 @@ const hooks =
         'pre-commit': `rush check && rush lint:staged -p 16 && rush build && GIT_DIR=${basePath} rush change -v`,
         'post-merge': 'rush install',
         'post-rewrite': 'rush install',
-        'post-checkout': 'rush install',
       };
 
 module.exports = {


### PR DESCRIPTION
### Description of the Change

Running `rush install` every checkout seems excessive. So we're removing it.

### Test Plan

It works.

### Alternate Designs

None.

### Benefits

Quicker development env.

### Possible Drawbacks

Don't forget to `rush install` when necessary.