### PR TITLE
fix(client): fix more client apis

### DIFF
--- a/packages/neo-one-cli/src/compile/interop.ts
+++ b/packages/neo-one-cli/src/compile/interop.ts
@@ -1,4 +1,4 @@
-import { ABI } from '@neo-one/client';
+import { ContractABI } from '@neo-one/client';
 import { common, crypto } from '@neo-one/client-common';
 
 const jmpABI = {
@@ -69,13 +69,13 @@ const convertABIMetadata = (metadata: NEOONEContractMetadata) => ({
   'is-payable': metadata.payable,
 });
 
-const convertABI = (abi: ABI, metadata: NEOONEContractMetadata, script: Buffer) => ({
+const convertABI = (abi: ContractABI, metadata: NEOONEContractMetadata, script: Buffer) => ({
   hash: common.uInt160ToHex(crypto.toScriptHash(script)),
   entrypoint: '@Jmp',
   functions: [
     jmpABI,
     dispatcherABI,
-    ...abi.functions.map((func) => ({
+    ...abi.methods.map((func) => ({
       name: func.name,
       parameters: func.parameters
         ? func.parameters.map(({ name, type }) => ({
@@ -83,19 +83,17 @@ const convertABI = (abi: ABI, metadata: NEOONEContractMetadata, script: Buffer) 
             type,
           }))
         : [],
-      returntype: func.returnType.type,
+      returntype: func.returnType,
     })),
   ],
-  events: abi.events
-    ? abi.events.map((event) => ({
-        name: event.name,
-        parameters: event.parameters.map(({ name, type }) => ({
-          name,
-          type,
-        })),
-        returntype: 'Void',
-      }))
-    : [],
+  events: abi.events.map((event) => ({
+    name: event.name,
+    parameters: event.parameters.map(({ name, type }) => ({
+      name,
+      type,
+    })),
+    returntype: 'Void',
+  })),
   metadata: convertABIMetadata(metadata),
 });
 

--- a/packages/neo-one-cli/src/console/startConsole.ts
+++ b/packages/neo-one-cli/src/console/startConsole.ts
@@ -1,6 +1,6 @@
 // tslint:disable no-console
 import { Configuration } from '@neo-one/cli-common';
-import { Hash256 } from '@neo-one/client-core';
+import { Hash160 } from '@neo-one/client-core';
 import BigNumber from 'bignumber.js';
 import repl from 'repl';
 import { loadClient } from '../common';
@@ -33,7 +33,7 @@ export const startConsole = async (config: Configuration, networks: readonly str
   addProperty('BigNumber', BigNumber);
   addProperty('print', console.log.bind(console));
   addProperty('printError', console.error.bind(console));
-  addProperty('Hash256', Hash256);
+  addProperty('Hash160', Hash160);
 
   return () => {
     replServer.close();

--- a/packages/neo-one-cli/src/deploy/runMigration.ts
+++ b/packages/neo-one-cli/src/deploy/runMigration.ts
@@ -125,7 +125,7 @@ export const runMigration = async (
           const params = await Promise.all(action.params);
           const result = await client.publishAndDeploy(
             contract.contract,
-            contract.abi,
+            contract.manifest,
             params,
             {
               ...(action.options === undefined ? {} : action.options),
@@ -144,7 +144,7 @@ export const runMigration = async (
           contracts = {
             ...contracts,
             [action.contract]: client.smartContract({
-              abi: contract.abi,
+              manifest: contract.manifest,
               networks: {
                 [network]: {
                   address: receipt.result.value.address,

--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -221,13 +221,6 @@ export interface UnclaimedGASJSON {
 
 export interface StackItemJSONBase {
   readonly type: StackItemJSON['type'];
-  // readonly value:
-  //   | string
-  //   | number
-  //   | boolean
-  //   | readonly StackItemJSON[]
-  //   | undefined
-  //   | ReadonlyArray<{ readonly key: PrimitiveStackItemJSON; readonly value: StackItemJSON }>;
 }
 
 export interface AnyStackItemJSON extends StackItemJSONBase {
@@ -278,8 +271,6 @@ export type StackItemJSON =
   | PrimitiveStackItemJSON
   | BufferStackItemJSON
   | ArrayStackItemJSON
-  // | StructStackItemJSON
-  // | InteropInterfaceStackItemJSON
   | MapStackItemJSON;
 
 export interface ExecutionResultJSON {
@@ -327,7 +318,6 @@ export interface VerboseTransactionJSON extends TransactionJSON {
 export interface TransactionWithInvocationDataJSON extends TransactionJSON {
   readonly script: string;
   readonly gas: string;
-  readonly invocationData?: InvocationDataJSON | undefined;
 }
 
 export interface TransactionReceiptJSON {

--- a/packages/neo-one-client-core/src/__tests__/provider/sendrawtransaction.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/provider/sendrawtransaction.test.ts
@@ -3,6 +3,7 @@ import {
   crypto,
   privateKeyToAddress,
   privateKeyToScriptHash,
+  publicKeyToAddress,
   ScriptBuilder,
   scriptHashToAddress,
   SignerModel,

--- a/packages/neo-one-client-core/src/nep5.ts
+++ b/packages/neo-one-client-core/src/nep5.ts
@@ -50,12 +50,12 @@ const decimalsFunction: ContractMethodDescriptorClient = {
   offset: 0,
 };
 
+// TODO: check that the script/hash can/should be blank here. also check offsets
 const blankScript = new ScriptBuilder().build();
 const blankHash = crypto.toScriptHash(blankScript);
 
 export const abi = (decimals: number): ContractABIClient => ({
-  // TODO: check
-  hash: blankHash,
+  hash: common.uInt160ToString(blankHash),
   methods: [
     {
       name: 'name',
@@ -136,9 +136,9 @@ export const abi = (decimals: number): ContractABIClient => ({
   ],
 });
 
+// TODO: check that the script/hash can/should be blank here
 export const manifest = (decimals: number): ContractManifestClient => ({
-  hash: blankHash, // TODO: check
-  hashHex: common.uInt160ToHex(blankHash), // TODO: check
+  hash: common.uInt160ToString(blankHash),
   groups: [],
   features: {
     storage: true,

--- a/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
+++ b/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
@@ -4,6 +4,7 @@ import {
   ApplicationLogJSON,
   BlockJSON,
   BufferString,
+  CallReceiptJSON,
   ContractJSON,
   GetOptions,
   Hash256String,
@@ -14,7 +15,6 @@ import {
   NetworkSettingsJSON,
   Peer,
   PrivateNetworkSettings,
-  RawInvocationResultJSON,
   RelayTransactionResultJSON,
   SendRawTransactionResultJSON,
   StorageItemJSON,
@@ -101,7 +101,7 @@ export class JSONRPCClient {
   public async testInvokeRaw(
     script: BufferString,
     verifications: readonly BufferString[] = [],
-  ): Promise<RawInvocationResultJSON> {
+  ): Promise<CallReceiptJSON> {
     return this.withInstance(async (provider) =>
       provider.request({
         method: 'invokescript',

--- a/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
@@ -8,9 +8,8 @@ import {
   IterOptions,
   NetworkSettings,
   NetworkType,
-  RawAction,
+  RawApplicationLogData,
   RawCallReceipt,
-  RawInvocationData,
   RelayTransactionResult,
   ScriptBuilderParam,
   Transaction,
@@ -73,8 +72,8 @@ export class NEOONEProvider implements Provider {
     return this.getProvider(network).getTransactionReceipt(hash, options);
   }
 
-  public async getInvocationData(network: NetworkType, hash: Hash256String): Promise<RawInvocationData> {
-    return this.getProvider(network).getInvocationData(hash);
+  public async getApplicationLogData(network: NetworkType, hash: Hash256String): Promise<RawApplicationLogData> {
+    return this.getProvider(network).getApplicationLogData(hash);
   }
 
   public async testInvoke(network: NetworkType, transaction: FeelessTransactionModel): Promise<RawCallReceipt> {
@@ -108,10 +107,6 @@ export class NEOONEProvider implements Provider {
 
   public async getAccount(network: NetworkType, address: AddressString): Promise<Account> {
     return this.getProvider(network).getAccount(address);
-  }
-
-  public iterActionsRaw(network: NetworkType, options?: IterOptions): AsyncIterable<RawAction> {
-    return this.getProvider(network).iterActionsRaw(options);
   }
 
   public iterBlocks(network: NetworkType, options: IterOptions = {}): AsyncIterable<Block> {

--- a/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
+++ b/packages/neo-one-client-core/src/user/LocalUserAccountProvider.ts
@@ -372,7 +372,7 @@ export class LocalUserAccountProvider<TKeyStore extends KeyStore = KeyStore, TPr
         from,
         transaction: invokeTransaction,
         onConfirm: async ({ transaction, receipt }) => {
-          const data = await this.provider.getInvocationData(from.network, transaction.hash);
+          const data = await this.provider.getApplicationLogData(from.network, transaction.hash);
 
           return onConfirm({ transaction, receipt, data });
         },


### PR DESCRIPTION
### Description of the Change

Fix up more Client APIs and related types. Especially in `NEOONEDataProvider` and `NEOONEProvider`.

Note that I removed `getInvocationData` and `iterActionsRaw` from the data provider/provider but kept the converters and types around in case we want to come back to them. I’m not sure where those were used or if they have any downstream affects in the Client. Figured we’d come back to them after finishing all this to start adding back functionality like “invocation data”.

Added getApplicationLogData.

### Test Plan

None. TBD in final e2e testing.

### Alternate Designs

None.

### Benefits

Closer to Neo3.

### Possible Drawbacks

None.

### Applicable Issues

#2218 
#2009 

