### PR TITLE
feat(vm): add ability to pass protocol settings into vm

### DIFF
--- a/packages/neo-one-node-core/src/StackItems/PrimitiveStackItemBase.ts
+++ b/packages/neo-one-node-core/src/StackItems/PrimitiveStackItemBase.ts
@@ -1,5 +1,5 @@
 import { BN } from 'bn.js';
-import { InvalidStackItemCastError } from 'src/errors';
+import { InvalidStackItemCastError } from '../errors';
 import { StackItemAdd, StackItemBase } from './StackItemBase';
 
 const MIN_SAFE_BN = new BN(Number.MIN_SAFE_INTEGER);

--- a/packages/neo-one-node-vm/lib/Dispatcher.csproj
+++ b/packages/neo-one-node-vm/lib/Dispatcher.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <!-- <PackageReference Include="Neo.VM" Version="3.0.0-preview3" />
     <PackageReference Include="Neo" Version="3.0.0-preview3" /> -->
   </ItemGroup>

--- a/packages/neo-one-node-vm/lib/ReturnHelpers.cs
+++ b/packages/neo-one-node-vm/lib/ReturnHelpers.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Neo.IO;
 using Neo.SmartContract;
 using Neo.VM.Types;
+using Neo;
 
 namespace NEOONE
 {
@@ -154,6 +155,29 @@ namespace NEOONE
                 this.scriptHash = notifyEvent.ScriptHash.ToArray();
                 this.eventName = notifyEvent.EventName;
                 this.state = convertStackItem(notifyEvent.State);
+            }
+        }
+        public class ProtocolSettingsReturn
+        {
+            public int magic;
+            public int addressVersion;
+            public string[] standbyCommittee;
+            public int committeeMembersCount;
+            public int validatorsCount;
+            public string[] seedList;
+            public int millisecondsPerBlock;
+            public int memoryPoolMaxTransactions;
+
+            public ProtocolSettingsReturn(ProtocolSettings value)
+            {
+                this.magic = Convert.ToInt32(value.Magic);
+                this.addressVersion = Convert.ToInt32(value.AddressVersion);
+                this.standbyCommittee = value.StandbyCommittee;
+                this.committeeMembersCount = value.CommitteeMembersCount;
+                this.validatorsCount = value.ValidatorsCount;
+                this.seedList = value.SeedList;
+                this.millisecondsPerBlock = Convert.ToInt32(value.MillisecondsPerBlock);
+                this.memoryPoolMaxTransactions = value.MemoryPoolMaxTransactions;
             }
         }
     }

--- a/packages/neo-one-node-vm/package.json
+++ b/packages/neo-one-node-vm/package.json
@@ -15,6 +15,7 @@
     "@neo-one/edge": "^15.0.0",
     "@neo-one/node-core": "^2.7.0",
     "@neo-one/client-common": "^2.7.0",
+    "@neo-one/utils": "^2.6.1",
     "bn.js": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/neo-one-node-vm/src/Methods/BaseMethods.ts
+++ b/packages/neo-one-node-vm/src/Methods/BaseMethods.ts
@@ -2,6 +2,29 @@ import { DefaultMethods, DispatchMethod } from '../types';
 
 interface InitArgs {
   readonly path?: string;
+  readonly settings?: ProtocolSettings;
+}
+
+export interface ProtocolSettings {
+  readonly magic?: number;
+  readonly addressVersion?: number;
+  readonly standbyCommittee?: readonly string[];
+  readonly committeeMembersCount?: number;
+  readonly validatorsCount?: number;
+  readonly seedList?: readonly string[];
+  readonly millisecondsPerBlock?: number;
+  readonly memoryPoolMaxTransactions?: number;
+}
+
+export interface ProtocolSettingsReturn {
+  readonly magic: number;
+  readonly addressVersion: number;
+  readonly standbyCommittee: readonly string[];
+  readonly committeeMembersCount: number;
+  readonly validatorsCount: number;
+  readonly seedList: readonly string[];
+  readonly millisecondsPerBlock: number;
+  readonly memoryPoolMaxTransactions: number;
 }
 
 export interface BaseMethods extends DefaultMethods {
@@ -9,4 +32,5 @@ export interface BaseMethods extends DefaultMethods {
   readonly dispose_engine: DispatchMethod<boolean>;
   readonly snapshot_reset: DispatchMethod<boolean>;
   readonly dispose: DispatchMethod<boolean>;
+  readonly get_config: DispatchMethod<ProtocolSettingsReturn>;
 }

--- a/packages/neo-one-node-vm/src/__tests__/Dispatcher.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/Dispatcher.test.ts
@@ -38,7 +38,62 @@ describe('Dispatcher Tests', () => {
     expect(() => postEngine.execute()).toThrow();
   });
 
-  test.only('', () => {
-    console.log(dispatcher.test().toString('hex'));
+  test('Dispatcher correctly parses and initializes options', () => {
+    const standbyValidators = [
+      '03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c',
+      '02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093',
+      '03b8d9d5771d8f513aa0869b9cc8d50986403b78c6da36890638c3d46a5adce04a',
+      '02ca0e27697b9c248f6f16e085fd0061e26f44da85b58ee835c110caa5ec3ba554',
+      '024c7b7fb6c310fccf1ba33b082519d82964ea93868d676662d4a59ad548df0e7d',
+      '02aaec38470f6aad0042c6e877cfd8087d2676b0f516fddd362801b9bd3936399e',
+      '02486fd15702c4490a26703112a5cc1d0923fd697a33406bd5a1c00e0013b09a70',
+    ];
+    const standbyMembers = [
+      '023a36c72844610b4d34d1968662424011bf783ca9d984efa19a20babf5582f3fe',
+      '03708b860c1de5d87f5b151a12c2a99feebd2e8b315ee8e7cf8aa19692a9e18379',
+      '03c6aa6e12638b36e88adc1ccdceac4db9929575c3e03576c617c49cce7114a050',
+      '03204223f8c86b8cd5c89ef12e4f0dbb314172e9241e30c9ef2293790793537cf0',
+      '02a62c915cf19c7f19a50ec217e79fac2439bbaad658493de0c7d8ffa92ab0aa62',
+      '03409f31f0d66bdc2f70a9730b66fe186658f84a8018204db01c106edc36553cd0',
+      '0288342b141c30dc8ffcde0204929bb46aed5756b41ef4a56778d15ada8f0c6654',
+      '020f2887f41474cfeb11fd262e982051c1541418137c02a0f4961af911045de639',
+      '0222038884bbd1d8ff109ed3bdef3542e768eef76c1247aea8bc8171f532928c30',
+      '03d281b42002647f0113f36c7b8efb30db66078dfaaa9ab3ff76d043a98d512fde',
+      '02504acbc1f4b3bdad1d86d6e1a08603771db135a73e61c9d565ae06a1938cd2ad',
+      '0226933336f1b75baa42d42b71d9091508b638046d19abd67f4e119bf64a7cfb4d',
+      '03cdcea66032b82f5c30450e381e5295cae85c5e6943af716cc6b646352a6067dc',
+      '02cd5a5547119e24feaa7c2a0f37b8c9366216bab7054de0065c9be42084003c8a',
+    ];
+    const standbyCommittee = standbyValidators.concat(standbyMembers).concat('random hash');
+    const input = {
+      magic: 5195086 + 1,
+      addressVersion: 0x35 + 1,
+      standbyCommittee,
+      committeeMembersCount: standbyCommittee.length,
+      validatorsCount: standbyValidators.length,
+      millisecondsPerBlock: 15000 + 1,
+      memoryPoolMaxTransactions: 50000 + 1,
+    };
+
+    const newDis = new Dispatcher({ protocolSettings: input });
+    const result = newDis.getConfig();
+    expect(result.magic).toEqual(input.magic);
+    expect(result.addressVersion).toEqual(input.addressVersion);
+    expect(result.standbyCommittee).toEqual(standbyCommittee);
+    expect(result.committeeMembersCount).toEqual(input.committeeMembersCount);
+    expect(result.validatorsCount).toEqual(input.validatorsCount);
+    expect(result.seedList).toEqual([
+      'seed1.neo.org:10333',
+      'seed2.neo.org:10333',
+      'seed3.neo.org:10333',
+      'seed4.neo.org:10333',
+      'seed5.neo.org:10333',
+    ]);
+    expect(result.millisecondsPerBlock).toEqual(input.millisecondsPerBlock);
+    expect(result.memoryPoolMaxTransactions).toEqual(input.memoryPoolMaxTransactions);
+  });
+
+  test('', () => {
+    console.log(dispatcher.test());
   });
 });

--- a/packages/neo-one-node-vm/src/errors.ts
+++ b/packages/neo-one-node-vm/src/errors.ts
@@ -1,0 +1,16 @@
+import { makeErrorWithCode } from '@neo-one/utils';
+
+export const InvalidUIntError = makeErrorWithCode(
+  'INVALID_UINT',
+  (num: number) => `Expected number to be a 32-bit unsigned integer. Got: ${num}`,
+);
+
+export const InvalidIntError = makeErrorWithCode(
+  'INVALID_INT',
+  (num: number) => `Expected number to be a 32-bit signed integer. Got: ${num}`,
+);
+
+export const InvalidByteError = makeErrorWithCode(
+  'INVALID_BYTE',
+  (num: number) => `Expected number to be an 8-bit signed integer. Got: ${num}`,
+);

--- a/packages/neo-one-node-vm/src/index.ts
+++ b/packages/neo-one-node-vm/src/index.ts
@@ -1,2 +1,3 @@
 export * from './ApplicationEngine';
 export * from './Dispatcher';
+export * from './utils';

--- a/packages/neo-one-node-vm/src/utils.ts
+++ b/packages/neo-one-node-vm/src/utils.ts
@@ -1,5 +1,9 @@
+import { common, ECPoint } from '@neo-one/client-common';
 import { func, Params, Source, TSQL } from '@neo-one/edge';
+import { Settings } from '@neo-one/node-core';
 import path from 'path';
+import { InvalidByteError, InvalidIntError, InvalidUIntError } from './errors';
+import { ProtocolSettings } from './Methods';
 import { DefaultMethods, DispatcherFunc } from './types';
 
 const APP_ROOT = path.resolve(__dirname, '..');
@@ -18,4 +22,49 @@ export const createCSharpDispatchInvoke = <Methods extends DefaultMethods>(
   const invokeFunction = func(options);
 
   return (input) => invokeFunction(input, true);
+};
+
+export const blockchainSettingsToProtocolSettings = (settingsIn: Settings) => ({
+  magic: settingsIn.messageMagic,
+  addressVersion: settingsIn.addressVersion,
+  standbyCommittee: settingsIn.standbyCommittee.map((ecpoint: ECPoint) => common.ecPointToString(ecpoint)),
+  committeeMembersCount: settingsIn.standbyCommittee.length,
+  validatorsCount: settingsIn.validatorsCount,
+  millisecondsPerBlock: settingsIn.millisecondsPerBlock,
+  memoryPoolMaxTransactions: settingsIn.memoryPoolMaxTransactions,
+});
+
+const numIsUint = (num: number) => num >= 0 && num < 2 ** 32 - 1;
+const numIsInt = (num: number) => num >= -(2 ** 32 / 2) && num <= 2 ** 32 / 2 - 1;
+const numIsByte = (num: number) => num >= 0 && num <= 2 ** 8 - 1;
+
+export const validateProtocolSettings = (settings: ProtocolSettings) => {
+  const {
+    magic,
+    addressVersion,
+    committeeMembersCount,
+    validatorsCount,
+    millisecondsPerBlock,
+    memoryPoolMaxTransactions,
+  } = settings;
+  if (magic !== undefined && !numIsUint(magic)) {
+    throw new InvalidUIntError(magic);
+  }
+  if (addressVersion !== undefined && !numIsByte(addressVersion)) {
+    throw new InvalidByteError(addressVersion);
+  }
+  if (committeeMembersCount !== undefined && !numIsInt(committeeMembersCount)) {
+    throw new InvalidIntError(committeeMembersCount);
+  }
+  if (validatorsCount !== undefined && !numIsInt(validatorsCount)) {
+    throw new InvalidIntError(validatorsCount);
+  }
+  if (millisecondsPerBlock !== undefined && !numIsUint(millisecondsPerBlock)) {
+    throw new InvalidUIntError(millisecondsPerBlock);
+  }
+  if (memoryPoolMaxTransactions !== undefined && !numIsInt(memoryPoolMaxTransactions)) {
+    throw new InvalidIntError(memoryPoolMaxTransactions);
+  }
+
+  return settings;
 };

--- a/packages/neo-one-node/src/startFullNode.ts
+++ b/packages/neo-one-node/src/startFullNode.ts
@@ -7,7 +7,7 @@ import { Network, NetworkOptions } from '@neo-one/node-network';
 import { dumpChain, loadChain } from '@neo-one/node-offline';
 import { Node, NodeOptions } from '@neo-one/node-protocol';
 import { storage as levelupStorage } from '@neo-one/node-storage-levelup';
-import { Dispatcher } from '@neo-one/node-vm';
+import { blockchainSettingsToProtocolSettings, Dispatcher } from '@neo-one/node-vm';
 import { composeDisposables, Disposable, noopDisposable } from '@neo-one/utils';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 import fs from 'fs-extra';
@@ -83,7 +83,10 @@ export const startFullNode = async ({
 
     const native = new NativeContainer(blockchainSettings);
 
-    const vm = new Dispatcher({ levelDBPath: dataPath });
+    const vm = new Dispatcher({
+      levelDBPath: dataPath,
+      protocolSettings: blockchainSettingsToProtocolSettings(blockchainSettings),
+    });
 
     const blockchain = await Blockchain.create({
       settings: blockchainSettings,


### PR DESCRIPTION
### Description of the Change

Adds the ability to pass an optional `protocolSettings` option into the Dispatcher, which will initialize the NeoVM with those settings. These settings are things like `millisecondsPerBlock`, validators, etc.

### Test Plan

`rush test -t packages/neo-one-node-vm/src/__tests__/Dispatcher.test.ts`

### Alternate Designs

None.

### Benefits

Closer to Neo3

### Possible Drawbacks

None.

### Applicable Issues

#2009
#2161
