### PR TITLE
fix(node): fixup byteStringStackItem toJSON return value

### DIFF
--- a/packages/neo-one-client-core/src/provider/convert.ts
+++ b/packages/neo-one-client-core/src/provider/convert.ts
@@ -42,7 +42,7 @@ export function convertStackItem(item: StackItemJSON): RawStackItem {
     case 'Buffer':
       return { type: 'Buffer', value: Buffer.from(item.value, 'hex') };
     case 'ByteString':
-      return { type: 'ByteString', value: item.value };
+      return { type: 'ByteString', value: Buffer.from(item.value, 'base64').toString('ascii') };
     case 'Array':
       return { type: 'Array', value: item.value.map(convertStackItem) };
     case 'Map':

--- a/packages/neo-one-node-core/src/StackItems/StackItems.ts
+++ b/packages/neo-one-node-core/src/StackItems/StackItems.ts
@@ -157,7 +157,7 @@ export const stackItemToJSON = (item: StackItem, context?: Set<StackItem>): Stac
     case StackItemType.ByteString:
       const byteString = assertByteStringStackItem(item);
 
-      return { type: 'ByteString', value: byteString.getBuffer().toString('ascii') };
+      return { type: 'ByteString', value: byteString.getBuffer().toString('base64') };
 
     case StackItemType.Integer:
       const integer = assertIntegerStackItem(item);


### PR DESCRIPTION
title, edit to previous PR.

ByteStringStackItem should return a base64 encoded string on the node side and convert to ascii on the frontend.