### PR TITLE
feat(transactions): fix all transaction stuff, rpc calls, more

### DIFF
--- a/packages/neo-one-client-common/src/crypto.ts
+++ b/packages/neo-one-client-common/src/crypto.ts
@@ -252,6 +252,7 @@ const createInvocationScript = (message: Buffer, privateKey: PrivateKey): Buffer
 const createVerificationScript = (publicKey: ECPoint): Buffer => {
   const builder = new ScriptBuilder();
   builder.emitPushECPoint(publicKey);
+  builder.emitOp('PUSHNULL');
   builder.emitSysCall('Neo.Crypto.VerifyWithECDsaSecp256r1');
 
   return builder.build();
@@ -320,6 +321,7 @@ const createMultiSignatureVerificationScript = (mIn: number, publicKeys: readonl
     builder.emitPushECPoint(ecPoint);
   });
   builder.emitPushInt(publicKeysSorted.length);
+  builder.emitOp('PUSHNULL');
   builder.emitSysCall('Neo.Crypto.CheckMultisigWithECDsaSecp256r1');
 
   return builder.build();

--- a/packages/neo-one-client-common/src/models/Serializable.ts
+++ b/packages/neo-one-client-common/src/models/Serializable.ts
@@ -18,14 +18,7 @@ export interface SerializableJSON<TJSON> {
   readonly serializeJSON: () => TJSON;
 }
 
-/** TODO: revist how the `magic` gets in here. Previously it was passed only as a `DeserializeContext` option
- * but now its needed for getting the hash of certain models. Really this is something that should get passed in
- * from `Blockchain` or `Settings`
- */
-
-// mainnet: 5195086
-// testnet: 1951352142
-export const createGetHashData = (serializeWire: () => Buffer, magic = 1951352142) => () => {
+export const createGetHashData = (serializeWire: () => Buffer, magic: number) => () => {
   const writer = new BinaryWriter();
   writer.writeUInt32LE(magic);
   writer.writeBytes(serializeWire());

--- a/packages/neo-one-client-common/src/models/VerifyResultModel.ts
+++ b/packages/neo-one-client-common/src/models/VerifyResultModel.ts
@@ -31,7 +31,7 @@ export const assertVerifyResult = (value: number): VerifyResultModel => {
   return value;
 };
 
-export const toJSONVerifyResult = (reason: VerifyResultModel): VerifyResultJSON =>
+export const toVerifyResultJSON = (reason: VerifyResultModel): VerifyResultJSON =>
   assertVerifyResultJSON(VerifyResultModel[reason]);
 
 export const isVerifyResultJSON = (reason: string): reason is VerifyResultJSON =>

--- a/packages/neo-one-client-common/src/models/transaction/TransactionModel.ts
+++ b/packages/neo-one-client-common/src/models/transaction/TransactionModel.ts
@@ -45,6 +45,7 @@ export class TransactionModel<
     hash,
     systemFee,
     networkFee,
+    messageMagic,
   }: TransactionModelAdd<TAttribute, TWitness, TSigner>) {
     super({
       version,
@@ -55,6 +56,7 @@ export class TransactionModel<
       validUntilBlock,
       script,
       hash,
+      messageMagic,
     });
 
     this.systemFee = systemFee;
@@ -75,6 +77,7 @@ export class TransactionModel<
       networkFee: this.networkFee,
       nonce: this.nonce,
       validUntilBlock: this.validUntilBlock,
+      messageMagic: this.messageMagic,
     });
   }
 
@@ -93,6 +96,7 @@ export class TransactionModel<
       networkFee: this.networkFee,
       nonce: options.nonce,
       validUntilBlock: options.validUntilBlock,
+      messageMagic: this.messageMagic,
     });
   }
 

--- a/packages/neo-one-client-common/src/models/transaction/helper.ts
+++ b/packages/neo-one-client-common/src/models/transaction/helper.ts
@@ -10,6 +10,7 @@ const addFees = (tx: FeelessTransactionModel, fees: TransactionFeesAdd): Transac
     witnesses: tx.witnesses,
     nonce: tx.nonce,
     validUntilBlock: tx.validUntilBlock,
+    messageMagic: tx.messageMagic,
     systemFee: fees.systemFee,
     networkFee: fees.networkFee,
   });

--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -320,7 +320,7 @@ export interface TransactionJSON {
 export interface VerboseTransactionJSON extends TransactionJSON {
   readonly blockhash: UInt256Hex;
   readonly confirmations: number;
-  readonly blocktime: string;
+  readonly blocktime: number;
   readonly vmstate: VMStateJSON;
 }
 
@@ -366,12 +366,7 @@ export interface ContractGroupJSON {
   readonly signature: string;
 }
 
-export interface ContractPermissionDescriptorJSON {
-  readonly hashOrGroup: string;
-  readonly isHash: boolean;
-  readonly isGroup: boolean;
-  readonly isWildcard: boolean;
-}
+export type ContractPermissionDescriptorJSON = string;
 
 export interface ContractPermissionJSON {
   readonly contract: ContractPermissionDescriptorJSON;
@@ -379,9 +374,6 @@ export interface ContractPermissionJSON {
 }
 
 export interface ContractManifestJSON {
-  readonly hash: string;
-  // TODO: only hash is included in old `ContractJSON` definition. Remove hashHex?
-  readonly hashHex: string;
   readonly abi: ContractABIJSON;
   readonly groups: readonly ContractGroupJSON[];
   readonly permissions: readonly ContractPermissionJSON[];
@@ -402,10 +394,9 @@ export interface ContractParameterDefinitionJSON {
 
 export interface ContractJSON {
   readonly id: number;
+  readonly hash: string;
   readonly script: string;
   readonly manifest: ContractManifestJSON;
-  readonly hasStorage: boolean;
-  readonly payable: boolean;
 }
 
 export interface Nep5TransfersJSON {
@@ -439,7 +430,7 @@ export interface BlockBaseJSON {
   readonly version: number;
   readonly previousblockhash: string;
   readonly merkleroot: string;
-  readonly time: string;
+  readonly time: number;
   readonly index: number;
   readonly nextconsensus: string;
   readonly nextblockhash?: string;
@@ -467,7 +458,7 @@ export interface TrimmedBlockJSON extends BlockBaseJSON {
 }
 
 export interface NetworkSettingsJSON {
-  readonly decrementinternal: number;
+  readonly decrementinterval: number;
   readonly generationamount: readonly number[];
   readonly privatekeyversion: number;
   readonly standbyvalidators: readonly string[];
@@ -516,9 +507,13 @@ export interface RelayTransactionResultJSON {
   readonly verifyResult?: VerifyResultJSON;
 }
 
+export interface SendRawTransactionResultJSON {
+  readonly hash: string;
+}
+
 export interface ValidatorJSON {
   readonly active: boolean;
-  readonly publicKey: string;
+  readonly publickey: string;
   readonly votes: string;
 }
 

--- a/packages/neo-one-client-core/src/__tests__/provider/sendrawtransaction.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/provider/sendrawtransaction.test.ts
@@ -1,0 +1,122 @@
+import {
+  common,
+  crypto,
+  privateKeyToAddress,
+  privateKeyToScriptHash,
+  ScriptBuilder,
+  scriptHashToAddress,
+  SignerModel,
+  TransactionModel,
+  WitnessModel,
+  WitnessScopeModel,
+} from '@neo-one/client-common';
+import { constants } from '@neo-one/utils';
+import BN from 'bn.js';
+import { LocalKeyStore, LocalMemoryStore } from '../../user';
+
+describe('RPC Call sendrawtransaction', () => {
+  const keystore = new LocalKeyStore(new LocalMemoryStore());
+  const messageMagic = 1951352142; // This is TestNet number. Make sure it matches the network's magic number
+
+  test('Create a valid private net transaction with one signer', async () => {
+    await keystore.addUserAccount({
+      network: constants.LOCAL_NETWORK_NAME,
+      privateKey: constants.PRIVATE_NET_PRIVATE_KEY,
+      name: 'master',
+    });
+
+    const signer = new SignerModel({
+      account: common.stringToUInt160(privateKeyToScriptHash(constants.PRIVATE_NET_PRIVATE_KEY)),
+      scopes: WitnessScopeModel.None,
+    });
+
+    const txUnsigned = new TransactionModel({
+      script: new ScriptBuilder().emitOp('PUSHNULL').build(),
+      systemFee: new BN(0),
+      networkFee: new BN(1590000),
+      validUntilBlock: 800000,
+      signers: [signer],
+      messageMagic,
+    });
+
+    const signature = await keystore.sign({
+      account: { network: 'local', address: privateKeyToAddress(constants.PRIVATE_NET_PRIVATE_KEY) },
+      message: txUnsigned.message.toString('hex'),
+    });
+
+    const witness = crypto.createWitnessForSignature(
+      Buffer.from(signature, 'hex'),
+      common.stringToECPoint(constants.PRIVATE_NET_PUBLIC_KEY),
+      WitnessModel,
+    );
+
+    const finalTransaction = txUnsigned.clone({ witnesses: [witness] });
+
+    // tslint:disable-next-line: no-console
+    console.log(finalTransaction.serializeWire().toString('hex'));
+  });
+
+  test('Create a valid private net transaction with multiple signers', async () => {
+    await keystore.addUserAccount({
+      network: constants.LOCAL_NETWORK_NAME,
+      privateKey: constants.PRIVATE_NET_PRIVATE_KEY,
+      name: 'master',
+    });
+
+    const standbyValidators = ['0248be3c070df745a60f3b8b494efcc6caf90244d803a9a72fe95d9bae2120ec70'].map((val) =>
+      common.stringToECPoint(val),
+    );
+
+    // The sender needs to be the address of the multisig address
+    const address = crypto.toScriptHash(
+      crypto.createMultiSignatureVerificationScript(standbyValidators.length / 2 + 1, standbyValidators),
+    );
+
+    const signer = new SignerModel({
+      account: address,
+      scopes: WitnessScopeModel.None,
+    });
+
+    const txUnsigned = new TransactionModel({
+      script: new ScriptBuilder().emitOp('PUSHNULL').build(),
+      systemFee: new BN(0),
+      networkFee: new BN(1590000),
+      validUntilBlock: 800000,
+      signers: [signer],
+      messageMagic,
+    });
+
+    const signature = await keystore.sign({
+      account: { network: 'local', address: privateKeyToAddress(constants.PRIVATE_NET_PRIVATE_KEY) },
+      message: txUnsigned.message.toString('hex'),
+    });
+
+    const witness = crypto.createMultiSignatureWitness(
+      standbyValidators.length / 2 + 1,
+      standbyValidators,
+      { [`${common.ecPointToHex(standbyValidators[0])}`]: Buffer.from(signature, 'hex') },
+      WitnessModel,
+    );
+
+    const finalTransaction = txUnsigned.clone({ witnesses: [witness] });
+
+    // tslint:disable-next-line: no-console
+    console.log(finalTransaction.serializeWire().toString('hex'));
+  });
+
+  test('Get the private net initialization address from standby validators', async () => {
+    // Standby validators is an array of public keys of the validators
+    const standbyValidators = ['0248be3c070df745a60f3b8b494efcc6caf90244d803a9a72fe95d9bae2120ec70'].map((val) =>
+      common.stringToECPoint(val),
+    );
+    const address = crypto.toScriptHash(
+      // The first argument might have to be changed to: validators.length - (validators.length - 1) / 3
+      crypto.createMultiSignatureVerificationScript(standbyValidators.length / 2 + 1, standbyValidators),
+    );
+
+    // The script hash and address printed here should match the script hash and address that is initialized in C# GasToken and NeoToken `initialize` methods
+    // In this case that would be 0xa25e93cc2a5f7108c02e9e3b4898aad9d3e91486 and NY8vnYnwgxs3prMcxnQi7Mog7VHezJgfwx
+    console.log(common.uInt160ToString(address));
+    console.log(scriptHashToAddress(common.uInt160ToString(address)));
+  });
+});

--- a/packages/neo-one-client-core/src/__tests__/provider/temp.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/provider/temp.test.ts
@@ -1,115 +1,98 @@
-import { common, ScriptBuilder, TransactionModel } from '@neo-one/client-common';
-import BN from 'bn.js';
+import { common, ScriptBuilder, UInt160 } from '@neo-one/client-common';
+import { Hash160 } from '../../Hash160';
 import { JSONRPCClient, JSONRPCHTTPProvider } from '../../provider';
 
-describe('JSONRPCClient Tests', () => {
-  const client = new JSONRPCClient(new JSONRPCHTTPProvider('https://staging.neotracker.io/rpc'));
+describe('JSONRPCClient Tests', async () => {
+  const neo = 'http://seed1t.neo.org:20332/';
+  const staging = 'https://staging.neotracker.io/rpc';
+  const local = 'http://localhost:8080/rpc';
+  const neoClient = new JSONRPCClient(new JSONRPCHTTPProvider(neo));
+  const stagingClient = new JSONRPCClient(new JSONRPCHTTPProvider(local));
+  const client = stagingClient;
   const address = 'NSVX6sk3z14pSSjFx6WFEGajQXEbmahvwx';
+  const addressAsScriptHash = '0x4262ca65a1523a3d01a96d15471ce1ee9a1f2948';
   const addressWithTransfers = 'NiXgSLtGUjTRTgp4y9ax7vyJ9UZAjsRDVt';
+  const addressWithTransfersAsScriptHash = '0x8e9193bb505b10f98e7fb8b3e4bb188eccc213f8';
   const transactionHash = '0x173dcbc4a88995a0cf7bdd006923d148f787f76ca75621dc4c440ca6d9afbc73';
+  // addressToScriptHash(Hash160.NEO) = 0xde5f57d430d3dece511cf975a8d37848cb9e0525;
 
-  test('getBlockHeader', async () => {
-    const {
-      version,
-      hash,
-      size,
-      previousblockhash,
-      merkleroot,
-      time,
-      index,
-      nextconsensus,
-      nextblockhash,
-      witnesses,
-      confirmations,
-    } = await client.getBlockHeader(1);
+  const getStorageArgs = (hash: UInt160, num: number) => [
+    common.uInt160ToString(hash),
+    Buffer.from([num]).toString('hex'),
+  ];
 
-    expect(version).toEqual(0);
-    expect(hash).toEqual('0x8f30c34a8a8ef997155aa4a0ef6664d872a127ecc3bb6a85b7bbc55d6d9912f5');
-    expect(size).toEqual(691);
-    expect(previousblockhash).toEqual('0xc359030132be10fd19cfd0a27e289fe04acb0c5c4ca5254af8a2d99498c7da45');
-    expect(merkleroot).toEqual('0x9ff5ba403c81151c0d031b548fe6cff82ef61a01be72c38ecc81d4bc2f1ee01c');
-    expect(time).toEqual('1596537327793');
-    expect(index).toEqual(1);
-    expect(nextconsensus).toEqual('NgPkjjLTNcQad99iRYeXRUuowE4gxLAnDL');
-    expect(confirmations).toEqual(369993);
-    expect(nextblockhash).toEqual('0x84fa4b26af4b00095d66714a3a2ec63acdeff7ae27ca5d4f6cbe5db2691d7fae');
-    expect(witnesses[0].invocation).toEqual(
-      'DED/2tpnw4uN5407xKQuwAXw+Hm9L4P51hSMfjwbEcm7pN+aFdn5+d/VxT9ifDX0KQRGlbericqr6h2gQvnJYvHqDECO9w/7PAccs3K3yqAZ4zDTpsnxxDU5EyR1PNNcBUx31lFGyHtjcxhce+YNYxcJc2zOFFk+lFmCBn+ZiF1HZrkPDEBbpwRGODeexXqSws2VQPrOg/BiCNYKmAj3vPW8HvC3ypnly/Hfy8lYF9iZiIighzUALC4QzQpxdq1IdNMSH22jDEAe/l0FF8HXc6e20zT6x0D8XvrITHsKMxxe4S5hGYwojgBDjJPcMwvJbT83AF+sorbZc7SMaCGwT1XOEg+9M0G2DEDOK/OsvMqyKgyHf/gz5QFgQxPjHKuuMoN38+OLuMRP36K4Eunv7oql3KstrgpVIqZHtETEHmxMEFIFXu5hFEa8',
-    );
-    expect(witnesses[0].verification).toEqual(
-      'FQwhAwCbdUDhDyVi5f2PrJ6uwlFmpYsm5BI0j/WoaSe/rCKiDCEDAgXpzvrqWh38WAryDI1aokaLsBSPGl5GBfxiLIDmBLoMIQIUuvDO6jpm8X5+HoOeol/YvtbNgua7bmglAYkGX0T/AQwhAj6bMuqJuU0GbmSbEk/VDjlu6RNp6OKmrhsRwXDQIiVtDCEDQI3NQWOW9keDrFh+oeFZPFfZ/qiAyKahkg6SollHeAYMIQKng0vpsy4pgdFXy1u9OstCz9EepcOxAiTXpE6YxZEPGwwhAroscPWZbzV6QxmHBYWfriz+oT4RcpYoAHcrPViKnUq9FwtBE43vrw==',
-    );
+  const methods: Array<[string, ReadonlyArray<string | number>]> = [
+    ['getStorage', getStorageArgs(common.nativeHashes.NEO, 11)],
+    ['getStorage', getStorageArgs(common.nativeHashes.NEO, 1)],
+    ['getStorage', getStorageArgs(common.nativeHashes.NEO, 14)], // 0xde5f57d430d3dece511cf975a8d37848cb9e0525, 0e
+    ['getStorage', getStorageArgs(common.nativeHashes.GAS, 11)],
+    ['getApplicationLog', [transactionHash]],
+    ['getBlock', [1]],
+    ['getNep5Balances', [address]],
+    ['getNep5Transfers', [addressWithTransfers, 1468595301000, 1603753592250]],
+    ['getBestBlockHash', []],
+    ['getBlockCount', []],
+    ['getContract', [Hash160.NEO]],
+    ['getMemPool', []],
+    ['getTransaction', [transactionHash]],
+    ['testInvokeRaw', [new ScriptBuilder().emitOp('PUSH0').build().toString('hex')]],
+    ['getUnclaimedGas', [address]],
+    ['getTransactionHeight', [transactionHash]],
+    ['getBlockHash', [1]],
+    ['getBlockHeader', [1]],
+    ['getValidators', []],
+    ['validateAddress', [address]],
+    // ['relayTransaction'], /// see sendrawtransaction.test.ts
+    // ['sendRawTransaction'], // see sendrawtransaction.test.ts
+    // ['getInvocationData'],
+    // ['runConsensusNow'],
+    // ['updateSettings'],
+    // ['fastForwardOffset'],
+    // ['fastForwardToTime'],
+    // ['reset'],
+    // ['getNEOTrackerURL'],
+    // ['resetProject'],
+  ];
+
+  const getBoth = async (method: string, args: ReadonlyArray<string | number> = []) =>
+    // @ts-ignore
+    Promise.all([neoClient[method](...args), stagingClient[method](...args)]);
+
+  methods.forEach(async (tuple) => {
+    test(tuple[0], async () => {
+      const [neoResult, stagingResult] = await getBoth(tuple[0], tuple[1]);
+      expect(neoResult).toEqual(stagingResult);
+    });
   });
 
-  test('getValidators', async () => {
-    const validators = await client.getValidators();
-    const currentPublicKey = '03daca45da7acf52602c630e58af4f45a894a427fa274544cadac5335a9a293d4e';
+  // TODO: needs to be looked into
+  test('getStorage - Policy', async () => {
+    const getStorageByNum = (hashIn: UInt160, num: number) =>
+      client.getStorage(common.uInt160ToString(hashIn), Buffer.from([num]).toString('hex'));
 
-    expect(validators.length).toEqual(11);
-    expect(validators.some((val) => val.publicKey === currentPublicKey));
-  });
+    const hash = common.nativeHashes.Policy;
+    // 0xce06595079cd69583126dbfd1d2e25cca74cffe9
 
-  test('getTransactionHeight', async () => {
-    const height = await client.getTransactionHeight(transactionHash);
+    const maxPerBlock = await getStorageByNum(hash, 23);
+    expect(maxPerBlock).toEqual('00020000');
 
-    expect(height).toEqual(1);
-  });
+    const feePerByte = await getStorageByNum(hash, 10);
+    expect(feePerByte).toEqual('e803000000000000');
 
-  test('getunclaimedgas', async () => {
-    const unclaimed = await client.getUnclaimedGas(address);
+    const blockedAccounts = await getStorageByNum(hash, 15);
+    expect(blockedAccounts).toEqual('00');
 
-    expect(unclaimed.address).toEqual(address);
-    expect(unclaimed.unclaimed).toEqual('0');
-  });
+    const maxBlockSize = await getStorageByNum(hash, 12);
+    expect(maxBlockSize).toEqual('00000400');
 
-  test('validateAddress', async () => {
-    const result = await client.validateAddress(address);
-
-    expect(result.address).toEqual(address);
-    expect(result.isvalid).toEqual(true);
+    const maxBlockSysFee = await getStorageByNum(hash, 17);
+    expect(maxBlockSysFee).toEqual('00282e8cd1000000');
   });
 
   test('getSettings', async () => {
     const settings = await client.getSettings();
 
     expect(settings.millisecondsPerBlock).toEqual(15000);
-  });
-
-  test('getBlock', async () => {
-    const block = await client.getBlock(1);
-
-    expect(block).toBeDefined();
-    expect(block.hash).toEqual('0x8f30c34a8a8ef997155aa4a0ef6664d872a127ecc3bb6a85b7bbc55d6d9912f5');
-    expect(block.nextconsensus).toEqual('NgPkjjLTNcQad99iRYeXRUuowE4gxLAnDL');
-    expect(block.tx).toEqual([]);
-  });
-
-  test('getBestBlockHash', async () => {
-    const hash = await client.getBestBlockHash();
-
-    expect(hash).toBeDefined();
-    expect(hash.length).toBe(66);
-    expect(common.isUInt256(common.stringToUInt256(hash))).toBeTruthy();
-  });
-
-  test('getBlockCount', async () => {
-    const count = await client.getBlockCount();
-
-    expect(count).toBeGreaterThan(343360);
-  });
-
-  test('getMemPool', async () => {
-    const mempool = await client.getMemPool();
-
-    expect(mempool.height).toBeGreaterThan(343360);
-    expect(mempool.verified).toEqual([]);
-  });
-
-  test('getTransaction', async () => {
-    const transaction = await client.getTransaction(transactionHash);
-
-    expect(transaction.hash).toEqual(transactionHash);
-    expect(transaction.blockhash).toEqual('0xc359030132be10fd19cfd0a27e289fe04acb0c5c4ca5254af8a2d99498c7da45');
   });
 
   test('getTransactionReceipt', async () => {
@@ -119,26 +102,14 @@ describe('JSONRPCClient Tests', () => {
     expect(receipt.blockIndex).toEqual(0);
     expect(receipt.globalIndex).toEqual('-1');
     expect(receipt.transactionHash).toEqual(transactionHash);
-    expect(receipt.confirmations).toBeGreaterThan(345557);
+    expect(receipt.confirmations).toBeDefined();
     expect(receipt.blockTime).toEqual('1468595301000');
-  });
-
-  test('getTransactionHeight', async () => {
-    const height = await client.getTransactionHeight(transactionHash);
-
-    expect(height).toEqual(0);
-  });
-
-  test('getBlockHash', async () => {
-    const hash = await client.getBlockHash(1);
-
-    expect(hash).toEqual('0x8f30c34a8a8ef997155aa4a0ef6664d872a127ecc3bb6a85b7bbc55d6d9912f5');
   });
 
   test('getConnectionCount', async () => {
     const count = await client.getConnectionCount();
 
-    expect(count).toBeGreaterThan(1);
+    expect(count).toBeGreaterThanOrEqual(1);
   });
 
   test('getVersion', async () => {
@@ -160,7 +131,7 @@ describe('JSONRPCClient Tests', () => {
 
   test('getNetworkSettings', async () => {
     const {
-      decrementinternal,
+      decrementinterval,
       generationamount,
       privatekeyversion,
       standbyvalidators,
@@ -173,9 +144,8 @@ describe('JSONRPCClient Tests', () => {
       memorypoolmaxtransactions,
     } = await client.getNetworkSettings();
 
-    expect(decrementinternal).toBeDefined();
+    expect(decrementinterval).toBeDefined();
     expect(generationamount).toBeDefined();
-    expect(decrementinternal).toBeDefined();
     expect(privatekeyversion).toBeDefined();
     expect(standbyvalidators).toBeDefined();
     expect(messagemagic).toBeDefined();
@@ -185,97 +155,5 @@ describe('JSONRPCClient Tests', () => {
     expect(validatorscount).toBeDefined();
     expect(millisecondsperblock).toBeDefined();
     expect(memorypoolmaxtransactions).toBeDefined();
-  });
-
-  test('getNep5Balances', async () => {
-    const balances = await client.getNep5Balances(address);
-
-    expect(balances.address).toEqual(address);
-    expect(balances.balance).toEqual([
-      {
-        amount: '8995481360',
-        assethash: '0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc',
-        lastupdatedblock: 5284,
-      },
-    ]);
-  });
-
-  test('getNep5Transfers', async () => {
-    const transfers = await client.getNep5Transfers(addressWithTransfers, 1468595301000, 1603753592250);
-
-    expect(transfers.address).toEqual(addressWithTransfers);
-    expect(transfers.received.length).toEqual(3);
-    expect(transfers.sent.length).toEqual(3);
-    expect(transfers.sent).not.toEqual(transfers.received);
-    expect(transfers.received[0]).toEqual({
-      amount: '50000000000',
-      assethash: '0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc',
-      blockindex: 74129,
-      timestamp: 1597856421280,
-      transferaddress: '0x31248a51a630048a3fa00c3cfed7428a76d320ad',
-      transfernotifyindex: 0,
-      txhash: '0x57726a30d9efb510017d698f0fc55e54586bed7878f05b867884bb03dd07aa64',
-    });
-    expect(transfers.sent[0]).toEqual({
-      amount: '50000000000',
-      assethash: '0x668e0c1f9d7b70a99dd9e06eadd4c784d641afbc',
-      blockindex: 74129,
-      timestamp: 1597856421280,
-      transferaddress: '0x31248a51a630048a3fa00c3cfed7428a76d320ad',
-      transfernotifyindex: 0,
-      txhash: '0x57726a30d9efb510017d698f0fc55e54586bed7878f05b867884bb03dd07aa64',
-    });
-  });
-
-  // TODO: run test/ debug
-  test('relayTransaction', async () => {
-    const receipt = await client.relayTransaction(Buffer.from([]).toString());
-    expect(receipt.transaction).toBeDefined();
-    expect(receipt.verifyResult).toBeDefined();
-  });
-
-  // TODO: run test/ debug
-  test('sendRawTransaction', async () => {
-    const transaction = new TransactionModel({
-      systemFee: new BN(0),
-      networkFee: new BN(0),
-      script: new ScriptBuilder().emitOp('PUSH0').build(),
-    });
-    const receipt = await client.sendRawTransaction(transaction.serializeWire().toString('hex'));
-
-    expect(receipt).toEqual(true);
-  });
-
-  test('testInvokeRaw', async () => {
-    const input = new ScriptBuilder().emitOp('PUSH0').build().toString('hex');
-    const { script, state, stack, gasconsumed, notifications } = await client.testInvokeRaw(input);
-
-    expect(script).toEqual('10');
-    expect(state).toEqual('HALT');
-    expect(stack).toEqual([{ type: 'Integer', value: '0' }]);
-    expect(gasconsumed).toEqual('30');
-    expect(notifications).toEqual([]);
-  });
-
-  test('getApplicationLog', async () => {
-    const { gasconsumed, notifications, stack, trigger, txid, vmstate } = await client.getApplicationLog(
-      transactionHash,
-    );
-
-    expect(gasconsumed).toEqual('0');
-    expect(stack).toEqual([]);
-    expect(trigger).toEqual('Application');
-    expect(vmstate).toEqual('HALT');
-    expect(txid).toEqual(transactionHash);
-    expect(notifications.length).toEqual(2);
-    expect(notifications[0]).toEqual({
-      eventname: 'Transfer',
-      scripthash: '0xde5f57d430d3dece511cf975a8d37848cb9e0525',
-      state: [
-        { type: 'Any' },
-        { type: 'ByteString', value: '4KPFXK1yAo+1kBdIsZonviH2VAQ=' },
-        { type: 'Integer', value: '100000000' },
-      ],
-    });
   });
 });

--- a/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
+++ b/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
@@ -16,6 +16,7 @@ import {
   PrivateNetworkSettings,
   RawInvocationResultJSON,
   RelayTransactionResultJSON,
+  SendRawTransactionResultJSON,
   StorageItemJSON,
   TransactionReceiptJSON,
   UnclaimedGASJSON,
@@ -127,7 +128,7 @@ export class JSONRPCClient {
     );
   }
 
-  public async sendRawTransaction(value: BufferString): Promise<boolean> {
+  public async sendRawTransaction(value: BufferString): Promise<SendRawTransactionResultJSON> {
     return this.withInstance(async (provider) =>
       provider
         .request({

--- a/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
@@ -175,7 +175,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore = KeyStore, TPr
       async () => {
         const signature = await this.keystore.sign({
           account: from,
-          message: transactionUnsigned.serializeUnsigned().toString('hex'),
+          message: transactionUnsigned.message.toString('hex'),
         });
 
         const userAccount = this.getUserAccount(from);

--- a/packages/neo-one-client-full-common/src/models/manifest/ContractManifestModel.ts
+++ b/packages/neo-one-client-full-common/src/models/manifest/ContractManifestModel.ts
@@ -85,10 +85,6 @@ export class ContractManifestModel<
 
   public serializeJSON(): ContractManifestJSON {
     return {
-      // TODO: not sure if hash and hashHex should be returned here
-      // we serialize hash but not hashHex in old `Contract.ts`
-      hash: JSONHelper.writeUInt160(this.hash),
-      hashHex: this.hashHex,
       groups: this.groups.map((group) => group.serializeJSON()),
       features: {
         storage: this.hasStorage,

--- a/packages/neo-one-client-full-common/src/models/manifest/ContractPermissionDescriptorModel.ts
+++ b/packages/neo-one-client-full-common/src/models/manifest/ContractPermissionDescriptorModel.ts
@@ -32,27 +32,12 @@ export class ContractPermissionDescriptorModel implements SerializableJSON<Contr
 
   public serializeJSON(): ContractPermissionDescriptorJSON {
     if (this.isGroup) {
-      return {
-        hashOrGroup: common.ecPointToString(this.hashOrGroup as ECPoint),
-        isHash: false,
-        isGroup: true,
-        isWildcard: false,
-      };
+      return common.ecPointToString(this.hashOrGroup as ECPoint);
     }
     if (this.isHash) {
-      return {
-        hashOrGroup: common.uInt160ToString(this.hashOrGroup as UInt160),
-        isHash: true,
-        isGroup: false,
-        isWildcard: false,
-      };
+      return common.uInt160ToString(this.hashOrGroup as UInt160);
     }
 
-    return {
-      hashOrGroup: this.hashOrGroup as Wildcard,
-      isHash: false,
-      isGroup: false,
-      isWildcard: true,
-    };
+    return this.hashOrGroup as Wildcard;
   }
 }

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -279,6 +279,7 @@ export class Blockchain {
   public get serializeJSONContext() {
     return {
       addressVersion: this.settings.addressVersion,
+      messageMagic: this.settings.messageMagic,
     };
   }
 
@@ -710,7 +711,11 @@ export class Blockchain {
         return {
           type: 'add',
           subType: 'add',
-          change: { type: 'applicationLog', key: transaction?.hash ?? block.hash, value },
+          change: {
+            type: 'applicationLog',
+            key: transaction?.hash ?? block.hash,
+            value,
+          },
         };
       },
     );
@@ -763,6 +768,7 @@ export class Blockchain {
       }),
       consensusData: new ConsensusData({ primaryIndex: 0, nonce: new BN(0) }),
       transactions: [],
+      messageMagic: this.settings.messageMagic,
     });
   }
 }

--- a/packages/neo-one-node-core/src/Block.ts
+++ b/packages/neo-one-node-core/src/Block.ts
@@ -28,6 +28,7 @@ export interface BlockAdd extends Omit<BlockBaseAdd, 'merkleRoot'> {
   readonly merkleRoot?: UInt256;
   readonly consensusData?: ConsensusData;
   readonly transactions: readonly Transaction[];
+  readonly messageMagic: number;
 }
 
 // export interface BlockVerifyOptions {
@@ -102,6 +103,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
       nextConsensus: blockBase.nextConsensus,
       witness: blockBase.witness,
       transactions,
+      messageMagic: options.context.messageMagic,
     });
   }
 
@@ -128,6 +130,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
         index: this.index,
         nextConsensus: this.nextConsensus,
         witness: this.witness,
+        messageMagic: this.messageMagic,
       }),
   );
 
@@ -145,6 +148,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
     witness,
     hash,
     transactions,
+    messageMagic,
     merkleRoot = MerkleTree.computeRoot(getCombinedModels(transactions, consensusData).map((model) => model.hash)),
   }: BlockAdd) {
     super({
@@ -156,6 +160,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
       nextConsensus,
       witness,
       hash,
+      messageMagic,
     });
 
     this.transactions = transactions;
@@ -185,6 +190,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
       index: this.index,
       consensusData: this.consensusData,
       nextConsensus: this.nextConsensus,
+      messageMagic: this.messageMagic,
       transactions,
       witness,
     });
@@ -218,6 +224,7 @@ export class Block extends BlockBase implements SerializableContainer, Serializa
       witness: this.witness,
       hashes: this.allHashes,
       consensusData: this.consensusData,
+      messageMagic: this.messageMagic,
     });
   }
 }

--- a/packages/neo-one-node-core/src/ConsensusData.ts
+++ b/packages/neo-one-node-core/src/ConsensusData.ts
@@ -1,4 +1,4 @@
-import { BinaryWriter, ConsensusDataJSON, crypto, IOHelper, UInt256 } from '@neo-one/client-common';
+import { BinaryWriter, ConsensusDataJSON, crypto, IOHelper, JSONHelper, UInt256 } from '@neo-one/client-common';
 import { BN } from 'bn.js';
 import { DEFAULT_VALIDATORS_COUNT } from './constants';
 import {
@@ -56,7 +56,7 @@ export class ConsensusData implements SerializableWire, SerializableJSON<Consens
   public serializeJSON() {
     return {
       primary: this.primaryIndex,
-      nonce: this.nonce.toString(16),
+      nonce: JSONHelper.writeUInt64LE(this.nonce),
     };
   }
 }

--- a/packages/neo-one-node-core/src/ContractState.ts
+++ b/packages/neo-one-node-core/src/ContractState.ts
@@ -1,4 +1,12 @@
-import { common, createSerializeWire, crypto, IOHelper, JSONHelper, UInt160 } from '@neo-one/client-common';
+import {
+  common,
+  ContractJSON,
+  createSerializeWire,
+  crypto,
+  IOHelper,
+  JSONHelper,
+  UInt160,
+} from '@neo-one/client-common';
 import { ContractStateModel } from '@neo-one/client-full-common';
 import { ContractManifest } from './manifest';
 import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
@@ -56,11 +64,11 @@ export class ContractState extends ContractStateModel<ContractManifest> {
     });
   }
 
-  public serializeJSON() {
+  public serializeJSON(): ContractJSON {
     return {
       id: this.id,
       hash: JSONHelper.writeUInt160(this.scriptHash),
-      script: JSONHelper.writeBuffer(this.script),
+      script: JSONHelper.writeBase64Buffer(this.script),
       manifest: this.manifest.serializeJSON(),
     };
   }

--- a/packages/neo-one-node-core/src/Header.ts
+++ b/packages/neo-one-node-core/src/Header.ts
@@ -36,6 +36,7 @@ export class Header extends BlockBase implements SerializableWire, SerializableJ
       index: blockBase.index,
       nextConsensus: blockBase.nextConsensus,
       witness: blockBase.witness,
+      messageMagic: options.context.messageMagic,
     });
   }
 
@@ -59,6 +60,7 @@ export class Header extends BlockBase implements SerializableWire, SerializableJ
       nextConsensus: this.nextConsensus,
       witness: this.witness,
       hashes: [],
+      messageMagic: this.messageMagic,
     });
   }
 

--- a/packages/neo-one-node-core/src/TrimmedBlock.ts
+++ b/packages/neo-one-node-core/src/TrimmedBlock.ts
@@ -46,6 +46,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
       witness,
       hashes,
       consensusData,
+      messageMagic: options.context.messageMagic,
     });
   }
 
@@ -76,6 +77,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
         index: this.index,
         nextConsensus: this.nextConsensus,
         witness: this.witness,
+        messageMagic: this.messageMagic,
       }),
   );
 
@@ -90,6 +92,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
     hash,
     consensusData,
     hashes,
+    messageMagic,
   }: TrimmedBlockAdd) {
     super({
       version,
@@ -100,6 +103,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
       nextConsensus,
       witness,
       hash,
+      messageMagic,
     });
     this.consensusData = consensusData;
     this.hashes = hashes;
@@ -127,6 +131,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
           return state.transaction;
         }),
       ),
+      messageMagic: this.messageMagic,
     });
   }
 
@@ -142,6 +147,7 @@ export class TrimmedBlock extends BlockBase implements SerializableWire {
       witness: this.witness,
       hashes: this.hashes,
       consensusData: this.consensusData,
+      messageMagic: this.messageMagic,
       ...options,
     });
   }

--- a/packages/neo-one-node-core/src/payload/ConsensusPayload.ts
+++ b/packages/neo-one-node-core/src/payload/ConsensusPayload.ts
@@ -44,6 +44,7 @@ export class ConsensusPayload extends UnsignedConsensusPayload implements Serial
       validatorIndex,
       data,
       witness,
+      magic: options.context.messageMagic,
     });
   }
 

--- a/packages/neo-one-node-core/src/payload/UnsignedConsensusPayload.ts
+++ b/packages/neo-one-node-core/src/payload/UnsignedConsensusPayload.ts
@@ -11,7 +11,7 @@ export interface UnsignedConsensusPayloadAdd {
   readonly data?: Buffer;
   readonly getConsensusMessage?: () => ConsensusMessage;
   readonly consensusMessage?: ConsensusMessage;
-  readonly magic?: number;
+  readonly magic: number;
 }
 
 export class UnsignedConsensusPayload implements SerializableWire {
@@ -56,7 +56,7 @@ export class UnsignedConsensusPayload implements SerializableWire {
   public readonly previousHash: UInt256;
   public readonly blockIndex: number;
   public readonly validatorIndex: number;
-  public readonly magic: number | undefined;
+  public readonly magic: number;
 
   public readonly serializeWire = createSerializeWire(this.serializeWireBase.bind(this));
   private readonly consensusMessageInternal: (() => ConsensusMessage) | undefined;
@@ -86,8 +86,8 @@ export class UnsignedConsensusPayload implements SerializableWire {
 
   public get consensusMessage() {
     if (this.consensusMessageInternal === undefined) {
-      // TODO: Implement an error here;
-      throw new Error('need a way to get consensusMessage');
+      // TODO: Implement an error here
+      throw new Error('Need a way to get consensusMessage');
     }
 
     return this.consensusMessageInternal();

--- a/packages/neo-one-node-core/src/transaction/Transaction.ts
+++ b/packages/neo-one-node-core/src/transaction/Transaction.ts
@@ -36,7 +36,7 @@ export type TransactionAddUnsigned = Omit<TransactionModelAdd<Attribute, Witness
 export interface VerboseData {
   readonly blockhash: string;
   readonly confirmations: number;
-  readonly blocktime: string;
+  readonly blocktime: number;
   readonly vmstate: VMStateJSON;
 }
 
@@ -77,6 +77,7 @@ export class Transaction
       attributes,
       script,
       witnesses,
+      messageMagic: options.context.messageMagic,
     });
   }
 
@@ -120,6 +121,7 @@ export class Transaction
       signers,
       attributes,
       script,
+      messageMagic: options.context.messageMagic,
     };
   }
 
@@ -201,7 +203,7 @@ export class Transaction
 
     const maxBlockSysFee = await native.Policy.getMaxBlockSystemFee(storage);
     const sysFee = this.systemFee;
-    if (sysFee.gtn(maxBlockSysFee)) {
+    if (sysFee.gt(new BN(maxBlockSysFee))) {
       return VerifyResultModel.PolicyFail;
     }
 
@@ -271,8 +273,8 @@ export class Transaction
       version: this.version,
       nonce: this.nonce,
       sender: this.sender ? scriptHashToAddress(common.uInt160ToString(this.sender)) : undefined,
-      sysfee: JSONHelper.writeUInt64LE(this.systemFee),
-      netfee: JSONHelper.writeUInt64LE(this.networkFee),
+      sysfee: JSONHelper.writeUInt64(this.systemFee),
+      netfee: JSONHelper.writeUInt64(this.networkFee),
       validuntilblock: this.validUntilBlock,
       signers: this.signers.map((signer) => signer.serializeJSON()),
       attributes: this.attributes.map((attr) => attr.serializeJSON()),

--- a/packages/neo-one-node-core/src/transaction/attributes/AttributeBase.ts
+++ b/packages/neo-one-node-core/src/transaction/attributes/AttributeBase.ts
@@ -6,7 +6,7 @@ import {
   IOHelper,
   toJSONAttributeType,
 } from '@neo-one/client-common';
-import { DeserializeWireBaseOptions, SerializableJSON, SerializeJSONContext } from '../../Serializable';
+import { DeserializeWireBaseOptions, SerializableJSON } from '../../Serializable';
 import { VerifyOptions } from '../../Verifiable';
 import { Transaction } from '../Transaction';
 

--- a/packages/neo-one-node-native/src/GASToken.ts
+++ b/packages/neo-one-node-native/src/GASToken.ts
@@ -1,7 +1,7 @@
 import { NEP5NativeContract } from './Nep5';
 
 export class GASToken extends NEP5NativeContract {
-  public static readonly decimals: 8;
+  public static readonly decimals: number = 8;
   public constructor() {
     super({
       id: -2,

--- a/packages/neo-one-node-native/src/NEOToken.ts
+++ b/packages/neo-one-node-native/src/NEOToken.ts
@@ -145,6 +145,9 @@ export class NEOToken extends NEP5NativeContract {
       amount = amount.addn((iend - istart) * this.settings.generationAmount[ustart]);
     }
 
-    return common.fixedFromDecimal(amount.mul(value), GASToken.decimals).div(this.totalAmount);
+    return common
+      .fixedFromDecimal(amount.mul(value), GASToken.decimals)
+      .mul(new BN(10 ** GASToken.decimals))
+      .div(this.totalAmount);
   }
 }

--- a/packages/neo-one-node-native/src/Nep5.ts
+++ b/packages/neo-one-node-native/src/Nep5.ts
@@ -11,6 +11,7 @@ export interface NEP5NativeContractAdd extends NativeContractAdd {
 export abstract class NEP5NativeContract extends NativeContract {
   public readonly symbol: string;
   public readonly decimals: number;
+  public readonly factor: BN;
 
   protected readonly totalSupplyPrefix = Buffer.from([11]);
   protected readonly accountPrefix = Buffer.from([20]);
@@ -19,6 +20,7 @@ export abstract class NEP5NativeContract extends NativeContract {
     super(options);
     this.symbol = options.symbol;
     this.decimals = options.decimals;
+    this.factor = new BN(10 ** this.decimals);
   }
 
   public async totalSupply({ storages }: NativeContractStorageContext): Promise<BN> {

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -290,7 +290,7 @@ export class Node implements INode {
 
     this.mutableMemPool = {};
     this.transactionVerificationContext = new TransactionVerificationContext({
-      getGasBalance: native.GAS.balanceOf,
+      getGasBalance: native.GAS.balanceOf.bind(native.GAS),
     });
     this.mutableKnownBlockHashes = createScalingBloomFilter();
     this.tempKnownBlockHashes = new Set();

--- a/packages/neo-one-node-protocol/src/TransactionVerificationContext.ts
+++ b/packages/neo-one-node-protocol/src/TransactionVerificationContext.ts
@@ -45,7 +45,7 @@ export class TransactionVerificationContext {
     const maybeFee = this.mutableSenderFee[key];
     if (maybeFee === undefined) {
       // TODO: implement error;
-      throw new Error('transaction not present in verification context to remove');
+      throw new Error('Transaction not present in verification context to remove');
     }
 
     const newFee = maybeFee.sub(tx.systemFee).sub(tx.networkFee);

--- a/packages/neo-one-node-storage-common/src/keys.ts
+++ b/packages/neo-one-node-storage-common/src/keys.ts
@@ -148,7 +148,7 @@ const getNep5TransferSentSearchRange = createGetSearchRange(Prefix.Nep5TransferS
 
 const createApplicationLogKey = getCreateKey<UInt256>({
   serializeKey: (key) => key,
-  prefix: Prefix.Transaction,
+  prefix: Prefix.ApplicationLog,
 });
 
 export const keys = {


### PR DESCRIPTION
### Description of the Change

Updates many things:

- `createGetHashData` function
- How `message`/`messageMagic` is passed around to the appropriate places where it's needed (like in ConsensusPayload, FeelessTransactionModel, TransactionModel, Block, BlockBase, TrimmedBlock, BlockHeader)
- Makes fixes to RPC server to match Neo C# Node implementation
- Updates types and methods in JSONRPCClient and RPC methods
- Adds a test to show how transactions should be signed (`sendrawtransaction.test.ts`)

### Test Plan

See `sendrawtransaction.test.ts` and `temp.test.ts` in `neo-one-client-core/src/__tests__/provider`.

Also tested manually with Postman.

### Alternate Designs

None.

### Benefits

Less bugs, closer to Neo3 Preview 3.

### Possible Drawbacks

None.

### Applicable Issues

#2176 
#2009 
#1882 
#2155 
