### PR TITLE
feat(test): fixup local node for unit test

### DIFF
--- a/packages/neo-one-client-core/src/__tests__/user/LocalUserAccountProvider.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/user/LocalUserAccountProvider.test.ts
@@ -142,21 +142,20 @@ describe.skip('Test LocalUserAccountProvider transfer methods -- staging network
 
 describe('contract info / usage testing', () => {
   const knownContractHashString = '0x79597a92440ce385fe1b0f4d9d2a92ca8608a575';
-  const knownContractHash = common.stringToUInt160(knownContractHashString);
 
   const providerOptions = {
     network: 'test',
-    rpcURL: 'http://localhost:8081/rpc',
+    rpcURL: 'https://staging.neotracker.io/rpc',
   };
   const provider = new NEOONEProvider([providerOptions]);
 
   test('use `call` to get name of NEO contract', async () => {
-    const result = await provider.call('test', common.nativeScriptHashes.NEO, 'name', []);
+    const result = await provider.call('test', knownContractHashString, 'name', []);
     const value = result.stack[0];
     if (typeof value === 'string') {
       throw new Error(value);
     }
 
-    expect(value.value).toEqual('NEO');
+    expect(value.value).toEqual('S3 Plus');
   });
 });

--- a/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
+++ b/packages/neo-one-client-core/src/provider/NEOONEProvider.ts
@@ -99,14 +99,14 @@ export class NEOONEProvider implements Provider {
     return this.getProvider(network).testTransaction(transaction);
   }
 
-  public async call(
-    network: NetworkType,
-    contract: AddressString,
-    method: string,
-    params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  ): Promise<RawCallReceipt> {
-    return this.getProvider(network).call(contract, method, params);
-  }
+  // public async call(
+  //   network: NetworkType,
+  //   contract: AddressString,
+  //   method: string,
+  //   params: ReadonlyArray<ScriptBuilderParam | undefined>,
+  // ): Promise<RawCallReceipt> {
+  //   return this.getProvider(network).call(contract, method, params);
+  // }
 
   public async getNetworkSettings(network: NetworkType): Promise<NetworkSettings> {
     return this.getProvider(network).getNetworkSettings();

--- a/packages/neo-one-client-core/src/user/UserAccountProviderBase.ts
+++ b/packages/neo-one-client-core/src/user/UserAccountProviderBase.ts
@@ -122,12 +122,12 @@ export interface Provider {
   readonly getApplicationLogData: (network: NetworkType, hash: Hash256String) => Promise<RawApplicationLogData>;
   readonly testInvoke: (network: NetworkType, script: Buffer) => Promise<RawCallReceipt>;
   readonly testTransaction: (network: NetworkType, transaction: TransactionModel) => Promise<RawCallReceipt>;
-  readonly call: (
-    network: NetworkType,
-    contract: AddressString,
-    method: string,
-    params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  ) => Promise<RawCallReceipt>;
+  // readonly call: (
+  //   network: NetworkType,
+  //   contract: AddressString,
+  //   method: string,
+  //   params: ReadonlyArray<ScriptBuilderParam | undefined>,
+  // ) => Promise<RawCallReceipt>;
   readonly getNetworkSettings: (network: NetworkType) => Promise<NetworkSettings>;
   readonly getBlockCount: (network: NetworkType) => Promise<number>;
   readonly getFeePerByte: (network: NetworkType) => Promise<BigNumber>;
@@ -466,14 +466,14 @@ export abstract class UserAccountProviderBase<TProvider extends Provider> {
     );
   }
 
-  public async call(
-    network: NetworkType,
-    contract: AddressString,
-    method: string,
-    params: ReadonlyArray<ScriptBuilderParam | undefined>,
-  ): Promise<RawCallReceipt> {
-    return this.provider.call(network, contract, method, params);
-  }
+  // public async call(
+  //   network: NetworkType,
+  //   contract: AddressString,
+  //   method: string,
+  //   params: ReadonlyArray<ScriptBuilderParam | undefined>,
+  // ): Promise<RawCallReceipt> {
+  //   return this.provider.call(network, contract, method, params);
+  // }
 
   public async getSystemFee({
     network,


### PR DESCRIPTION
fixup the `createNode` helper for smart-contract testing in the future.

Add an option for using `Memdown` in testing, essentially just writing all storage to the VM between every block persist.