### PR TITLE
fix(node): fixup RPC methods

### DIFF
--- a/packages/neo-one-client-common/src/models/nep5/Nep5BalanceKeyModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5BalanceKeyModel.ts
@@ -18,7 +18,7 @@ export class Nep5BalanceKeyModel implements SerializableWire {
   }
 
   public serializeWireBase(writer: BinaryWriter): void {
-    writer.writeVarBytesLE(this.userScriptHash);
-    writer.writeVarBytesLE(this.assetScriptHash);
+    writer.writeUInt160(this.userScriptHash);
+    writer.writeUInt160(this.assetScriptHash);
   }
 }

--- a/packages/neo-one-client-common/src/models/nep5/Nep5TransferKeyModel.ts
+++ b/packages/neo-one-client-common/src/models/nep5/Nep5TransferKeyModel.ts
@@ -7,32 +7,32 @@ export interface Nep5TransferKeyModelAdd {
   readonly userScriptHash: UInt160;
   readonly timestampMS: BN;
   readonly assetScriptHash: UInt160;
-  readonly blockXferNotificationIndex: number;
+  readonly blockTransferNotificationIndex: number;
 }
 
 export class Nep5TransferKeyModel implements SerializableWire {
   public readonly userScriptHash: UInt160;
   public readonly timestampMS: BN;
   public readonly assetScriptHash: UInt160;
-  public readonly blockXferNotificationIndex: number;
+  public readonly blockTransferNotificationIndex: number;
   public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
 
   public constructor({
     userScriptHash,
     timestampMS,
     assetScriptHash,
-    blockXferNotificationIndex,
+    blockTransferNotificationIndex,
   }: Nep5TransferKeyModelAdd) {
     this.userScriptHash = userScriptHash;
     this.timestampMS = timestampMS;
     this.assetScriptHash = assetScriptHash;
-    this.blockXferNotificationIndex = blockXferNotificationIndex;
+    this.blockTransferNotificationIndex = blockTransferNotificationIndex;
   }
 
   public serializeWireBase(writer: BinaryWriter): void {
-    writer.writeVarBytesLE(this.userScriptHash);
+    writer.writeUInt160(this.userScriptHash);
     writer.writeUInt64LE(this.timestampMS);
-    writer.writeVarBytesLE(this.assetScriptHash);
-    writer.writeUInt32LE(this.blockXferNotificationIndex);
+    writer.writeUInt160(this.assetScriptHash);
+    writer.writeUInt32LE(this.blockTransferNotificationIndex);
   }
 }

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -619,9 +619,10 @@ export class Blockchain {
       applicationsExecuted,
       block,
     });
+
     const nep5BalancePairs = assetKeys.map((key) => {
       const script = new ScriptBuilder().emitAppCall(key.assetScriptHash, 'balanceOf', key.userScriptHash).build();
-      const callReceipt = this.runEngineWrapper({ script, gas: 100000000, snapshot: 'main' });
+      const callReceipt = this.runEngineWrapper({ script, gas: 1, snapshot: 'main' });
       const balanceBuffer = callReceipt.stack[0].getInteger().toBuffer();
 
       return { key, value: new Nep5Balance({ balanceBuffer, lastUpdatedBlock: this.currentBlockIndex }) };

--- a/packages/neo-one-node-blockchain/src/getNep5UpdateOptions.ts
+++ b/packages/neo-one-node-blockchain/src/getNep5UpdateOptions.ts
@@ -80,7 +80,7 @@ export function getNep5UpdateOptions({
         const fromKey = new Nep5BalanceKey({ userScriptHash: from, assetScriptHash: scriptHash });
         const fromKeyString = fromKey.serializeWire().toString('hex');
         // No need to check address balance for every single transfer. Just need to check new balances for
-        // addresses that we know have transfered assets
+        // addresses that we know have transferred assets
 
         // mutableNep5BalancesChangedKeys will be used to run scripts to check storage for new balance of each address
         // whose balance we know has changed based on the transfers we know happened
@@ -110,7 +110,7 @@ export function getNep5UpdateOptions({
               userScriptHash: from,
               timestampMS: block.timestamp,
               assetScriptHash: scriptHash,
-              blockXferNotificationIndex: transferIndex,
+              blockTransferNotificationIndex: transferIndex,
             }),
             value: new Nep5Transfer({
               userScriptHash: to,
@@ -127,7 +127,7 @@ export function getNep5UpdateOptions({
               userScriptHash: to,
               timestampMS: block.timestamp,
               assetScriptHash: scriptHash,
-              blockXferNotificationIndex: transferIndex,
+              blockTransferNotificationIndex: transferIndex,
             }),
             value: new Nep5Transfer({
               userScriptHash: from,

--- a/packages/neo-one-node-core/src/Nep5TransferKey.ts
+++ b/packages/neo-one-node-core/src/Nep5TransferKey.ts
@@ -7,7 +7,7 @@ export interface Nep5TransferKeyAdd {
   readonly userScriptHash: UInt160;
   readonly timestampMS: BN;
   readonly assetScriptHash: UInt160;
-  readonly blockXferNotificationIndex: number;
+  readonly blockTransferNotificationIndex: number;
 }
 
 export class Nep5TransferKey extends Nep5TransferKeyModel {
@@ -16,13 +16,13 @@ export class Nep5TransferKey extends Nep5TransferKeyModel {
     const userScriptHash = reader.readUInt160();
     const timestampMS = reader.readUInt64LE();
     const assetScriptHash = reader.readUInt160();
-    const blockXferNotificationIndex = reader.readUInt16LE();
+    const blockTransferNotificationIndex = reader.readUInt16LE();
 
     return new this({
       userScriptHash,
       timestampMS,
       assetScriptHash,
-      blockXferNotificationIndex,
+      blockTransferNotificationIndex,
     });
   }
 
@@ -47,7 +47,7 @@ export class Nep5TransferKey extends Nep5TransferKeyModel {
       userScriptHash: this.userScriptHash,
       timestampMS: this.timestampMS,
       assetScriptHash: this.assetScriptHash,
-      blockXferNotificationIndex: this.blockXferNotificationIndex,
+      blockTransferNotificationIndex: this.blockTransferNotificationIndex,
     });
   }
 }

--- a/packages/neo-one-node-core/src/StackItems/ByteStringStackItem.ts
+++ b/packages/neo-one-node-core/src/StackItems/ByteStringStackItem.ts
@@ -38,6 +38,6 @@ export class ByteStringStackItem extends PrimitiveStackItemBase {
       throw new InvalidIntegerStackItemError(this.size);
     }
 
-    return new BN(this.getBuffer());
+    return new BN(this.getBuffer(), 'le');
   }
 }

--- a/packages/neo-one-node-core/src/StackItems/IntegerStackItem.ts
+++ b/packages/neo-one-node-core/src/StackItems/IntegerStackItem.ts
@@ -13,7 +13,7 @@ export class IntegerStackItem extends PrimitiveStackItemBase {
   public constructor(value: BN) {
     const size = value.eqn(0) ? 0 : value.byteLength();
     super({
-      memory: value.eqn(0) ? Buffer.from([]) : value.toBuffer(),
+      memory: value.eqn(0) ? Buffer.from([]) : value.toBuffer('le'),
       type: StackItemType.Integer,
       isNull: false,
       size,

--- a/packages/neo-one-node-core/src/manifest/ContractPermissionDescriptor.ts
+++ b/packages/neo-one-node-core/src/manifest/ContractPermissionDescriptor.ts
@@ -11,7 +11,7 @@ export class ContractPermissionDescriptor extends ContractPermissionDescriptorMo
     if (jsonString.length === 66) {
       return new ContractPermissionDescriptor({ hashOrGroup: JSONHelper.readECPoint(jsonString) });
     }
-    if (jsonString === '*') {
+    if (jsonString === '"*"') {
       return new ContractPermissionDescriptor();
     }
 

--- a/packages/neo-one-node-core/src/utils/deserializeStackItem.ts
+++ b/packages/neo-one-node-core/src/utils/deserializeStackItem.ts
@@ -54,7 +54,7 @@ export const deserializeStackItem = (reader: BinaryReader, maxArraySize: number,
         break;
 
       case StackItemType.Integer:
-        deserialized.unshift(new IntegerStackItem(new BN(reader.readVarBytesLE(IntegerStackItem.maxSize))));
+        deserialized.unshift(new IntegerStackItem(new BN(reader.readVarBytesLE(IntegerStackItem.maxSize), 'le')));
         break;
 
       case StackItemType.ByteString:

--- a/packages/neo-one-node-native/src/NEOToken.ts
+++ b/packages/neo-one-node-native/src/NEOToken.ts
@@ -97,7 +97,7 @@ export class NEOToken extends NEP5NativeContract {
 
   private async getCommitteeMembers(storage: NativeContractStorageContext): Promise<readonly ECPoint[]> {
     const item = await storage.storages.get(this.createStorageKey(this.prefixes.votersCount).toStorageKey());
-    const votersCount = new BN(item.value).toNumber();
+    const votersCount = new BN(item.value, 'le').toNumber();
     const voterTurnout = votersCount / this.totalAmount.toNumber();
     if (voterTurnout < this.effectiveVoterTurnout) {
       return this.settings.standbyCommittee;
@@ -123,10 +123,10 @@ export class NEOToken extends NEP5NativeContract {
     }
 
     let amount = new BN(0);
-    let ustart = start / this.settings.decrementInterval;
+    let ustart = Math.floor(start / this.settings.decrementInterval);
     if (ustart < this.settings.generationAmount.length) {
       let istart = start % this.settings.decrementInterval;
-      let uend = end / this.settings.decrementInterval;
+      let uend = Math.floor(end / this.settings.decrementInterval);
       let iend = end % this.settings.decrementInterval;
       if (uend >= this.settings.generationAmount.length) {
         uend = this.settings.generationAmount.length;

--- a/packages/neo-one-node-storage-common/src/keys.ts
+++ b/packages/neo-one-node-storage-common/src/keys.ts
@@ -1,4 +1,4 @@
-import { BinaryWriter, common, InvalidFormatError, UInt160, UInt256 } from '@neo-one/client-common';
+import { common, InvalidFormatError, UInt160, UInt256 } from '@neo-one/client-common';
 import { BlockKey, Nep5BalanceKey, Nep5TransferKey, StorageKey, StreamOptions } from '@neo-one/node-core';
 import { BN } from 'bn.js';
 
@@ -76,7 +76,6 @@ const createGetSearchRange = (prefix: Prefix) => {
 const createBlockKey = getCreateKey<BlockKey>({
   serializeKey: ({ hashOrIndex }) => {
     if (typeof hashOrIndex === 'number') {
-      // TODO: implement getting a block by its index
       throw new Error();
     }
 

--- a/packages/neo-one-node-vm/src/converters/stackItems.ts
+++ b/packages/neo-one-node-vm/src/converters/stackItems.ts
@@ -141,7 +141,7 @@ const parsePrimitiveStackItem = (item: PrimitiveStackItemReturn): PrimitiveStack
       return new ByteStringStackItem(item.value);
 
     case 'Integer':
-      return new IntegerStackItem(new BN(item.value));
+      return new IntegerStackItem(new BN(item.value, 'le'));
 
     default:
       throw new Error(`invalid stack item when parsing, found type ${item}`);

--- a/packages/neo-one-node/src/__tests__/blockchain.test.ts
+++ b/packages/neo-one-node/src/__tests__/blockchain.test.ts
@@ -1,15 +1,27 @@
 import { common, crypto, JSONHelper } from '@neo-one/client-common';
 import { Blockchain } from '@neo-one/node-blockchain';
-import { StorageKey, StreamOptions } from '@neo-one/node-core';
-import { KeyBuilder, NativeContainer } from '@neo-one/node-native';
+import { Nep5BalanceKey, StorageKey, StreamOptions, utils } from '@neo-one/node-core';
+import { KeyBuilder, NativeContainer, NEOAccountState } from '@neo-one/node-native';
 import { test as createTest } from '@neo-one/node-neo-settings';
 import { storage as levelupStorage } from '@neo-one/node-storage-levelup';
 import { blockchainSettingsToProtocolSettings, Dispatcher } from '@neo-one/node-vm';
+import { utils as commonUtils } from '@neo-one/utils';
 import { BN } from 'bn.js';
 import LevelUp from 'levelup';
 import RocksDB from 'rocksdb';
-import { map, toArray } from 'rxjs/operators';
+import { filter, map, toArray } from 'rxjs/operators';
 import { data } from '../__data__';
+
+const rawReadStreamPromise = async (db: any, options: { readonly gte: Buffer; readonly lte: Buffer }) =>
+  new Promise((resolve, reject) => {
+    db.createReadStream(options)
+      .on('data', (data: any) => {
+        console.log(data.key.toString('hex'));
+      })
+      .on('error', reject)
+      .on('close', resolve)
+      .on('end', resolve);
+  });
 
 describe('Blockchain storage works', () => {
   test('Blockchain can persist and retrieve blocks', async () => {
@@ -27,20 +39,24 @@ describe('Blockchain storage works', () => {
       protocolSettings: blockchainSettingsToProtocolSettings(blockchainSettings),
     });
 
-    const balances = await storage.nep5Balances.all$.pipe(toArray()).toPromise();
+    const native = new NativeContainer(blockchainSettings);
 
-    console.log(balances);
+    const blockchain = await Blockchain.create({
+      settings: blockchainSettings,
+      storage,
+      vm: dispatcher,
+      native,
+    });
 
-    // const native = new NativeContainer(blockchainSettings);
-    // const blockchain = await Blockchain.create({
-    //   settings: blockchainSettings,
-    //   storage,
-    //   vm: dispatcher,
-    //   native,
-    // });
+    const sc = '0xf813c2cc8e18bbe4b3b87f8ef9105b50bb93918e';
+    const scriptHash = common.stringToUInt160(sc).reverse();
 
-    // console.log(blockchain.currentBlockIndex);
+    const timeIn = Buffer.from('830ce2c273010000', 'hex');
 
-    // await blockchain.persistBlock({ block: data.debugBlock });
+    const gte = Buffer.concat([scriptHash, timeIn]);
+    const lte = Buffer.concat([scriptHash, new BN(Date.now(), 'le').toBuffer()]);
+
+    const transfers = await storage.nep5TransfersSent.find$(gte, lte).pipe(toArray()).toPromise();
+    expect(transfers.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
getunclaimed, getnep5transfers, getnep5balances all had some issues.

- fixed `calculateBonus` method not using Integer division like it was supposed to (Math.floor(...)).
- fixed nep5balance storage using `writeVarBytesLE` to the correct `writeUInt160`
- fixed getNep5Transfers not using the provided scriptHash in its storage search.
- adjusts the block request rate in the node, hopefully increases stability.
- fixed `IntegerStackItem` not using 'le' for its BN representation.
- syntax nits

fixes #2204 
