### PR TITLE
fix(client): fix more client apis

### DIFF
--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -595,14 +595,14 @@ export interface UserAccountProvider {
    *
    * Otherwise, parameters are the same as `invoke`.
    */
-  // readonly invokeClaim: (
-  //   contract: AddressString,
-  //   method: string,
-  //   params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  //   paramsZipped: ReadonlyArray<readonly [string, Param | undefined]>,
-  //   options?: TransactionOptions,
-  //   sourceMaps?: SourceMaps,
-  // ) => Promise<TransactionResult>;
+  readonly invokeClaim: (
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<readonly [string, Param | undefined]>,
+    options?: TransactionOptions,
+    sourceMaps?: SourceMaps,
+  ) => Promise<TransactionResult>;
   /**
    * Invokes the constant `method` on `contract` with `params` on `network`.
    */

--- a/packages/neo-one-client-core/src/Client.ts
+++ b/packages/neo-one-client-core/src/Client.ts
@@ -610,29 +610,29 @@ export class Client<
   /**
    * @internal
    */
-  // public async __invokeClaim(
-  //   contract: AddressString,
-  //   method: string,
-  //   params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  //   paramsZipped: ReadonlyArray<readonly [string, Param | undefined]>,
-  //   optionsIn?: TransactionOptions,
-  //   sourceMaps: SourceMaps = {},
-  // ): Promise<TransactionResult> {
-  //   args.assertAddress('contract', contract);
-  //   args.assertString('method', method);
-  //   args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
-  //   paramsZipped.forEach(([tupleString, tupleParam]) => [
-  //     args.assertString('tupleString', tupleString),
-  //     args.assertNullableParam('tupleParam', tupleParam),
-  //   ]);
-  //   const options = args.assertTransactionOptions('options', optionsIn);
-  //   args.assertSourceMaps('sourceMaps', sourceMaps);
-  //   await this.applyBeforeRelayHook(options);
+  public async __invokeClaim(
+    contract: AddressString,
+    method: string,
+    params: ReadonlyArray<ScriptBuilderParam | undefined>,
+    paramsZipped: ReadonlyArray<readonly [string, Param | undefined]>,
+    optionsIn?: TransactionOptions,
+    sourceMaps: SourceMaps = {},
+  ): Promise<TransactionResult> {
+    args.assertAddress('contract', contract);
+    args.assertString('method', method);
+    args.assertArray('params', params).forEach((param) => args.assertNullableScriptBuilderParam('params.param', param));
+    paramsZipped.forEach(([tupleString, tupleParam]) => [
+      args.assertString('tupleString', tupleString),
+      args.assertNullableParam('tupleParam', tupleParam),
+    ]);
+    const options = args.assertTransactionOptions('options', optionsIn);
+    args.assertSourceMaps('sourceMaps', sourceMaps);
+    await this.applyBeforeRelayHook(options);
 
-  //   return this.addTransactionHooks(
-  //     this.getProvider(options).invokeClaim(contract, method, params, paramsZipped, options, sourceMaps),
-  //   );
-  // }
+    return this.addTransactionHooks(
+      this.getProvider(options).invokeClaim(contract, method, params, paramsZipped, options, sourceMaps),
+    );
+  }
 
   /**
    * @internal


### PR DESCRIPTION
### Description of the Change

More updates to Client APIs. You can see how I handle `validUntilBlock` and `messageMagic` for transactions here. Just request those things from the Node and go from there.

See here for more info: https://github.com/neo-one-suite/neo-one/issues/2218

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Client API updates.

### Possible Drawbacks

None.

### Applicable Issues

#2009 
#2218
