### PR TITLE
fix(compiler): serialize and deserialize keys to primitive types

### DIFF
--- a/packages/neo-one-cli/src/__data__/projects/exchange/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/exchange/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash 62c81cb3802f775995035832c616b05b */
+/* @hash 14de5ea97f6e83fb29ab4ee22844e4e4 */
 // tslint:disable
 /* eslint-disable */
 import {

--- a/packages/neo-one-cli/src/__data__/projects/ico-Js/codegen/client.js
+++ b/packages/neo-one-cli/src/__data__/projects/ico-Js/codegen/client.js
@@ -1,4 +1,4 @@
-/* @hash 9b096a2a34b26c1ef0089640880bf614 */
+/* @hash afc05d2caed0efb1385d1e1e0eddb729 */
 // tslint:disable
 /* eslint-disable */
 import {

--- a/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
+++ b/packages/neo-one-cli/src/__data__/projects/ico/codegen/client.ts
@@ -1,4 +1,4 @@
-/* @hash 62c81cb3802f775995035832c616b05b */
+/* @hash dd096b49c861db1ef931d609f5542192 */
 // tslint:disable
 /* eslint-disable */
 import {
@@ -64,7 +64,7 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 
   const providers = [];
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
-    providers.push({ network: 'local', rpcURL: `http://${host}:10020/rpc` });
+    providers.push({ network: 'local', rpcURL: `http://${host}:10010/rpc` });
   }
   const provider = new NEOONEProvider(providers);
   const userAccountProviders = getUserAccountProviders(provider);
@@ -145,5 +145,5 @@ export const createClient = <TUserAccountProviders extends UserAccountProviders<
 };
 
 export const createDeveloperClients = (host = 'localhost'): DeveloperClients => ({
-  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10020/rpc` })),
+  local: new DeveloperClient(new NEOONEDataProvider({ network: 'local', rpcURL: `http://${host}:10010/rpc` })),
 });

--- a/packages/neo-one-node-vm/src/errors.ts
+++ b/packages/neo-one-node-vm/src/errors.ts
@@ -121,14 +121,26 @@ export const InvalidPickItemKeyError = makeErrorWithCode(
   (context: ExecutionContext, key: string, value: string) =>
     getMessage(context, `Invalid PICKITEM Index: ${key}. Value: ${value}`),
 );
+export const InvalidPickItemKeyTypeError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
+  getMessage(context, `Invalid PICKITEM Key Type`),
+);
 export const InvalidRemoveIndexError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext, index: number) =>
   getMessage(context, `Invalid REMOVE Index: ${index}`),
+);
+export const InvalidRemoveKeyTypeError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
+  getMessage(context, `Invalid REMOVE Key Type`),
 );
 export const InvalidHasKeyIndexError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Invalid HASKEY Index'),
 );
+export const InvalidHasKeyKeyTypeError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
+  getMessage(context, `Invalid HASKEY Key Type`),
+);
 export const InvalidSetItemIndexError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Invalid SETITEM Index'),
+);
+export const InvalidSetItemKeyTypeError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
+  getMessage(context, `Invalid SETITEM Key Type`),
 );
 export const InvalidCheckWitnessArgumentsError = makeErrorWithCode('VM_ERROR', (context: ExecutionContext) =>
   getMessage(context, 'Invalid CheckWitness Arguments'),

--- a/packages/neo-one-node-vm/src/opcodes.ts
+++ b/packages/neo-one-node-vm/src/opcodes.ts
@@ -21,10 +21,14 @@ import {
   InsufficientReturnValueError,
   InvalidCheckMultisigArgumentsError,
   InvalidHasKeyIndexError,
+  InvalidHasKeyKeyTypeError,
   InvalidPackCountError,
   InvalidPickItemKeyError,
+  InvalidPickItemKeyTypeError,
   InvalidRemoveIndexError,
+  InvalidRemoveKeyTypeError,
   InvalidSetItemIndexError,
+  InvalidSetItemKeyTypeError,
   InvalidTailCallReturnValueError,
   ItemTooLargeError,
   LeftNegativeError,
@@ -1718,8 +1722,12 @@ const OPCODE_PAIRS = ([
         in: 2,
         out: 1,
         invoke: ({ context, args }) => {
+          const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidPickItemKeyTypeError(context);
+          }
           if (args[1].isArray()) {
-            const index = vmUtils.toNumber(context, args[0].asBigIntegerUnsafe());
+            const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();
             if (index < 0 || index >= val.length) {
               throw new InvalidPickItemKeyError(context, `${index}`, JSON.stringify(args[1].convertJSON()));
@@ -1733,7 +1741,6 @@ const OPCODE_PAIRS = ([
             };
           }
 
-          const key = args[0];
           const value = args[1].asMapStackItem();
           if (!value.has(key)) {
             throw new InvalidPickItemKeyError(context, key.toStructuralKey(), JSON.stringify(args[1].convertJSON()));
@@ -1755,11 +1762,15 @@ const OPCODE_PAIRS = ([
         in: 3,
         invoke: ({ context, args }) => {
           let newItem = args[0];
+          const key = args[1];
+          if (key.isICollection) {
+            throw new InvalidSetItemKeyTypeError(context);
+          }
           if (newItem instanceof StructStackItem) {
             newItem = newItem.clone();
           }
           if (args[2].isArray()) {
-            const index = vmUtils.toNumber(context, args[1].asBigIntegerUnsafe());
+            const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const mutableValue = args[2].asArray();
             if (index < 0 || index >= mutableValue.length) {
               throw new InvalidSetItemIndexError(context);
@@ -1779,7 +1790,6 @@ const OPCODE_PAIRS = ([
             };
           }
 
-          const key = args[1];
           const value = args[2].asMapStackItem();
           const existingValue = value.has(key) ? value.get(key) : undefined;
           value.set(key, newItem);
@@ -1861,8 +1871,12 @@ const OPCODE_PAIRS = ([
         name: 'REMOVE',
         in: 2,
         invoke: ({ context, args }) => {
+          const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidRemoveKeyTypeError(context);
+          }
           if (args[1].isArray()) {
-            const index = vmUtils.toNumber(context, args[0].asBigIntegerUnsafe());
+            const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const mutableValue = args[1].asArray();
             if (index < 0 || index >= mutableValue.length) {
               throw new InvalidRemoveIndexError(context, index);
@@ -1879,7 +1893,6 @@ const OPCODE_PAIRS = ([
             };
           }
 
-          const key = args[0];
           const value = args[1].asMapStackItem();
           if (value.has(key)) {
             const val = value.get(key);
@@ -1909,8 +1922,12 @@ const OPCODE_PAIRS = ([
         in: 2,
         out: 1,
         invoke: ({ context, args }) => {
+          const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidHasKeyKeyTypeError(context);
+          }
           if (args[1].isArray()) {
-            const index = vmUtils.toNumber(context, args[0].asBigIntegerUnsafe());
+            const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();
             if (index < 0) {
               throw new InvalidHasKeyIndexError(context);
@@ -1922,7 +1939,6 @@ const OPCODE_PAIRS = ([
             };
           }
 
-          const key = args[0];
           const value = args[1].asMapStackItem();
 
           return {

--- a/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
@@ -4,6 +4,7 @@ import { StackItemType } from './StackItemType';
 
 export class ArrayStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Array;
+  public readonly isICollection = true;
   private readonly referenceID = getNextID();
 
   public toStructuralKey(): string {

--- a/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
@@ -11,6 +11,7 @@ import { StackItemBase } from './StackItemBase';
 import { StackItemType } from './StackItemType';
 
 export class MapStackItem extends StackItemBase {
+  public readonly isICollection = true;
   private readonly referenceKeys: Map<string, StackItem>;
   private readonly referenceValues: Map<string, StackItem>;
   private readonly referenceID = getNextID();

--- a/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
@@ -57,6 +57,7 @@ export interface AsStorageContextStackItemOptions {
 }
 
 export class StackItemBase implements Equatable {
+  public readonly isICollection: boolean = false;
   private mutableCount = 0;
 
   public get referenceCount(): number {

--- a/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
@@ -4,6 +4,7 @@ import { StackItemType } from './StackItemType';
 
 export class StructStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Struct;
+  public readonly isICollection = true;
 
   public clone(): StructStackItem {
     return new StructStackItem(this.value.map((value) => (value instanceof StructStackItem ? value.clone() : value)));

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/map/getSetHasDelete.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/map/getSetHasDelete.test.ts
@@ -23,23 +23,23 @@ describe('Map.prototype.get/set/has/delete', () => {
     `);
   });
 
-  test('should respect reference semantics', async () => {
+  test('should NOT respect reference semantics', async () => {
     await helpers.executeString(`
       const x = new Map<ReadonlyArray<number>, string>();
       const y = [0];
       const z = [0];
       x.set(y, 'bar').set(z, 'baz');
 
-      assertEqual(x.get(y), 'bar');
+      assertEqual(x.get(y), 'baz');
       assertEqual(x.has(y), true);
       assertEqual(x.get(z), 'baz');
       assertEqual(x.has(z), true);
-      assertEqual(x.get([0]), undefined);
-      assertEqual(x.has([0]), false);
-      assertEqual(x.size, 2);
+      assertEqual(x.get([0]), 'baz');
+      assertEqual(x.has([0]), true);
+      assertEqual(x.size, 1);
 
       x.delete(y);
-      assertEqual(x.delete(z), true);
+      assertEqual(x.delete(z), false);
       assertEqual(x.delete(z), false);
       assertEqual(x.size, 0);
       assertEqual(x.get(y), undefined);

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/set/hasAddDelete.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/set/hasAddDelete.test.ts
@@ -20,7 +20,7 @@ describe('Set.prototype.hasAddDelete', () => {
     `);
   });
 
-  test('should respect reference semantics', async () => {
+  test('should NOT respect reference semantics', async () => {
     await helpers.executeString(`
       const x = new Set<ReadonlyArray<number>>();
       const y = [0];
@@ -29,11 +29,11 @@ describe('Set.prototype.hasAddDelete', () => {
 
       assertEqual(x.has(y), true);
       assertEqual(x.has(z), true);
-      assertEqual(x.has([0]), false);
-      assertEqual(x.size, 2);
+      assertEqual(x.has([0]), true);
+      assertEqual(x.size, 1);
 
       x.delete(y);
-      assertEqual(x.delete(z), true);
+      assertEqual(x.delete(z), false);
       assertEqual(x.delete(z), false);
       assertEqual(x.size, 0);
       assertEqual(x.has(y), false);

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/delete.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/delete.ts
@@ -33,6 +33,8 @@ export class MapDelete extends BuiltinInstanceMemberCall {
     sb.emitHelper(node, options, sb.helpers.unwrapMap);
     // [keyVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
+    // [key, map]
+    sb.emitSysCall(node, 'Neo.Runtime.Serialize');
     // [val]
     sb.emitHelper(node, optionsIn, sb.helpers.mapDelete);
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/forEach.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/forEach.ts
@@ -36,7 +36,7 @@ export class MapForEach extends BuiltinInstanceMemberCall {
     // [objectVal, iterator]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
     // []
-    sb.emitHelper(node, options, sb.helpers.rawIteratorForEachFunc);
+    sb.emitHelper(node, options, sb.helpers.rawIteratorForEachFunc({ deserializeKey: true }));
 
     if (optionsIn.pushValue) {
       // [val]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/get.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/get.ts
@@ -33,6 +33,8 @@ export class MapGet extends BuiltinInstanceMemberCall {
     sb.emitHelper(node, options, sb.helpers.unwrapMap);
     // [keyVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
+    // [key, map]
+    sb.emitSysCall(node, 'Neo.Runtime.Serialize');
     // [map, keyVal]
     sb.emitOp(node, 'SWAP');
     // [map, keyVal, map]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/has.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/has.ts
@@ -33,6 +33,8 @@ export class MapHas extends BuiltinInstanceMemberCall {
     sb.emitHelper(node, options, sb.helpers.unwrapMap);
     // [keyVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
+    // [key, map]
+    sb.emitSysCall(node, 'Neo.Runtime.Serialize');
     // [boolean]
     sb.emitOp(node, 'HASKEY');
     // [booleanVal]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/iterator.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/iterator.ts
@@ -36,6 +36,6 @@ export class MapIterator extends BuiltinInstanceMemberCall {
     // [iterator]
     sb.emitSysCall(node, 'Neo.Iterator.Create');
     // [val]
-    sb.emitHelper(node, options, sb.helpers.createIteratorIterableIterator({}));
+    sb.emitHelper(node, options, sb.helpers.createIteratorIterableIterator({ deserializeKey: true }));
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/set.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/map/set.ts
@@ -37,6 +37,8 @@ export class MapSet extends BuiltinInstanceMemberCall {
     sb.emitHelper(node, options, sb.helpers.unwrapMap);
     // [keyVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
+    // [key, map]
+    sb.emitSysCall(node, 'Neo.Runtime.Serialize');
     // [valVal, keyVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[1], options);
     // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/add.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/add.ts
@@ -37,6 +37,8 @@ export class SetAdd extends BuiltinInstanceMemberCall {
     sb.emitHelper(node, options, sb.helpers.unwrapMap);
     // [valVal, map]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
+    // [key, map]
+    sb.emitSysCall(node, 'Neo.Runtime.Serialize');
     // [value, keyVal, map]
     sb.emitPushBoolean(node, true);
     // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/forEach.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/forEach.ts
@@ -38,7 +38,7 @@ export class SetForEach extends BuiltinInstanceMemberCall {
     // [objectVal, iterator]
     sb.visit(tsUtils.argumented.getArguments(node)[0], options);
     // []
-    sb.emitHelper(node, sb.noPushValueOptions(options), sb.helpers.rawEnumeratorForEachFunc);
+    sb.emitHelper(node, sb.noPushValueOptions(options), sb.helpers.rawEnumeratorForEachFunc({ deserializeKey: true }));
 
     if (optionsIn.pushValue) {
       // [val]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/index.ts
@@ -57,6 +57,8 @@ class SetValue extends BuiltinNew {
             sb.emitOp(node, 'TUCK');
             // [val, map, map]
             sb.emitOp(node, 'SWAP');
+            // [val, map, map]
+            sb.emitSysCall(node, 'Neo.Runtime.Serialize');
             // [boolean, val, map, map]
             sb.emitPushBoolean(node, true);
             // [map]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/iterator.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/iterator.ts
@@ -38,6 +38,6 @@ export class SetIterator extends BuiltinInstanceMemberCall {
     // [enumerator]
     sb.emitSysCall(node, 'Neo.Iterator.Keys');
     // [val]
-    sb.emitHelper(node, options, sb.helpers.createEnumeratorIterableIterator({}));
+    sb.emitHelper(node, options, sb.helpers.createEnumeratorIterableIterator({ deserializeKey: true }));
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/bind/ArrayBindingHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/bind/ArrayBindingHelper.ts
@@ -153,6 +153,8 @@ export class ArrayBindingHelper extends TypedHelper<ts.ArrayBindingPattern> {
         sb.emitOp(element, 'SWAP');
         // [key, val]
         sb.emitSysCall(element, 'Neo.Iterator.Key');
+        // [key, val]
+        sb.emitSysCall(element, 'Neo.Runtime.Deserialize');
         // [2, key, val]
         sb.emitPushInt(element, 2);
         // [arr]
@@ -170,6 +172,7 @@ export class ArrayBindingHelper extends TypedHelper<ts.ArrayBindingPattern> {
           element,
           innerOptions,
           sb.helpers.rawIteratorReduce({
+            deserializeKey: true,
             each: handleMapLike(element),
           }),
         );
@@ -205,6 +208,8 @@ export class ArrayBindingHelper extends TypedHelper<ts.ArrayBindingPattern> {
         sb.emitOp(element, 'DROP');
         // [val]
         sb.emitSysCall(element, 'Neo.Iterator.Key');
+        // [val]
+        sb.emitSysCall(element, 'Neo.Runtime.Deserialize');
       },
       (element, innerOptions) => {
         // [0, iterator]
@@ -216,6 +221,7 @@ export class ArrayBindingHelper extends TypedHelper<ts.ArrayBindingPattern> {
           element,
           innerOptions,
           sb.helpers.rawIteratorReduce({
+            deserializeKey: true,
             each: handleSetLike(element),
           }),
         );

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/common/GenericLogSerializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/common/GenericLogSerializeHelper.ts
@@ -50,6 +50,7 @@ export class GenericLogSerializeHelper extends Helper {
         node,
         innerOptions,
         sb.helpers.mapReduce({
+          deserializeKey: true,
           each: (innerInnerOptions) => {
             // [val, arr, key]
             sb.emitOp(node, 'ROT');
@@ -87,6 +88,7 @@ export class GenericLogSerializeHelper extends Helper {
         node,
         innerOptions,
         sb.helpers.mapReduce({
+          deserializeKey: true,
           each: (innerInnerOptions) => {
             // [val, arr, key]
             sb.emitOp(node, 'ROT');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -142,6 +142,7 @@ import {
   RawEnumeratorFindHelper,
   RawEnumeratorFindHelperOptions,
   RawEnumeratorForEachFuncHelper,
+  RawEnumeratorForEachFuncHelperOptions,
   RawEnumeratorForEachHelper,
   RawEnumeratorForEachHelperOptions,
   RawEnumeratorReduceHelper,
@@ -158,6 +159,7 @@ import {
   RawIteratorForEachFuncBaseHelperOptions,
   RawIteratorForEachFuncHelper,
   RawIteratorForEachHelper,
+  RawIteratorForEachHelperFuncOptions,
   RawIteratorForEachHelperOptions,
   RawIteratorForEachKeyHelper,
   RawIteratorForEachKeyHelperOptions,
@@ -631,11 +633,11 @@ export interface Helpers {
   readonly rawIteratorForEach: (options: RawIteratorForEachHelperOptions) => RawIteratorForEachHelper;
   readonly rawIteratorForEachKey: (options: RawIteratorForEachKeyHelperOptions) => RawIteratorForEachKeyHelper;
   readonly rawIteratorForEachBase: (options: RawIteratorForEachBaseHelperOptions) => RawIteratorForEachBaseHelper;
-  readonly rawIteratorForEachFunc: RawIteratorForEachFuncHelper;
+  readonly rawIteratorForEachFunc: (options: RawIteratorForEachHelperFuncOptions) => RawIteratorForEachFuncHelper;
   readonly rawIteratorForEachFuncBase: (
     options: RawIteratorForEachFuncBaseHelperOptions,
   ) => RawIteratorForEachFuncBaseHelper;
-  readonly rawEnumeratorForEachFunc: RawEnumeratorForEachFuncHelper;
+  readonly rawEnumeratorForEachFunc: (options: RawEnumeratorForEachFuncHelperOptions) => RawEnumeratorForEachFuncHelper;
   readonly rawEnumeratorForEach: (options: RawEnumeratorForEachHelperOptions) => RawEnumeratorForEachHelper;
   readonly rawEnumeratorFilter: (options: RawEnumeratorFilterHelperOptions) => RawEnumeratorFilterHelper;
   readonly rawEnumeratorFind: (options: RawEnumeratorFindHelperOptions) => RawEnumeratorFindHelper;
@@ -1072,9 +1074,9 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     rawIteratorForEach: (options) => new RawIteratorForEachHelper(options),
     rawIteratorForEachKey: (options) => new RawIteratorForEachKeyHelper(options),
     rawIteratorForEachBase: (options) => new RawIteratorForEachBaseHelper(options),
-    rawIteratorForEachFunc: new RawIteratorForEachFuncHelper(),
+    rawIteratorForEachFunc: (options) => new RawIteratorForEachFuncHelper(options),
     rawIteratorForEachFuncBase: (options) => new RawIteratorForEachFuncBaseHelper(options),
-    rawEnumeratorForEachFunc: new RawEnumeratorForEachFuncHelper(),
+    rawEnumeratorForEachFunc: (options) => new RawEnumeratorForEachFuncHelper(options),
     rawEnumeratorForEach: (options) => new RawEnumeratorForEachHelper(options),
     rawEnumeratorFilter: (options) => new RawEnumeratorFilterHelper(options),
     rawEnumeratorFind: (options) => new RawEnumeratorFindHelper(options),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
@@ -113,6 +113,7 @@ export class ArgumentsHelper extends Helper<ts.CallExpression | ts.NewExpression
             arg,
             innerOptions,
             sb.helpers.mapReduce({
+              deserializeKey: true,
               each: handleMapLike,
             }),
           );
@@ -140,6 +141,7 @@ export class ArgumentsHelper extends Helper<ts.CallExpression | ts.NewExpression
             arg,
             innerOptions,
             sb.helpers.mapReduce({
+              deserializeKey: true,
               each: handleSetLike,
             }),
           );

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/CreateEnumeratorIterableIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/CreateEnumeratorIterableIteratorHelper.ts
@@ -4,6 +4,7 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface CreateEnumeratorIterableIteratorHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly mapValue?: (options: VisitOptions) => void;
 }
 
@@ -14,11 +15,13 @@ const doNothing = () => {
 // Input: [enumerator]
 // Output: [val]
 export class CreateEnumeratorIterableIteratorHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly mapValue: (options: VisitOptions) => void;
 
   public constructor(options: CreateEnumeratorIterableIteratorHelperOptions) {
     super();
     this.mapValue = options.mapValue === undefined ? doNothing : options.mapValue;
+    this.deserializeKey = options.deserializeKey ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -29,6 +32,10 @@ export class CreateEnumeratorIterableIteratorHelper extends Helper {
         handleNext: (innerOptions) => {
           // [value]
           sb.emitSysCall(node, 'Neo.Enumerator.Value');
+          if (this.deserializeKey) {
+            // [value]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // [val]
           this.mapValue(innerOptions);
         },

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/CreateIteratorIterableIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/CreateIteratorIterableIteratorHelper.ts
@@ -4,6 +4,7 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface CreateIteratorIterableIteratorHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly mapKey?: (options: VisitOptions) => void;
   readonly mapValue?: (options: VisitOptions) => void;
 }
@@ -15,11 +16,13 @@ const doNothing = () => {
 // Input: [iterator]
 // Output: [val]
 export class CreateIteratorIterableIteratorHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly mapKey: (options: VisitOptions) => void;
   private readonly mapValue: (options: VisitOptions) => void;
 
   public constructor(options: CreateIteratorIterableIteratorHelperOptions) {
     super();
+    this.deserializeKey = options.deserializeKey ?? false;
     this.mapKey = options.mapKey === undefined ? doNothing : options.mapKey;
     this.mapValue = options.mapValue === undefined ? doNothing : options.mapValue;
   }
@@ -40,6 +43,10 @@ export class CreateIteratorIterableIteratorHelper extends Helper {
           sb.emitOp(node, 'SWAP');
           // [key, valueVal]
           sb.emitSysCall(node, 'Neo.Iterator.Key');
+          if (this.deserializeKey) {
+            // [key, valueVal]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // [keyVal, valueVal]
           this.mapKey(innerOptions);
           // [number, keyVal, valueVal]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawEnumeratorForEachFuncHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawEnumeratorForEachFuncHelper.ts
@@ -3,9 +3,20 @@ import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
+export interface RawEnumeratorForEachFuncHelperOptions {
+  readonly deserializeKey?: boolean;
+}
+
 // Input: [objectVal, enumerator]
 // Output: []
 export class RawEnumeratorForEachFuncHelper extends Helper {
+  private readonly deserializeKey: boolean;
+
+  public constructor(options: RawEnumeratorForEachFuncHelperOptions) {
+    super();
+    this.deserializeKey = options.deserializeKey ?? false;
+  }
+
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     const options = sb.pushValueOptions(optionsIn);
 
@@ -28,6 +39,10 @@ export class RawEnumeratorForEachFuncHelper extends Helper {
           sb.emitOp(node, 'DUP');
           // [key, enumerator, callable]
           sb.emitSysCall(node, 'Neo.Enumerator.Value');
+          if (this.deserializeKey) {
+            // [key, enumerator, callable]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // [1, value, enumerator, callable]
           sb.emitPushInt(node, 1);
           // [argsarr, enumerator, callable]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachFuncHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachFuncHelper.ts
@@ -3,9 +3,20 @@ import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
+export interface RawIteratorForEachHelperFuncOptions {
+  readonly deserializeKey?: boolean;
+}
+
 // Input: [objectVal, iterator]
 // Output: []
 export class RawIteratorForEachFuncHelper extends Helper {
+  private readonly deserializeKey: boolean;
+
+  public constructor(options: RawIteratorForEachHelperFuncOptions) {
+    super();
+    this.deserializeKey = options.deserializeKey ?? false;
+  }
+
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     const options = sb.pushValueOptions(optionsIn);
 
@@ -16,6 +27,10 @@ export class RawIteratorForEachFuncHelper extends Helper {
         handleNext: () => {
           // [key, iterator, callable]
           sb.emitSysCall(node, 'Neo.Iterator.Key');
+          if (this.deserializeKey) {
+            // [key, iterator, callable]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // [iterator, key, iterator, callable]
           sb.emitOp(node, 'OVER');
           // [value, key, iterator, callable]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachHelper.ts
@@ -4,17 +4,20 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface RawIteratorForEachHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly each: (options: VisitOptions) => void;
 }
 
 // Input: [iterator]
 // Output: []
 export class RawIteratorForEachHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly each: (options: VisitOptions) => void;
 
   public constructor(options: RawIteratorForEachHelperOptions) {
     super();
     this.each = options.each;
+    this.deserializeKey = options.deserializeKey ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -29,6 +32,10 @@ export class RawIteratorForEachHelper extends Helper {
           sb.emitOp(node, 'OVER');
           // [key, val]
           sb.emitSysCall(node, 'Neo.Iterator.Key');
+          if (this.deserializeKey) {
+            // [key, val]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // []
           this.each(innerOptions);
         },

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachKeyHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorForEachKeyHelper.ts
@@ -4,17 +4,20 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface RawIteratorForEachKeyHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly each: (options: VisitOptions) => void;
 }
 
 // Input: [iterator]
 // Output: []
 export class RawIteratorForEachKeyHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly each: (options: VisitOptions) => void;
 
   public constructor(options: RawIteratorForEachKeyHelperOptions) {
     super();
     this.each = options.each;
+    this.deserializeKey = options.deserializeKey ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -25,6 +28,10 @@ export class RawIteratorForEachKeyHelper extends Helper {
         each: (innerOptions) => {
           // [key]
           sb.emitSysCall(node, 'Neo.Iterator.Key');
+          if (this.deserializeKey) {
+            // [key]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // []
           this.each(innerOptions);
         },

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorReduceHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawIteratorReduceHelper.ts
@@ -4,17 +4,20 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface RawIteratorReduceHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly each: (options: VisitOptions) => void;
 }
 
 // Input: [accum, iterator]
 // Output: [accum]
 export class RawIteratorReduceHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly each: (options: VisitOptions) => void;
 
   public constructor(options: RawIteratorReduceHelperOptions) {
     super();
     this.each = options.each;
+    this.deserializeKey = options.deserializeKey ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -31,6 +34,10 @@ export class RawIteratorReduceHelper extends Helper {
           sb.emitOp(node, 'ROT');
           // [key, value, accum]
           sb.emitSysCall(node, 'Neo.Iterator.Key');
+          if (this.deserializeKey) {
+            // [key, value, accum]
+            sb.emitSysCall(node, 'Neo.Runtime.Deserialize');
+          }
           // [accum, key, value]
           sb.emitOp(node, 'ROT');
           // [accum]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapReduceHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapReduceHelper.ts
@@ -4,17 +4,20 @@ import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
 export interface MapReduceHelperOptions {
+  readonly deserializeKey?: boolean;
   readonly each: (options: VisitOptions) => void;
 }
 
 // Input: [accum, map]
 // Output: [accum]
 export class MapReduceHelper extends Helper {
+  private readonly deserializeKey: boolean;
   private readonly each: (options: VisitOptions) => void;
 
   public constructor(options: MapReduceHelperOptions) {
     super();
     this.each = options.each;
+    this.deserializeKey = options.deserializeKey ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -29,6 +32,7 @@ export class MapReduceHelper extends Helper {
       node,
       options,
       sb.helpers.rawIteratorReduce({
+        deserializeKey: this.deserializeKey,
         each: this.each,
       }),
     );

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/WrapValRecursiveHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/WrapValRecursiveHelper.ts
@@ -9,6 +9,7 @@ import { isAddress, isHash256, isPublicKey } from './buffer';
 import { isOnlyMap } from './map';
 
 export interface WrapValRecursiveHelperOptions {
+  readonly serializeFinalVal?: boolean;
   readonly checkValue?: boolean;
   readonly type: ts.Type | undefined;
   readonly optional?: boolean;
@@ -17,6 +18,7 @@ export interface WrapValRecursiveHelperOptions {
 // Input: [val]
 // Output: [value]
 export class WrapValRecursiveHelper extends Helper {
+  private readonly serializeFinalVal: boolean;
   private readonly checkValue: boolean;
   private readonly type: ts.Type | undefined;
   private readonly optional?: boolean;
@@ -26,6 +28,7 @@ export class WrapValRecursiveHelper extends Helper {
     this.checkValue = options.checkValue === undefined ? false : options.checkValue;
     this.type = options.type;
     this.optional = options.optional;
+    this.serializeFinalVal = options.serializeFinalVal ?? false;
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
@@ -45,6 +48,9 @@ export class WrapValRecursiveHelper extends Helper {
       }
 
       body(innerOptions);
+      if (this.serializeFinalVal) {
+        sb.emitSysCall(node, 'Neo.Runtime.Serialize');
+      }
     };
 
     const handleUndefined = createHandleValue(false, (innerOptions) => {
@@ -243,6 +249,7 @@ export class WrapValRecursiveHelper extends Helper {
                   node,
                   innerInnerOptions,
                   sb.helpers.wrapValRecursive({
+                    serializeFinalVal: true,
                     checkValue: this.checkValue,
                     type: keyType,
                   }),

--- a/packages/neo-one-smart-contract-compiler/src/compile/statement/ForOfStatementCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/statement/ForOfStatementCompiler.ts
@@ -87,6 +87,7 @@ export class ForOfStatementCompiler extends NodeCompiler<ts.ForOfStatement> {
         node,
         innerOptions,
         sb.helpers.rawIteratorForEach({
+          deserializeKey: true,
           each: (innerInnerOptionsIn) => {
             const innerInnerOptions = sb.pushValueOptions(innerInnerOptionsIn);
             // [2, key, val]
@@ -129,7 +130,7 @@ export class ForOfStatementCompiler extends NodeCompiler<ts.ForOfStatement> {
       // [iterator]
       sb.emitSysCall(expression, 'Neo.Iterator.Create');
       // []
-      sb.emitHelper(node, innerOptions, sb.helpers.rawIteratorForEachKey({ each }));
+      sb.emitHelper(node, innerOptions, sb.helpers.rawIteratorForEachKey({ each, deserializeKey: true }));
     };
 
     const handleSetStorage = (innerOptions: VisitOptions) => {

--- a/packages/neo-one-website/docs/1-main-concepts/12-deployment.md
+++ b/packages/neo-one-website/docs/1-main-concepts/12-deployment.md
@@ -130,7 +130,7 @@ This will ensure that after deploying the `ico` contract (and confirming it is d
 Once you have successfully configured your `migration` file as explained above you are all set to deploy your Smart Contract! Using the set of [networks](/docs/config-options) defined in `.neo-one.config.js` you can deploy using the command:
 
 ```bash
-yarn neo-one deploy --<network>
+yarn neo-one deploy --network <network>
 ```
 
 where `network` is one of the keys provided by your configuration. By default `yarn neo-one deploy` will use the `test` key.


### PR DESCRIPTION
### Description of the Change

Brings NEO•ONE version 2.x up to speed with a Neo2 VM change from early 2018 which we never implemented in our VM implementation. This change no longer allows struct stack items to be used as keys in VM maps. Keys must be primitive stack item types (not array, struct, or map types). Since we "wrap" all our values in structs this wouldn't work. So now in the compiler we just serialize and deserialize all wrapped values that need to be used as keys for maps in the VM to get around this.

### Test Plan

`rush test`
`rush e2e`

### Alternate Designs

None.

### Benefits

NEO•ONE 2.x (latest) working on Neo2.

### Possible Drawbacks

None.

### Applicable Issues

None.
