### PR TITLE
feat(rpc): first round of RPC updates

### DIFF
--- a/packages/neo-one-client-common/src/GasToken.ts
+++ b/packages/neo-one-client-common/src/GasToken.ts
@@ -1,0 +1,1 @@
+export class GasToken {}

--- a/packages/neo-one-client-common/src/NativeContract.ts
+++ b/packages/neo-one-client-common/src/NativeContract.ts
@@ -1,12 +1,19 @@
 import { common, UInt160 } from './common';
 import { crypto } from './crypto';
+import { GasToken } from './GasToken';
 import { scriptHashToAddress } from './helpers';
+import { NeoToken } from './NeoToken';
+import { PolicyContract } from './PolicyContract';
 import { ScriptBuilder } from './ScriptBuilder';
 import { AddressString } from './types';
 
-export type NativeContractServiceName = 'Neo.Native.Policy' | 'Neo.Native.Tokens.GAS' | 'Neo.Native.Tokens.NEO';
+export type NativeContractServiceName = 'Policy' | 'GAS' | 'NEO';
 
-class NativeContract {
+export class NativeContract {
+  public static readonly NEO: NeoToken;
+  public static readonly GAS: GasToken;
+  public static readonly Policy: PolicyContract;
+
   public readonly serviceName: NativeContractServiceName;
   public readonly script: Buffer;
   public readonly scriptHex: string;
@@ -26,9 +33,3 @@ class NativeContract {
     this.address = scriptHashToAddress(this.scriptHash);
   }
 }
-
-export const NativeContracts = {
-  NEO: new NativeContract('Neo.Native.Tokens.NEO'),
-  GAS: new NativeContract('Neo.Native.Tokens.GAS'),
-  Policy: new NativeContract('Neo.Native.Policy'),
-};

--- a/packages/neo-one-client-common/src/NeoToken.ts
+++ b/packages/neo-one-client-common/src/NeoToken.ts
@@ -1,0 +1,1 @@
+export class NeoToken {}

--- a/packages/neo-one-client-common/src/PolicyContract.ts
+++ b/packages/neo-one-client-common/src/PolicyContract.ts
@@ -1,0 +1,7 @@
+import { NativeContract } from './NativeContract';
+
+export class PolicyContract extends NativeContract {
+  public constructor() {
+    super('Policy');
+  }
+}

--- a/packages/neo-one-client-common/src/index.ts
+++ b/packages/neo-one-client-common/src/index.ts
@@ -8,6 +8,8 @@ export * from './IOHelper';
 export * from './JSONHelper';
 export * from './models';
 export * from './NativeContract';
+export * from './GasToken';
+export * from './NeoToken';
 export * from './paramUtils';
 export * from './BaseScriptBuilder';
 export * from './ScriptBuilder';

--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -190,7 +190,7 @@ export type AttributeTypeJSON = keyof typeof AttributeTypeModel;
 
 export type VerifyResultJSON = keyof typeof VerifyResultModel;
 
-// TODO: check that this can be removed. or rename to "TransactionDataJSON" ?
+// TODO: what extra invocation data are we going to include now?
 export interface InvocationDataJSON {
   readonly result: InvocationResultJSON;
   // readonly asset?: AssetJSON;
@@ -217,8 +217,14 @@ export interface TransactionJSON {
   readonly witnesses: readonly WitnessJSON[];
 }
 
+export interface TransactionWithInvocationDataJSON extends TransactionJSON {
+  readonly script: string;
+  readonly gas: string;
+  readonly invocationData?: InvocationDataJSON | undefined;
+}
+
 export interface TransactionReceiptJSON {
-  readonly blockIndex: number; // TODO: check this
+  readonly blockIndex: number;
   readonly blockHash: string;
   readonly transactionIndex: number;
   readonly globalIndex: string;
@@ -281,6 +287,7 @@ export interface ContractParameterDefinitionJSON {
 }
 
 export interface ContractJSON {
+  readonly id: number;
   readonly hash: string;
   readonly script: string;
   readonly manifest: ContractManifestJSON;

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -2290,6 +2290,7 @@ export type ParamJSON =
  * Constant settings used to initialize the client APIs.
  */
 export interface NetworkSettings {
+  // TODO: remove/replace this
   readonly issueGASFee: BigNumber;
 }
 

--- a/packages/neo-one-csharp-core/package.json
+++ b/packages/neo-one-csharp-core/package.json
@@ -13,6 +13,7 @@
   "sideEffects": false,
   "dependencies": {
     "@neo-one/client-common": "^2.7.0",
+    "@neo-one/client-full-common": "^2.7.0",
     "@neo-one/utils": "^2.6.1",
     "bignumber.js": "^9.0.0",
     "bn.js": "^5.0.0",

--- a/packages/neo-one-csharp-core/src/Node.ts
+++ b/packages/neo-one-csharp-core/src/Node.ts
@@ -1,0 +1,36 @@
+import { VersionJSON } from '@neo-one/client-common';
+import { Block } from './Block';
+import { Blockchain, VerifyTransactionResult } from './Blockchain';
+import { Endpoint } from './net';
+import { ConsensusPayload } from './payload';
+import { Transaction } from './transaction';
+
+export interface Consensus {
+  readonly runConsensusNow: () => Promise<void>;
+  readonly fastForwardOffset: (seconds: number) => Promise<void>;
+  readonly fastForwardToTime: (seconds: number) => Promise<void>;
+  readonly nowSeconds: () => number;
+  readonly pause: () => Promise<void>;
+  readonly reset: () => Promise<void>;
+  readonly resume: () => Promise<void>;
+}
+
+export interface RelayTransactionResult {
+  readonly verifyResult?: VerifyTransactionResult;
+}
+
+export interface Node {
+  readonly version: VersionJSON;
+  readonly blockchain: Blockchain;
+  readonly relayTransaction: (
+    transaction: Transaction,
+    options?: { readonly throwVerifyError?: boolean; readonly forceAdd?: boolean },
+  ) => Promise<RelayTransactionResult>;
+  readonly relayConsensusPayload: (payload: ConsensusPayload) => void;
+  readonly relayBlock: (block: Block) => Promise<void>;
+  readonly connectedPeers: readonly Endpoint[];
+  readonly memPool: { readonly [hash: string]: Transaction };
+  readonly syncMemPool: () => void;
+  readonly consensus: Consensus | undefined;
+  readonly reset: () => Promise<void>;
+}

--- a/packages/neo-one-csharp-core/src/TransactionData.ts
+++ b/packages/neo-one-csharp-core/src/TransactionData.ts
@@ -1,0 +1,148 @@
+import { BinaryWriter, IOHelper, UInt256 } from '@neo-one/client-common';
+import { BaseState } from '@neo-one/client-full-common';
+import { BN } from 'bn.js';
+import {
+  createSerializeWire,
+  DeserializeWireBaseOptions,
+  DeserializeWireOptions,
+  SerializableWire,
+  SerializeWire,
+} from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface TransactionDataAdd {
+  readonly version?: number;
+  readonly hash: UInt256;
+  readonly blockHash: UInt256;
+  readonly startHeight: number;
+  readonly index: number;
+  readonly globalIndex: BN;
+  readonly endHeights?: { readonly [index: number]: number };
+  readonly claimed?: { readonly [index: number]: boolean };
+}
+
+export interface TransactionDataUpdate {
+  readonly endHeights?: { readonly [index: number]: number };
+  readonly claimed?: { readonly [index: number]: boolean };
+}
+
+export interface TransactionDataKey {
+  readonly hash: UInt256;
+}
+
+export class TransactionData extends BaseState implements SerializableWire<TransactionData> {
+  public static deserializeWireBase({ reader }: DeserializeWireBaseOptions): TransactionData {
+    const version = reader.readUInt8();
+    const hash = reader.readUInt256();
+    const blockHash = reader.readUInt256();
+    const startHeight = reader.readUInt32LE();
+    const index = reader.readUInt32LE();
+    const globalIndex = reader.readUInt64LE();
+    const endHeights = reader.readObject(() => {
+      const key = reader.readUInt32LE();
+      const value = reader.readUInt32LE();
+
+      return { key, value };
+    });
+    const claimed = reader.readObject(() => {
+      const key = reader.readUInt32LE();
+      const value = reader.readBoolean();
+
+      return { key, value };
+    });
+
+    return new this({
+      version,
+      hash,
+      blockHash,
+      startHeight,
+      index,
+      globalIndex,
+      endHeights,
+      claimed,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): TransactionData {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly hash: UInt256;
+  public readonly blockHash: UInt256;
+  public readonly startHeight: number;
+  public readonly index: number;
+  public readonly globalIndex: BN;
+  public readonly endHeights: {
+    readonly [index: number]: number;
+  };
+  public readonly claimed: {
+    readonly [index: number]: boolean;
+  };
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal: () => number;
+
+  public constructor({
+    version,
+    hash,
+    blockHash,
+    startHeight,
+    index,
+    globalIndex,
+    endHeights = {},
+    claimed = {},
+  }: TransactionDataAdd) {
+    super({ version });
+    this.hash = hash;
+    this.blockHash = blockHash;
+    this.startHeight = startHeight;
+    this.index = index;
+    this.globalIndex = globalIndex;
+    this.endHeights = endHeights;
+    this.claimed = claimed;
+    this.sizeInternal = utils.lazy(
+      () =>
+        IOHelper.sizeOfUInt8 +
+        IOHelper.sizeOfUInt256 +
+        IOHelper.sizeOfUInt32LE +
+        IOHelper.sizeOfObject(this.endHeights, () => IOHelper.sizeOfUInt32LE + IOHelper.sizeOfUInt32LE) +
+        IOHelper.sizeOfObject(this.claimed, () => IOHelper.sizeOfUInt32LE + IOHelper.sizeOfBoolean),
+    );
+  }
+
+  public get size(): number {
+    return this.sizeInternal();
+  }
+
+  public update({ endHeights = this.endHeights, claimed = this.claimed }: TransactionDataUpdate): TransactionData {
+    return new TransactionData({
+      version: this.version,
+      hash: this.hash,
+      blockHash: this.blockHash,
+      startHeight: this.startHeight,
+      index: this.index,
+      globalIndex: this.globalIndex,
+      endHeights,
+      claimed,
+    });
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeUInt8(this.version);
+    writer.writeUInt256(this.hash);
+    writer.writeUInt256(this.blockHash);
+    writer.writeUInt32LE(this.startHeight);
+    writer.writeUInt32LE(this.index);
+    writer.writeUInt64LE(this.globalIndex);
+    writer.writeObject(this.endHeights, (key, value) => {
+      writer.writeUInt32LE(key);
+      writer.writeUInt32LE(value);
+    });
+    writer.writeObject(this.claimed, (key, value) => {
+      writer.writeUInt32LE(key);
+      writer.writeBoolean(value);
+    });
+  }
+}

--- a/packages/neo-one-csharp-core/src/index.ts
+++ b/packages/neo-one-csharp-core/src/index.ts
@@ -15,3 +15,5 @@ export * from './Verifiable';
 export * from './vm';
 export * from './Witness';
 export * from './CallFlags';
+export * from './TransactionData';
+export * from './Node';

--- a/packages/neo-one-csharp-core/src/transaction/Transaction.ts
+++ b/packages/neo-one-csharp-core/src/transaction/Transaction.ts
@@ -8,6 +8,7 @@ import {
   TransactionJSON,
   TransactionModel,
   TransactionModelAdd,
+  TransactionWithInvocationDataJSON,
   UInt160,
 } from '@neo-one/client-common';
 import { BN } from 'bn.js';
@@ -27,7 +28,8 @@ import { Attribute, deserializeAttribute } from './attributes';
 export type TransactionAddUnsigned = Omit<TransactionModelAdd<Attribute, Witness, Signer>, 'witnesses'>;
 export type TransactionAdd = TransactionModelAdd<Attribute, Witness, Signer>;
 
-export class Transaction extends TransactionModel<Attribute, Witness, Signer>
+export class Transaction
+  extends TransactionModel<Attribute, Witness, Signer>
   implements SerializableWire<Transaction>, SerializableJSON<TransactionJSON> {
   public static deserializeWireBase(options: DeserializeWireBaseOptions): Transaction {
     const {
@@ -186,5 +188,12 @@ export class Transaction extends TransactionModel<Attribute, Witness, Signer>
       script: JSONHelper.writeBuffer(this.script),
       witnesses: this.witnesses.map((witness) => witness.serializeJSON(options)),
     };
+  }
+
+  public async serializeJSONWithInvocationData(
+    _options: SerializeJSONContext,
+  ): Promise<TransactionWithInvocationDataJSON> {
+    // TODO: Implement method similar to old InvocationTransaction.serializeJSON(), which includes extra invocation data
+    return Promise.reject();
   }
 }

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -1,4 +1,4 @@
-import { common, crypto, ECPoint, ScriptBuilder, UInt160, VMState } from '@neo-one/client-common';
+import { common, crypto, ECPoint, ScriptBuilder, VMState } from '@neo-one/client-common';
 import { createChild, nodeLogger } from '@neo-one/logger';
 import {
   Action,

--- a/packages/neo-one-node-blockchain/src/__tests__/Blockchain.test.ts
+++ b/packages/neo-one-node-blockchain/src/__tests__/Blockchain.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable no-any no-object-mutation
-import { BooleanContractParameter, Transaction, Witness } from '@neo-one/node-core';
+import { Transaction, Witness } from '@neo-one/node-core';
 import { BN } from 'bn.js';
 import { of as _of } from 'rxjs';
 import { settings } from '../__data__';

--- a/packages/neo-one-node-core/src/TransactionData.ts
+++ b/packages/neo-one-node-core/src/TransactionData.ts
@@ -1,0 +1,148 @@
+import { BinaryWriter, IOHelper, UInt256 } from '@neo-one/client-common';
+import { BaseState } from '@neo-one/client-full-common';
+import { BN } from 'bn.js';
+import {
+  createSerializeWire,
+  DeserializeWireBaseOptions,
+  DeserializeWireOptions,
+  SerializableWire,
+  SerializeWire,
+} from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface TransactionDataAdd {
+  readonly version?: number;
+  readonly hash: UInt256;
+  readonly blockHash: UInt256;
+  readonly startHeight: number;
+  readonly index: number;
+  readonly globalIndex: BN;
+  readonly endHeights?: { readonly [index: number]: number };
+  readonly claimed?: { readonly [index: number]: boolean };
+}
+
+export interface TransactionDataUpdate {
+  readonly endHeights?: { readonly [index: number]: number };
+  readonly claimed?: { readonly [index: number]: boolean };
+}
+
+export interface TransactionDataKey {
+  readonly hash: UInt256;
+}
+
+export class TransactionData extends BaseState implements SerializableWire<TransactionData> {
+  public static deserializeWireBase({ reader }: DeserializeWireBaseOptions): TransactionData {
+    const version = reader.readUInt8();
+    const hash = reader.readUInt256();
+    const blockHash = reader.readUInt256();
+    const startHeight = reader.readUInt32LE();
+    const index = reader.readUInt32LE();
+    const globalIndex = reader.readUInt64LE();
+    const endHeights = reader.readObject(() => {
+      const key = reader.readUInt32LE();
+      const value = reader.readUInt32LE();
+
+      return { key, value };
+    });
+    const claimed = reader.readObject(() => {
+      const key = reader.readUInt32LE();
+      const value = reader.readBoolean();
+
+      return { key, value };
+    });
+
+    return new this({
+      version,
+      hash,
+      blockHash,
+      startHeight,
+      index,
+      globalIndex,
+      endHeights,
+      claimed,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): TransactionData {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly hash: UInt256;
+  public readonly blockHash: UInt256;
+  public readonly startHeight: number;
+  public readonly index: number;
+  public readonly globalIndex: BN;
+  public readonly endHeights: {
+    readonly [index: number]: number;
+  };
+  public readonly claimed: {
+    readonly [index: number]: boolean;
+  };
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal: () => number;
+
+  public constructor({
+    version,
+    hash,
+    blockHash,
+    startHeight,
+    index,
+    globalIndex,
+    endHeights = {},
+    claimed = {},
+  }: TransactionDataAdd) {
+    super({ version });
+    this.hash = hash;
+    this.blockHash = blockHash;
+    this.startHeight = startHeight;
+    this.index = index;
+    this.globalIndex = globalIndex;
+    this.endHeights = endHeights;
+    this.claimed = claimed;
+    this.sizeInternal = utils.lazy(
+      () =>
+        IOHelper.sizeOfUInt8 +
+        IOHelper.sizeOfUInt256 +
+        IOHelper.sizeOfUInt32LE +
+        IOHelper.sizeOfObject(this.endHeights, () => IOHelper.sizeOfUInt32LE + IOHelper.sizeOfUInt32LE) +
+        IOHelper.sizeOfObject(this.claimed, () => IOHelper.sizeOfUInt32LE + IOHelper.sizeOfBoolean),
+    );
+  }
+
+  public get size(): number {
+    return this.sizeInternal();
+  }
+
+  public update({ endHeights = this.endHeights, claimed = this.claimed }: TransactionDataUpdate): TransactionData {
+    return new TransactionData({
+      version: this.version,
+      hash: this.hash,
+      blockHash: this.blockHash,
+      startHeight: this.startHeight,
+      index: this.index,
+      globalIndex: this.globalIndex,
+      endHeights,
+      claimed,
+    });
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeUInt8(this.version);
+    writer.writeUInt256(this.hash);
+    writer.writeUInt256(this.blockHash);
+    writer.writeUInt32LE(this.startHeight);
+    writer.writeUInt32LE(this.index);
+    writer.writeUInt64LE(this.globalIndex);
+    writer.writeObject(this.endHeights, (key, value) => {
+      writer.writeUInt32LE(key);
+      writer.writeUInt32LE(value);
+    });
+    writer.writeObject(this.claimed, (key, value) => {
+      writer.writeUInt32LE(key);
+      writer.writeBoolean(value);
+    });
+  }
+}

--- a/packages/neo-one-node-core/src/index.ts
+++ b/packages/neo-one-node-core/src/index.ts
@@ -22,6 +22,7 @@ export * from './Storage';
 export * from './StorageFlags';
 export * from './StorageItem';
 export * from './TrimmedBlock';
+export * from './TransactionData';
 export * from './Validator';
 export * from './ValidatorsCount';
 export * from './Witness';

--- a/packages/neo-one-node-core/src/transaction/Transaction.ts
+++ b/packages/neo-one-node-core/src/transaction/Transaction.ts
@@ -27,7 +27,8 @@ import { Attribute, deserializeAttribute } from './attributes';
 export type TransactionAddUnsigned = Omit<TransactionModelAdd<Attribute, Witness, Signer>, 'witnesses'>;
 export type TransactionAdd = TransactionModelAdd<Attribute, Witness, Signer>;
 
-export class Transaction extends TransactionModel<Attribute, Witness, Signer>
+export class Transaction
+  extends TransactionModel<Attribute, Witness, Signer>
   implements SerializableWire<Transaction>, SerializableJSON<TransactionJSON> {
   public static deserializeWireBase(options: DeserializeWireBaseOptions): Transaction {
     const {

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -1,4 +1,4 @@
-import { common, crypto, UInt256Hex, utils } from '@neo-one/client-common';
+import { common, crypto, UInt256Hex, utils, VersionJSON } from '@neo-one/client-common';
 import { createChild, nodeLogger } from '@neo-one/logger';
 import { Consensus, ConsensusOptions } from '@neo-one/node-consensus';
 import {
@@ -124,6 +124,15 @@ interface PeerHealth {
 }
 
 export class Node implements INode {
+  public get version(): VersionJSON {
+    return {
+      tcpPort: this.externalPort,
+      wsPort: -1,
+      nonce: this.nonce,
+      useragent: this.userAgent,
+    };
+  }
+
   public get consensus(): Consensus | undefined {
     return this.mutableConsensus;
   }


### PR DESCRIPTION
### Description of the Change

First round of RPC server method updates. All the methods from `neo-project/neo-modules` are here but not all are implemented or finished. Note we also have RPC methods that are unique to NEO•ONE. Those have largely stayed the same or they are noted where they will need extra work.

Here are the methods that still need work/consideration:

- invokescript
    - Implemented just fine, but needs to be tested
- getnetworksettings
    - Unique to NEO•ONE
- getinvocationdata
    - Unique to NEO•ONE
    - Need to implement serializeJSONWithInvocationData() in Transaction.ts
    - Maybe remove or change name depending on data storage changes
- relaytransaction
    - NEO•ONE
- relaystrippedtransaction
    - NEO•ONE
- getclaimamount
    - NEO•ONE
    - Need to figure out how we’re going to implement calculateClaimAmount in Blockchain
- getvalidators
    - Needs work on the NativeContract
- getnep5balances
    - New
    - We need to add a way to get “lastupdatedblock”
- getnep5transfers
    - New
    - See how we get this information in NEO tracker scraper
- getapplicationlog
    - New
    - Similar to getinvocationdata. Likely unnecessary or redundant

Here are the methods that have not been implemented because they are wallet-related:

- closewallet
- dumpprivkey
- getnewaddress
- getwalletbalance
- getwalletunclaimedgas
- importprivkey
- listaddress
- openwallet
- sendfrom
- sendmany
- sendtoaddress
- getblockheader
- getunclaimedgas

### Test Plan

None. Test later.

### Alternate Designs

None.

### Benefits

RPC server updated, with more knowledge on what else needs to be done.

### Possible Drawbacks

None.

### Applicable Issues

#1882
#2009