### PR TITLE
fix(cli): migration.ts fix

### DIFF
--- a/common/changes/@neo-one/cli/migration-ts-fix_2020-07-22-20-43.json
+++ b/common/changes/@neo-one/cli/migration-ts-fix_2020-07-22-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "patch migration.ts file transpiling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "danwbyrne@gmail.com"
+}

--- a/packages/neo-one-cli/src/common/load.ts
+++ b/packages/neo-one-cli/src/common/load.ts
@@ -1,5 +1,3 @@
-import { register } from 'ts-node';
-
 const load = async (path: string) => {
   const value = await import(path);
 
@@ -13,12 +11,4 @@ export const loadJS = async (path: string) => {
   return load(path);
 };
 
-export const loadTS = async (path: string) => {
-  register({
-    compilerOptions: {
-      module: 'commonjs',
-    },
-  });
-
-  return load(path);
-};
+export const loadTS = load;


### PR DESCRIPTION
### Issue

#2090 

Migration files saved as typescript were not working because of a ts-node register call when loading them. This removes that register call which fixes everything.

### Additional Comments
Its not completely clear to me what was happening but the ts error:
```
mart-contract/migration.ts:3:28 - error TS7006: Parameter '_a' implicitly has an 'any' type.

3 module.exports = function (_a, _network) {
                             ~~
smart-contract/migration.ts:3:32 - error TS7006: Parameter '_network' implicitly has an 'any' type.

3 module.exports = function (_a, _network) {
                                 ~~~~~~~~
","stack":"TSError: ⨯ Unable to compile TypeScript:
smart-contract/migration.ts:3:28 - error TS7006: Parameter '_a' implicitly has an 'any' type.

3 module.exports = function (_a, _network) {
                             ~~
smart-contract/migration.ts:3:32 - error TS7006: Parameter '_network' implicitly has an 'any' type.
```

leads me to believe it was trying to transpile the `migration.ts` file twice in loading it.