### PR TITLE
feat(nep5): add nep5 balance/transfer models and storage

### DIFF
--- a/packages/neo-one-client-common/src/models/index.ts
+++ b/packages/neo-one-client-common/src/models/index.ts
@@ -6,5 +6,6 @@ export * from './StorageFlagsModel';
 export * from './WitnessModel';
 export * from './WitnessScopeModel';
 export * from './transaction';
+export * from './nep5';
 export * from './types';
 export * from './vm';

--- a/packages/neo-one-client-common/src/models/nep5/Nep5BalanceKeyModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5BalanceKeyModel.ts
@@ -1,0 +1,24 @@
+import { BinaryWriter } from '../../BinaryWriter';
+import { UInt160 } from '../../common';
+import { createSerializeWire, SerializableWire, SerializeWire } from '../Serializable';
+
+export interface Nep5BalanceKeyModelAdd {
+  readonly userScriptHash: UInt160;
+  readonly assetScriptHash: UInt160;
+}
+
+export class Nep5BalanceKeyModel implements SerializableWire {
+  public readonly userScriptHash: UInt160;
+  public readonly assetScriptHash: UInt160;
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+
+  public constructor({ userScriptHash, assetScriptHash }: Nep5BalanceKeyModelAdd) {
+    this.userScriptHash = userScriptHash;
+    this.assetScriptHash = assetScriptHash;
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeVarBytesLE(this.userScriptHash);
+    writer.writeVarBytesLE(this.assetScriptHash);
+  }
+}

--- a/packages/neo-one-client-common/src/models/nep5/Nep5BalanceModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5BalanceModel.ts
@@ -1,0 +1,23 @@
+import { BinaryWriter } from '../../BinaryWriter';
+import { createSerializeWire, SerializableWire, SerializeWire } from '../Serializable';
+
+export interface Nep5BalanceModelAdd {
+  readonly balanceBuffer: Buffer;
+  readonly lastUpdatedBlock: number;
+}
+
+export class Nep5BalanceModel implements SerializableWire {
+  public readonly balanceInternal: Buffer;
+  public readonly lastUpdatedBlock: number;
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+
+  public constructor({ balanceBuffer, lastUpdatedBlock }: Nep5BalanceModelAdd) {
+    this.balanceInternal = balanceBuffer;
+    this.lastUpdatedBlock = lastUpdatedBlock;
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeVarBytesLE(this.balanceInternal);
+    writer.writeUInt32LE(this.lastUpdatedBlock);
+  }
+}

--- a/packages/neo-one-client-common/src/models/nep5/Nep5TransferKeyModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5TransferKeyModel.ts
@@ -1,0 +1,38 @@
+import { BN } from 'bn.js';
+import { BinaryWriter } from '../../BinaryWriter';
+import { UInt160 } from '../../common';
+import { createSerializeWire, SerializableWire, SerializeWire } from '../Serializable';
+
+export interface Nep5TransferKeyModelAdd {
+  readonly userScriptHash: UInt160;
+  readonly timestampMS: BN;
+  readonly assetScriptHash: UInt160;
+  readonly blockXferNotificationIndex: number;
+}
+
+export class Nep5TransferKeyModel implements SerializableWire {
+  public readonly userScriptHash: UInt160;
+  public readonly timestampMS: BN;
+  public readonly assetScriptHash: UInt160;
+  public readonly blockXferNotificationIndex: number;
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+
+  public constructor({
+    userScriptHash,
+    timestampMS,
+    assetScriptHash,
+    blockXferNotificationIndex,
+  }: Nep5TransferKeyModelAdd) {
+    this.userScriptHash = userScriptHash;
+    this.timestampMS = timestampMS;
+    this.assetScriptHash = assetScriptHash;
+    this.blockXferNotificationIndex = blockXferNotificationIndex;
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeVarBytesLE(this.userScriptHash);
+    writer.writeUInt64LE(this.timestampMS);
+    writer.writeVarBytesLE(this.assetScriptHash);
+    writer.writeUInt32LE(this.blockXferNotificationIndex);
+  }
+}

--- a/packages/neo-one-client-common/src/models/nep5/Nep5TransferModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5TransferModel.ts
@@ -1,0 +1,32 @@
+import { BinaryWriter } from '../../BinaryWriter';
+import { UInt160, UInt256 } from '../../common';
+import { createSerializeWire, SerializableWire, SerializeWire } from '../Serializable';
+
+export interface Nep5TransferModelAdd {
+  readonly userScriptHash: UInt160;
+  readonly blockIndex: number;
+  readonly txHash: UInt256;
+  readonly amountBuffer: Buffer;
+}
+
+export class Nep5TransferModel implements SerializableWire {
+  public readonly userScriptHash: UInt160;
+  public readonly blockIndex: number;
+  public readonly txHash: UInt256;
+  public readonly amountInternal: Buffer;
+  public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+
+  public constructor({ userScriptHash, blockIndex, txHash, amountBuffer }: Nep5TransferModelAdd) {
+    this.userScriptHash = userScriptHash;
+    this.blockIndex = blockIndex;
+    this.txHash = txHash;
+    this.amountInternal = amountBuffer;
+  }
+
+  public serializeWireBase(writer: BinaryWriter): void {
+    writer.writeUInt160(this.userScriptHash);
+    writer.writeUInt32LE(this.blockIndex);
+    writer.writeUInt256(this.txHash);
+    writer.writeVarBytesLE(this.amountInternal);
+  }
+}

--- a/packages/neo-one-client-common/src/models/nep5/index.ts
+++ b/packages/neo-one-client-common/src/models/nep5/index.ts
@@ -1,0 +1,4 @@
+export * from './Nep5BalanceModel';
+export * from './Nep5TransferModel';
+export * from './Nep5TransferKeyModel';
+export * from './Nep5BalanceKeyModel';

--- a/packages/neo-one-node-blockchain/src/getNep5ChangeSet.ts
+++ b/packages/neo-one-node-blockchain/src/getNep5ChangeSet.ts
@@ -1,0 +1,196 @@
+import { common, ScriptBuilder, VMState } from '@neo-one/client-common';
+import {
+  ApplicationExecuted,
+  Block,
+  BlockchainSettings,
+  CallReceipt,
+  ChangeSet,
+  Nep5Balance,
+  Nep5BalanceKey,
+  Nep5Transfer,
+  Nep5TransferKey,
+  RunEngineOptions,
+  StackItemType,
+  Transaction,
+} from '@neo-one/node-core';
+import { BN } from 'bn.js';
+
+export function getNep5ChangeSet({
+  applicationsExecuted,
+  block,
+  settings,
+  runEngineWrapper,
+}: {
+  readonly applicationsExecuted: readonly ApplicationExecuted[];
+  readonly block: Block;
+  readonly settings: BlockchainSettings;
+  readonly runEngineWrapper: (options: RunEngineOptions) => CallReceipt;
+}): ChangeSet {
+  let transferIndex = 0;
+  const nep5BalancesChanged = new Set<string>();
+  const mutableNep5BalancesChangedKeys: Nep5BalanceKey[] = [];
+  const mutableTransfersSent: Array<{ readonly key: Nep5TransferKey; readonly value: Nep5Transfer }> = [];
+  const mutableTransfersReceived: Array<{ readonly key: Nep5TransferKey; readonly value: Nep5Transfer }> = [];
+
+  applicationsExecuted.forEach((appExecuted) => {
+    if (appExecuted.state === VMState.FAULT) {
+      return;
+    }
+
+    appExecuted.notifications.forEach((notifyEventArgs) => {
+      const { scriptContainer, scriptHash, eventName, state: stateItems } = notifyEventArgs;
+
+      if (stateItems.length === 0) {
+        return;
+      }
+      if (eventName !== 'Transfer') {
+        return;
+      }
+      if (stateItems.length < 3) {
+        return;
+      }
+      if (!stateItems[0].isNull && stateItems[0].type !== StackItemType.ByteString) {
+        return;
+      }
+      if (!stateItems[1].isNull && stateItems[1].type !== StackItemType.ByteString) {
+        return;
+      }
+      const amountItem = stateItems[2];
+      if (!(amountItem.type === StackItemType.ByteString || amountItem.type === StackItemType.Integer)) {
+        return;
+      }
+      const fromBytes = stateItems[0].isNull ? undefined : stateItems[0].getBuffer();
+      if (fromBytes !== undefined && fromBytes.length !== common.UINT160_BUFFER_BYTES) {
+        return;
+      }
+      const toBytes = stateItems[1].isNull ? undefined : stateItems[1].getBuffer();
+      if (toBytes !== undefined && toBytes.length !== common.UINT160_BUFFER_BYTES) {
+        return;
+      }
+      if (fromBytes === undefined && toBytes === undefined) {
+        return;
+      }
+      let from = common.ZERO_UINT160;
+      let to = common.ZERO_UINT160;
+
+      if (fromBytes !== undefined) {
+        from = common.bufferToUInt160(fromBytes);
+        const fromKey = new Nep5BalanceKey({ userScriptHash: from, assetScriptHash: scriptHash });
+        const fromKeyString = fromKey.serializeWire().toString('hex');
+        // No need to check address balance for every single transfer. Just need to check new balances for
+        // addresses that we know have transfered assets
+
+        // mutableNep5BalancesChangedKeys will be used to run scripts to check storage for new balance of each address
+        // whose balance we know has changed based on the transfers we know happened
+        if (!nep5BalancesChanged.has(fromKeyString)) {
+          nep5BalancesChanged.add(fromKeyString);
+          mutableNep5BalancesChangedKeys.push(fromKey);
+        }
+      }
+
+      if (toBytes !== undefined) {
+        to = common.bufferToUInt160(toBytes);
+        const toKey = new Nep5BalanceKey({ userScriptHash: from, assetScriptHash: scriptHash });
+        const toKeyString = toKey.serializeWire().toString('hex');
+        if (!nep5BalancesChanged.has(toKeyString)) {
+          nep5BalancesChanged.add(toKeyString);
+          mutableNep5BalancesChangedKeys.push(toKey);
+        }
+      }
+
+      if (scriptContainer.type === 'Transaction') {
+        const amount = amountItem.getInteger();
+        const txHash = Transaction.deserializeWire({
+          buffer: scriptContainer.buffer,
+          context: { messageMagic: settings.messageMagic },
+        }).hash;
+
+        if (!from.equals(common.ZERO_UINT160)) {
+          mutableTransfersSent.push({
+            key: new Nep5TransferKey({
+              userScriptHash: from,
+              timestampMS: block.timestamp,
+              assetScriptHash: scriptHash,
+              blockXferNotificationIndex: transferIndex,
+            }),
+            value: new Nep5Transfer({
+              userScriptHash: to,
+              txHash,
+              blockIndex: block.index,
+              amountBuffer: amount.toBuffer(),
+            }),
+          });
+        }
+
+        if (!to.equals(common.ZERO_UINT160)) {
+          mutableTransfersReceived.push({
+            key: new Nep5TransferKey({
+              userScriptHash: to,
+              timestampMS: block.timestamp,
+              assetScriptHash: scriptHash,
+              blockXferNotificationIndex: transferIndex,
+            }),
+            value: new Nep5Transfer({
+              userScriptHash: from,
+              txHash,
+              blockIndex: block.index,
+              amountBuffer: amount.toBuffer(),
+            }),
+          });
+        }
+
+        transferIndex += 1;
+      }
+    });
+  });
+
+  const nep5BalancePairs = mutableNep5BalancesChangedKeys.map((key) => {
+    const script = new ScriptBuilder().emitAppCall(key.assetScriptHash, 'balanceOf', key.userScriptHash).build();
+    const callReceipt = runEngineWrapper({ script, gas: 100000000, snapshot: 'main' });
+    const balanceBuffer = callReceipt.stack[0].getInteger().toBuffer();
+
+    return { key, value: new Nep5Balance({ balanceBuffer, lastUpdatedBlock: block.index }) };
+  });
+
+  const nep5BalanceChangeSet: ChangeSet = nep5BalancePairs.map(({ key, value }) => {
+    if (value.balance.eqn(0)) {
+      return {
+        type: 'delete',
+        change: {
+          type: 'nep5Balance',
+          key,
+        },
+      };
+    }
+
+    return {
+      type: 'add',
+      change: {
+        type: 'nep5Balance',
+        key,
+        value,
+      },
+      subType: 'update',
+    };
+  });
+  const nep5TransfersSentChangeSet: ChangeSet = mutableTransfersSent.map(({ key, value }) => ({
+    type: 'add',
+    subType: 'add',
+    change: {
+      type: 'nep5TransferSent',
+      key,
+      value,
+    },
+  }));
+  const nep5TransfersReceivedChangeSet: ChangeSet = mutableTransfersReceived.map(({ key, value }) => ({
+    type: 'add',
+    subType: 'add',
+    change: {
+      type: 'nep5TransferReceived',
+      key,
+      value,
+    },
+  }));
+
+  return nep5BalanceChangeSet.concat(nep5TransfersReceivedChangeSet, nep5TransfersSentChangeSet);
+}

--- a/packages/neo-one-node-blockchain/src/utils.ts
+++ b/packages/neo-one-node-blockchain/src/utils.ts
@@ -43,14 +43,14 @@ const getApplicationExecuted = (engine: ApplicationEngine, transaction?: Transac
   state: engine.state,
   gasConsumed: engine.gasConsumed,
   stack: engine.resultStack,
-  // notifications: engine.notifications,
+  notifications: engine.notifications,
 });
 
 const getCallReceipt = (engine: ApplicationEngine) => ({
   state: engine.state,
   gasConsumed: engine.gasConsumed,
   stack: engine.resultStack,
-  // notifications: engine.notifications,
+  notifications: engine.notifications,
 });
 
 export interface TempWalletAccount {

--- a/packages/neo-one-node-core/src/Native.ts
+++ b/packages/neo-one-node-core/src/Native.ts
@@ -1,4 +1,4 @@
-import { common, ECPoint, UInt160 } from '@neo-one/client-common';
+import { ECPoint, UInt160 } from '@neo-one/client-common';
 import { BN } from 'bn.js';
 import { ReadFindStorage } from './Storage';
 import { StorageItem } from './StorageItem';

--- a/packages/neo-one-node-core/src/Nep5Balance.ts
+++ b/packages/neo-one-node-core/src/Nep5Balance.ts
@@ -1,0 +1,49 @@
+import { createSerializeWire, IOHelper, Nep5BalanceModel } from '@neo-one/client-common';
+import { BN } from 'bn.js';
+import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface Nep5BalanceAdd {
+  readonly balanceBuffer: Buffer;
+  readonly lastUpdatedBlock: number;
+}
+
+export class Nep5Balance extends Nep5BalanceModel {
+  public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep5Balance {
+    const { reader } = options;
+    const balanceBuffer = reader.readVarBytesLE(512);
+    const lastUpdatedBlock = reader.readUInt32LE();
+
+    return new this({
+      balanceBuffer,
+      lastUpdatedBlock,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): Nep5Balance {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly serializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal = utils.lazy(
+    () => IOHelper.sizeOfVarBytesLE(this.balanceInternal) + IOHelper.sizeOfUInt32LE,
+  );
+
+  public get balance() {
+    return new BN(this.balanceInternal);
+  }
+
+  public get size() {
+    return this.sizeInternal();
+  }
+
+  public clone() {
+    return new Nep5Balance({
+      balanceBuffer: this.balanceInternal,
+      lastUpdatedBlock: this.lastUpdatedBlock,
+    });
+  }
+}

--- a/packages/neo-one-node-core/src/Nep5BalanceKey.ts
+++ b/packages/neo-one-node-core/src/Nep5BalanceKey.ts
@@ -1,0 +1,42 @@
+import { createSerializeWire, IOHelper, Nep5BalanceKeyModel, UInt160 } from '@neo-one/client-common';
+import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface Nep5BalanceKeyAdd {
+  readonly userScriptHash: UInt160;
+  readonly assetScriptHash: UInt160;
+}
+
+export class Nep5BalanceKey extends Nep5BalanceKeyModel {
+  public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep5BalanceKey {
+    const { reader } = options;
+    const userScriptHash = reader.readUInt160();
+    const assetScriptHash = reader.readUInt160();
+
+    return new this({
+      userScriptHash,
+      assetScriptHash,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): Nep5BalanceKey {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly serializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal = utils.lazy(() => IOHelper.sizeOfUInt160 + IOHelper.sizeOfUInt160);
+
+  public get size() {
+    return this.sizeInternal();
+  }
+
+  public clone() {
+    return new Nep5BalanceKey({
+      userScriptHash: this.userScriptHash,
+      assetScriptHash: this.assetScriptHash,
+    });
+  }
+}

--- a/packages/neo-one-node-core/src/Nep5Transfer.ts
+++ b/packages/neo-one-node-core/src/Nep5Transfer.ts
@@ -1,0 +1,61 @@
+import { createSerializeWire, IOHelper, Nep5TransferModel, UInt160, UInt256 } from '@neo-one/client-common';
+import { BN } from 'bn.js';
+import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface Nep5TransferAdd {
+  readonly userScriptHash: UInt160;
+  readonly blockIndex: number;
+  readonly txHash: UInt256;
+  readonly amountBuffer: Buffer;
+}
+
+export class Nep5Transfer extends Nep5TransferModel {
+  public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep5Transfer {
+    const { reader } = options;
+    const userScriptHash = reader.readUInt160();
+    const blockIndex = reader.readUInt32LE();
+    const txHash = reader.readUInt256();
+    const amountBuffer = reader.readVarBytesLE(512);
+
+    return new this({
+      userScriptHash,
+      blockIndex,
+      txHash,
+      amountBuffer,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): Nep5Transfer {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly serializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal = utils.lazy(
+    () =>
+      IOHelper.sizeOfUInt160 +
+      IOHelper.sizeOfUInt32LE +
+      IOHelper.sizeOfUInt256 +
+      IOHelper.sizeOfVarBytesLE(this.amountInternal),
+  );
+
+  public get amount() {
+    return new BN(this.amountInternal);
+  }
+
+  public get size() {
+    return this.sizeInternal();
+  }
+
+  public clone() {
+    return new Nep5Transfer({
+      userScriptHash: this.userScriptHash,
+      blockIndex: this.blockIndex,
+      txHash: this.txHash,
+      amountBuffer: this.amountInternal,
+    });
+  }
+}

--- a/packages/neo-one-node-core/src/Nep5TransferKey.ts
+++ b/packages/neo-one-node-core/src/Nep5TransferKey.ts
@@ -1,0 +1,53 @@
+import { createSerializeWire, IOHelper, Nep5TransferKeyModel, UInt160 } from '@neo-one/client-common';
+import { BN } from 'bn.js';
+import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
+import { BinaryReader, utils } from './utils';
+
+export interface Nep5TransferKeyAdd {
+  readonly userScriptHash: UInt160;
+  readonly timestampMS: BN;
+  readonly assetScriptHash: UInt160;
+  readonly blockXferNotificationIndex: number;
+}
+
+export class Nep5TransferKey extends Nep5TransferKeyModel {
+  public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep5TransferKey {
+    const { reader } = options;
+    const userScriptHash = reader.readUInt160();
+    const timestampMS = reader.readUInt64LE();
+    const assetScriptHash = reader.readUInt160();
+    const blockXferNotificationIndex = reader.readUInt16LE();
+
+    return new this({
+      userScriptHash,
+      timestampMS,
+      assetScriptHash,
+      blockXferNotificationIndex,
+    });
+  }
+
+  public static deserializeWire(options: DeserializeWireOptions): Nep5TransferKey {
+    return this.deserializeWireBase({
+      context: options.context,
+      reader: new BinaryReader(options.buffer),
+    });
+  }
+
+  public readonly serializeWire = createSerializeWire(this.serializeWireBase.bind(this));
+  private readonly sizeInternal = utils.lazy(
+    () => IOHelper.sizeOfUInt160 + IOHelper.sizeOfUInt64LE + IOHelper.sizeOfUInt64LE + IOHelper.sizeOfUInt16LE,
+  );
+
+  public get size() {
+    return this.sizeInternal();
+  }
+
+  public clone() {
+    return new Nep5TransferKey({
+      userScriptHash: this.userScriptHash,
+      timestampMS: this.timestampMS,
+      assetScriptHash: this.assetScriptHash,
+      blockXferNotificationIndex: this.blockXferNotificationIndex,
+    });
+  }
+}

--- a/packages/neo-one-node-core/src/Storage.ts
+++ b/packages/neo-one-node-core/src/Storage.ts
@@ -3,6 +3,10 @@ import { ContractIDState } from './ContractIDState';
 import { ContractKey, ContractState } from './ContractState';
 import { HashIndexState } from './HashIndexState';
 import { HeaderHashList, HeaderKey } from './HeaderHashList';
+import { Nep5Balance } from './Nep5Balance';
+import { Nep5BalanceKey } from './Nep5BalanceKey';
+import { Nep5Transfer } from './Nep5Transfer';
+import { Nep5TransferKey } from './Nep5TransferKey';
 import { StorageItem } from './StorageItem';
 import { StorageKey } from './StorageKey';
 import { TransactionKey, TransactionState } from './transaction';
@@ -36,7 +40,7 @@ export interface ReadAllStorage<Key, Value> extends ReadStorage<Key, Value> {
 }
 
 export interface ReadFindStorage<Key, Value> extends ReadStorage<Key, Value> {
-  readonly find$: (lookup: Buffer) => Observable<StorageReturn<Key, Value>>;
+  readonly find$: (lookup: Buffer, secondaryLookup?: Buffer) => Observable<StorageReturn<Key, Value>>;
 }
 
 export interface ReadGetAllStorage<Key, Value> extends ReadStorage<Key, Value> {
@@ -110,11 +114,15 @@ export type AddChange =
   | { readonly type: 'headerHashList'; readonly key: HeaderKey; readonly value: HeaderHashList }
   | { readonly type: 'blockHashIndex'; readonly value: HashIndexState }
   | { readonly type: 'headerHashIndex'; readonly value: HashIndexState }
-  | { readonly type: 'contractID'; readonly value: ContractIDState };
+  | { readonly type: 'contractID'; readonly value: ContractIDState }
+  | { readonly type: 'nep5Balance'; readonly key: Nep5BalanceKey; readonly value: Nep5Balance }
+  | { readonly type: 'nep5TransferSent'; readonly key: Nep5TransferKey; readonly value: Nep5Transfer }
+  | { readonly type: 'nep5TransferReceived'; readonly key: Nep5TransferKey; readonly value: Nep5Transfer };
 
 export type DeleteChange =
   | { readonly type: 'contract'; readonly key: ContractKey }
-  | { readonly type: 'storage'; readonly key: StorageKey };
+  | { readonly type: 'storage'; readonly key: StorageKey }
+  | { readonly type: 'nep5Balance'; readonly key: Nep5BalanceKey };
 
 export type Change =
   | { readonly type: 'add'; readonly change: AddChange; readonly subType: 'add' | 'update' }
@@ -124,6 +132,9 @@ export type ChangeSet = readonly Change[];
 
 export interface BlockchainStorage {
   readonly blocks: ReadStorage<BlockKey, TrimmedBlock>;
+  readonly nep5Balances: ReadFindStorage<Nep5BalanceKey, Nep5Balance>;
+  readonly nep5TransfersSent: ReadFindStorage<Nep5TransferKey, Nep5Transfer>;
+  readonly nep5TransfersReceived: ReadFindStorage<Nep5TransferKey, Nep5Transfer>;
   readonly transactions: ReadStorage<TransactionKey, TransactionState>;
   readonly contracts: ReadStorage<ContractKey, ContractState>;
   readonly storages: ReadFindStorage<StorageKey, StorageItem>;

--- a/packages/neo-one-node-core/src/index.ts
+++ b/packages/neo-one-node-core/src/index.ts
@@ -33,3 +33,7 @@ export * from './Witness';
 export * from './CallFlags';
 export * from './TransactionData';
 export * from './Node';
+export * from './Nep5Balance';
+export * from './Nep5Transfer';
+export * from './Nep5BalanceKey';
+export * from './Nep5TransferKey';

--- a/packages/neo-one-node-core/src/utils/utils.ts
+++ b/packages/neo-one-node-core/src/utils/utils.ts
@@ -205,7 +205,7 @@ function equals<T>(
 const wildCardFromJSON = <T>(json: WildcardContainerJSON, selector: (input: string) => T) => {
   if (typeof json === 'string') {
     if (json !== '*') {
-      // TODO: more descriptive;
+      // TODO: more descriptive
       throw new InvalidFormatError();
     }
 
@@ -359,20 +359,6 @@ const getSerializableArrayFromStorageItem = <T>(
   return getSerializableArray(value, readValue, max);
 };
 
-/* crude method but it does what we want it to do */
-const generateSearchRange = (lookupKey: Buffer): StreamOptions => {
-  const asBN = new BN(lookupKey);
-  const lte = asBN.addn(1).toBuffer();
-  if (lte.length !== lookupKey.length) {
-    throw new InvalidFormatError('not sure how this happened');
-  }
-
-  return {
-    gte: lookupKey,
-    lte,
-  };
-};
-
 export const utils = {
   ...clientUtils,
   toASCII,
@@ -389,5 +375,4 @@ export const utils = {
   getInteroperable,
   getSerializableArray,
   getSerializableArrayFromStorageItem,
-  generateSearchRange,
 };

--- a/packages/neo-one-node-core/src/vm.ts
+++ b/packages/neo-one-node-core/src/vm.ts
@@ -12,7 +12,7 @@ export enum TriggerType {
 }
 
 export interface Notification {
-  readonly scriptContainer: SerializableContainer;
+  readonly scriptContainer: SerializedScriptContainer;
   readonly scriptHash: UInt160;
   readonly eventName: string;
   readonly state: readonly StackItem[];
@@ -22,7 +22,7 @@ export interface CallReceipt {
   readonly state: VMState;
   readonly gasConsumed: number;
   readonly stack: readonly StackItem[];
-  // readonly notifications: readonly Notification[];
+  readonly notifications: readonly Notification[];
 }
 
 export type SnapshotName = 'main' | 'clone';
@@ -79,7 +79,7 @@ export interface ApplicationExecuted {
   readonly state: VMState;
   readonly gasConsumed: number;
   readonly stack: readonly StackItem[];
-  // readonly notifications: readonly Notification[];
+  readonly notifications: readonly Notification[];
 }
 
 export interface VM {

--- a/packages/neo-one-node-http-rpc/src/middleware/rpc.ts
+++ b/packages/neo-one-node-http-rpc/src/middleware/rpc.ts
@@ -1,16 +1,26 @@
 import { loadConfiguration } from '@neo-one/cli-common-node';
 import { bodyParser } from '@neo-one/http';
 import { Blockchain, Node } from '@neo-one/node-core';
+import { NativeContainer } from '@neo-one/node-native';
 import { createHandler } from '@neo-one/node-rpc-handler';
 import execa from 'execa';
 import { Context } from 'koa';
 import compose from 'koa-compose';
 import koaCompress from 'koa-compress';
 
-export const rpc = ({ blockchain, node }: { readonly blockchain: Blockchain; readonly node: Node }) => {
+export const rpc = ({
+  blockchain,
+  node,
+  native,
+}: {
+  readonly blockchain: Blockchain;
+  readonly node: Node;
+  readonly native: NativeContainer;
+}) => {
   const handler = createHandler({
     blockchain,
     node,
+    native,
     handleGetNEOTrackerURL: async () => {
       const config = await loadConfiguration();
 

--- a/packages/neo-one-node-http-rpc/src/setupRPCServer.ts
+++ b/packages/neo-one-node-http-rpc/src/setupRPCServer.ts
@@ -2,6 +2,7 @@ import { cors, setupServer } from '@neo-one/http';
 import { context, onError as appOnError } from '@neo-one/http-context';
 import { createChild, nodeLogger, rpcLogger } from '@neo-one/logger';
 import { Blockchain, Node } from '@neo-one/node-core';
+import { NativeContainer } from '@neo-one/node-native';
 import { Disposable, Labels } from '@neo-one/utils';
 import * as nodeHttp from 'http';
 import Application from 'koa';
@@ -27,10 +28,12 @@ export interface Options {
 export const setupRPCServer = async ({
   blockchain,
   node,
+  native,
   options: { http, splashScreen, liveHealthCheck: liveHealthCheckOptions, readyHealthCheck: readyHealthCheckOptions },
 }: {
   readonly blockchain: Blockchain;
   readonly node: Node;
+  readonly native: NativeContainer;
   readonly options: Options;
 }): Promise<Disposable> => {
   if (http === undefined) {
@@ -48,7 +51,7 @@ export const setupRPCServer = async ({
   // tslint:disable-next-line:no-any
   const router = new Router<any, {}>();
 
-  const rpcMiddleware = rpc({ blockchain, node });
+  const rpcMiddleware = rpc({ blockchain, node, native });
   router.use(context(logger));
 
   if (liveHealthCheckOptions !== undefined) {

--- a/packages/neo-one-node-neo-settings/src/common.ts
+++ b/packages/neo-one-node-neo-settings/src/common.ts
@@ -88,9 +88,10 @@ const getDeployNativeContracts = () => {
 
 interface GetGenesisBlockOptions {
   readonly consensusAddress: UInt160;
+  readonly privateNet?: boolean;
 }
 
-const getGenesisBlock = ({ consensusAddress }: GetGenesisBlockOptions) =>
+const getGenesisBlock = ({ consensusAddress, privateNet }: GetGenesisBlockOptions) =>
   new Block({
     previousHash: clientCommon.ZERO_UINT256,
     timestamp: new BN(Date.UTC(2016, 6, 15, 15, 8, 21)),
@@ -107,6 +108,7 @@ const getGenesisBlock = ({ consensusAddress }: GetGenesisBlockOptions) =>
 export const common = ({ privateNet, consensusAddress }: Options) => ({
   genesisBlock: getGenesisBlock({
     consensusAddress,
+    privateNet,
   }),
   decrementInterval: DECREMENT_INTERVAL,
   generationAmount: privateNet ? GENERATION_AMOUNT_PRIVATE : GENERATION_AMOUNT,

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -274,7 +274,7 @@ export class Node implements INode {
     const { externalPort = 0 } = options;
     this.externalPort = externalPort;
     this.nonce = Math.floor(Math.random() * utils.UINT_MAX_NUMBER);
-    this.userAgent = `NEO:neo-one-js:3.0.0-preview`;
+    this.userAgent = `NEO:neo-one-js:3.0.0-preview3`;
 
     this.mutableMemPool = {};
     this.transactionVerificationContext = new TransactionVerificationContext({

--- a/packages/neo-one-node-rpc-handler/package.json
+++ b/packages/neo-one-node-rpc-handler/package.json
@@ -18,6 +18,8 @@
     "@neo-one/logger": "^2.6.1",
     "@neo-one/node-core": "^2.7.0",
     "@neo-one/utils": "^2.6.1",
+    "@types/bn.js": "^4.11.5",
+    "bn.js": "^5.0.0",
     "rxjs": "^6.5.3",
     "tslib": "^1.10.0"
   },

--- a/packages/neo-one-node-storage-levelup/package.json
+++ b/packages/neo-one-node-storage-levelup/package.json
@@ -19,6 +19,7 @@
     "@neo-one/utils": "^2.6.1",
     "@types/levelup": "^3.1.1",
     "@types/abstract-leveldown": "^5.0.1",
+    "abstract-leveldown": "^6.0.3",
     "levelup": "4.1.0",
     "rocksdb": "^4.1.0",
     "rxjs": "^6.5.3",
@@ -29,6 +30,7 @@
     "@types/jest": "^24.0.18",
     "@types/memdown": "^3.0.0",
     "@types/rocksdb": "3.0.0",
+    "bn.js": "^5.0.0",
     "gulp": "~4.0.2",
     "memdown": "^5.0.0"
   }

--- a/packages/neo-one-node-storage-levelup/src/convertChange.ts
+++ b/packages/neo-one-node-storage-levelup/src/convertChange.ts
@@ -12,6 +12,33 @@ import { UnknownChangeTypeError, UnknownTypeError } from './errors';
 
 const convertAddChange = (change: AddChange): readonly PutBatch[] => {
   switch (change.type) {
+    case 'nep5Balance':
+      return [
+        {
+          type: 'put',
+          key: keys.createNep5BalanceKey(change.key),
+          value: change.value.serializeWire(),
+        },
+      ];
+
+    case 'nep5TransferReceived':
+      return [
+        {
+          type: 'put',
+          key: keys.createNep5TransferReceivedKey(change.key),
+          value: change.value.serializeWire(),
+        },
+      ];
+
+    case 'nep5TransferSent':
+      return [
+        {
+          type: 'put',
+          key: keys.createNep5TransferSentKey(change.key),
+          value: change.value.serializeWire(),
+        },
+      ];
+
     case 'block':
       return [
         {
@@ -102,6 +129,12 @@ const convertDeleteChange = (change: DeleteChange): DelBatch => {
       return {
         type: 'del',
         key: keys.createStorageKey(change.key),
+      };
+
+    case 'nep5Balance':
+      return {
+        type: 'del',
+        key: keys.createNep5BalanceKey(change.key),
       };
 
     default:

--- a/packages/neo-one-node-storage-levelup/src/levelUpStorage.ts
+++ b/packages/neo-one-node-storage-levelup/src/levelUpStorage.ts
@@ -1,4 +1,3 @@
-import { common } from '@neo-one/client-common';
 import {
   BinaryReader,
   BlockKey,
@@ -8,8 +7,12 @@ import {
   HashIndexState,
   // InvocationData,
   HeaderHashList,
-  Storage,
+  Nep5Balance,
   // TransactionData,
+  Nep5BalanceKey,
+  Nep5Transfer,
+  Nep5TransferKey,
+  Storage,
   StorageItem,
   StorageKey,
   TransactionState,
@@ -81,6 +84,42 @@ export const levelUpStorage = ({ db, context }: LevelUpStorageOptions): Storage 
 
   return {
     blocks,
+
+    nep5Balances: read.createReadFindStorage({
+      db,
+      getSearchRange: keys.getNep5BalanceSearchRange,
+      serializeKey: keys.createNep5BalanceKey,
+      deserializeValue: (buffer) =>
+        Nep5Balance.deserializeWire({
+          context,
+          buffer,
+        }),
+      deserializeKey: (buffer) => Nep5BalanceKey.deserializeWire({ context, buffer }),
+    }),
+
+    nep5TransfersReceived: read.createReadFindStorage({
+      db,
+      getSearchRange: keys.getNep5TransferReceivedSearchRange,
+      serializeKey: keys.createNep5TransferReceivedKey,
+      deserializeValue: (buffer) =>
+        Nep5Transfer.deserializeWire({
+          context,
+          buffer,
+        }),
+      deserializeKey: (buffer) => Nep5TransferKey.deserializeWire({ context, buffer }),
+    }),
+
+    nep5TransfersSent: read.createReadFindStorage({
+      db,
+      getSearchRange: keys.getNep5TransferSentSearchRange,
+      serializeKey: keys.createNep5TransferSentKey,
+      deserializeValue: (buffer) =>
+        Nep5Transfer.deserializeWire({
+          context,
+          buffer,
+        }),
+      deserializeKey: (buffer) => Nep5TransferKey.deserializeWire({ context, buffer }),
+    }),
 
     transactions: read.createReadStorage({
       db,

--- a/packages/neo-one-node-storage-levelup/src/read.ts
+++ b/packages/neo-one-node-storage-levelup/src/read.ts
@@ -131,14 +131,14 @@ export function createFind$<Key, Value>({
   deserializeValue,
 }: {
   readonly db: LevelUp;
-  readonly getSearchRange: (key: Buffer) => StreamOptions;
+  readonly getSearchRange: (key: Buffer, secondary?: Buffer) => StreamOptions;
   readonly deserializeKey: (key: Buffer) => Key;
   readonly deserializeValue: (value: Buffer) => Value;
-}): (lookup: Buffer) => Observable<StorageReturn<Key, Value>> {
-  return (lookup: Buffer) =>
-    streamToObservable<StorageReturn<Buffer, Buffer>>(() => db.createReadStream(getSearchRange(lookup))).pipe(
-      map(({ key, value }) => ({ key: deserializeKey(key.slice(1)), value: deserializeValue(value) })),
-    );
+}): (lookup: Buffer, secondaryLookup?: Buffer) => Observable<StorageReturn<Key, Value>> {
+  return (lookup: Buffer, secondaryLookup?: Buffer) =>
+    streamToObservable<StorageReturn<Buffer, Buffer>>(() =>
+      db.createReadStream(getSearchRange(lookup, secondaryLookup)),
+    ).pipe(map(({ key, value }) => ({ key: deserializeKey(key.slice(1)), value: deserializeValue(value) })));
 }
 
 export function createReadFindStorage<Key, Value>({
@@ -149,7 +149,7 @@ export function createReadFindStorage<Key, Value>({
   deserializeValue,
 }: {
   readonly db: LevelUp;
-  readonly getSearchRange: (key: Buffer) => StreamOptions;
+  readonly getSearchRange: (key: Buffer, secondary?: Buffer) => StreamOptions;
   readonly serializeKey: SerializeKey<Key>;
   readonly deserializeKey: (value: Buffer) => Key;
   readonly deserializeValue: (value: Buffer) => Value;

--- a/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
@@ -16,7 +16,7 @@ namespace NEOONE
         {
             Block,
             Transaction,
-            Signer,
+            Signers,
         }
 
         private IVerifiable deserializeContainer(dynamic args)

--- a/packages/neo-one-node/src/__data__/jsonBlocks.ts
+++ b/packages/neo-one-node/src/__data__/jsonBlocks.ts
@@ -30,7 +30,7 @@ export const genesisJSON = {
       signers: [
         {
           account: '0xa7213b15cc18d19c810f644e37411d882ee561ca',
-          scopes: 'FeeOnly', // FeeOnly should be None. This indicates that this JSON data is from Preview 2 or earlier, not Preview 3
+          scopes: 'FeeOnly', // FeeOnly should be None. This indicates that this JSON data could be from Preview 2 or earlier, not Preview 3
         },
       ],
       attributes: [],

--- a/packages/neo-one-node/src/__tests__/blockchain.test.ts
+++ b/packages/neo-one-node/src/__tests__/blockchain.test.ts
@@ -1,4 +1,3 @@
-import { common } from '@neo-one/client-common';
 import { Blockchain } from '@neo-one/node-blockchain';
 import { StorageKey, StreamOptions } from '@neo-one/node-core';
 import { KeyBuilder, NativeContainer } from '@neo-one/node-native';
@@ -11,8 +10,8 @@ import RocksDB from 'rocksdb';
 import { map, toArray } from 'rxjs/operators';
 import { data } from '../__data__';
 
-describe('blockchain persists second block', () => {
-  test('test', async () => {
+describe('Blockchain storage works', () => {
+  test('Blockchain can persist and retrieve blocks', async () => {
     const blockchainSettings = createTest();
     const levelDBPath = '/Users/danielbyrne/Desktop/test-location';
     const db = LevelUp(RocksDB(levelDBPath));

--- a/packages/neo-one-node/src/startFullNode.ts
+++ b/packages/neo-one-node/src/startFullNode.ts
@@ -130,6 +130,7 @@ export const startFullNode = async ({
       blockchain,
       node,
       options: rpcOptions,
+      native,
     });
     disposable = composeDisposables(disposable, rpcDisposable);
 


### PR DESCRIPTION
### Description of the Change

Adds storage for NEP5 transfers and balances. Add RPC methods for getting NEP5 balances/transfers.

### Test Plan

Test in final e2e testing.

### Alternate Designs

None.

### Benefits

Closer to Neo3. Can now track NEP5 balances/transfers.

### Possible Drawbacks

None.

### Applicable Issues

#2156 
#2009 
#2142 
#1882 
