### PR TITLE
fix(vm): fixup environment variable requirements

### DIFF
--- a/common/changes/@neo-one/node-vm/vm-env-fixup_2020-12-09-19-41.json
+++ b/common/changes/@neo-one/node-vm/vm-env-fixup_2020-12-09-19-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-vm",
+      "comment": "add default environment variable instead of requiring them from the user",
+      "type": "none"
+    }
+  ],
+  "packageName": "@neo-one/node-vm",
+  "email": "danwbyrne@gmail.com"
+}

--- a/packages/neo-one-node-vm/src/utils.ts
+++ b/packages/neo-one-node-vm/src/utils.ts
@@ -6,7 +6,9 @@ import { InvalidByteError, InvalidIntError, InvalidUIntError } from './errors';
 import { ProtocolSettings } from './Methods';
 import { DefaultMethods, DispatcherFunc } from './types';
 
-const APP_ROOT = path.resolve(__dirname, '..');
+const directory = path.basename(__dirname);
+const APP_ROOT =
+  directory === 'cjs' || directory === 'esm' ? path.resolve(__dirname, '..', '..') : path.resolve(__dirname, '..');
 const CSHARP_APP_ROOT = process.env.EDGE_APP_ROOT ?? path.resolve(APP_ROOT, 'lib', 'bin', 'Debug', 'netcoreapp3.0');
 
 export const constants = {
@@ -19,6 +21,14 @@ type EdgeOptions = (() => void) | string | Params | Source | TSQL;
 export const createCSharpDispatchInvoke = <Methods extends DefaultMethods>(
   options: EdgeOptions,
 ): DispatcherFunc<Methods> => {
+  if (process.env.EDGE_APP_ROOT === undefined) {
+    process.env.EDGE_APP_ROOT = CSHARP_APP_ROOT;
+  }
+
+  if (process.env.EDGE_USE_CORECLR === undefined) {
+    process.env.EDGE_USE_CORECLR = '1';
+  }
+
   const invokeFunction = func(options);
 
   return (input) => invokeFunction(input, true);


### PR DESCRIPTION
Add default environment variables for edge in the vm

adds a switch for the case of the package being exported.