### PR TITLE
fix(cli): fix migration file path for typescript

### DIFF
--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -305,7 +305,12 @@ const validateConfig = async (rootDir: string, configIn: any): Promise<Configura
     },
     migration: {
       ...config.migration,
-      path: nodePath.resolve(rootDir, config.migration.path),
+      path: nodePath.resolve(
+        rootDir,
+        newLanguage === undefined || newLanguage === 'javascript'
+          ? config.migration.path
+          : config.migration.path.slice(0, -3).concat('.ts'),
+      ),
     },
     contracts: {
       ...config.contracts,

--- a/packages/neo-one-website/docs/2-advanced-guides/09-configuration-options.md
+++ b/packages/neo-one-website/docs/2-advanced-guides/09-configuration-options.md
@@ -39,7 +39,7 @@ export default {
   },
   migration: {
     // NEO•ONE will load the deployment migration from this path.
-    path: 'neo-one/migration.js',
+    path: 'neo-one/migration.ts',
   },
   codegen: {
     // NEO•ONE will write source artifacts to this directory. This directory should be committed.


### PR DESCRIPTION
### Description of the Change

Fixes small error when generating a config file in a typescript environment. Migration file would be `.js` regardless of language. Now it will be `.ts` when it detects typescript.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Better usability.

### Possible Drawbacks

None.

### Applicable Issues

None.