### PR TITLE
feat(cli): add cli configpath option and do cli cleanup

### DIFF
--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -190,13 +190,13 @@ ${exportConfig} {
     // NEO•ONE will look for smart contracts in this directory.
     path: '${config.contracts.path}',
     // Set this to true if you want the compile command to output JSON.
-    // json: ${true},
+    json: ${true},
     // Set this to true if you want the compile command to output AVM.
-    // avm: ${false},
+    avm: ${false},
     // Set this to true if you want the compile command to output additional debug information.
-    // debug: ${false},
+    debug: ${false},
     // Set this to true if you want the compile command to output the AVM in a human-readable format for debugging (requires debug: true).
-    // opcodes: ${false},
+    opcodes: ${false},
   },
   artifacts: {
     // NEO•ONE will store build and deployment artifacts that should be checked in to vcs in this directory.
@@ -338,7 +338,20 @@ const validateConfig = async (rootDir: string, configIn: any): Promise<Configura
 // tslint:disable-next-line no-let
 let cachedConfig: Configuration | undefined;
 
-export const loadConfiguration = async (): Promise<Configuration> => {
+export const loadConfiguration = async (optionalConfigPath?: string): Promise<Configuration> => {
+  if (cachedConfig === undefined && optionalConfigPath !== undefined) {
+    register({
+      compilerOptions: {
+        module: 'commonjs',
+        allowJs: true,
+      },
+    });
+    const obj = await import(optionalConfigPath);
+    const output = obj.default === undefined ? obj : obj.default;
+
+    cachedConfig = await validateConfig(nodePath.dirname(optionalConfigPath), output === null ? {} : output);
+  }
+
   if (cachedConfig === undefined) {
     const explorer = cosmiconfig('neo-one', {
       loaders: {

--- a/packages/neo-one-cli-common-node/src/networks.ts
+++ b/packages/neo-one-cli-common-node/src/networks.ts
@@ -1,3 +1,4 @@
+import { rpcURL as commonRpcURL } from '@neo-one/cli-common';
 import { LocalKeyStore, LocalMemoryStore, NEOONEProvider } from '@neo-one/client-core';
 import { LocalUserAccountProvider } from '@neo-one/client-full-core';
 import prompts from 'prompts';
@@ -21,12 +22,12 @@ export const createUserAccountProviderFunc = (network: string, rpcURL: string) =
 // tslint:disable-next-line export-name
 export const defaultNetworks = {
   main: {
-    userAccountProvider: createUserAccountProviderFunc('main', 'https://neotracker.io/rpc'),
+    userAccountProvider: createUserAccountProviderFunc('main', commonRpcURL.main),
   },
   test: {
-    userAccountProvider: createUserAccountProviderFunc('test', 'https://testnet.neotracker.io/rpc'),
+    userAccountProvider: createUserAccountProviderFunc('test', commonRpcURL.test),
   },
   local: {
-    userAccountProvider: createUserAccountProviderFunc('neo-one', 'localhost:9040'),
+    userAccountProvider: createUserAccountProviderFunc('neo-one', 'localhost:9040'), // TODO: should this end with /rpc ? abstrac this if not
   },
 };

--- a/packages/neo-one-cli-common/src/index.ts
+++ b/packages/neo-one-cli-common/src/index.ts
@@ -2,3 +2,4 @@ export * from './configuration';
 export * from './deployContract';
 export * from './getClients';
 export * from './setupWallets';
+export * from './rpcURL';

--- a/packages/neo-one-cli-common/src/rpcURL.ts
+++ b/packages/neo-one-cli-common/src/rpcURL.ts
@@ -1,0 +1,4 @@
+export const rpcURL = {
+  test: 'https://testnet.neotracker.io/rpc',
+  main: 'https://neotracker.io/rpc',
+};

--- a/packages/neo-one-cli/src/__data__/generateTests.ts
+++ b/packages/neo-one-cli/src/__data__/generateTests.ts
@@ -331,13 +331,10 @@ const verifySmartContractAfterMint = async (
   expect(escrowPairBalanceAfterClaim.toString()).toEqual('15');
 };
 
-export const buildTests = async (project: string) => {
+export const generateTests = async (project: string) => {
   const start = Math.round(Date.now() / 1000);
   const exec = one.createExec(project);
-  one.addCleanup(async () => {
-    await exec('stop network');
-  });
-  await exec('build');
+  await exec('generate');
 
   const [{ client: outerClient }, config] = await Promise.all([getClients(project), one.getProjectConfig(project)]);
   const contracts = await getContracts(outerClient, constants.LOCAL_NETWORK_NAME);

--- a/packages/neo-one-cli/src/__data__/index.ts
+++ b/packages/neo-one-cli/src/__data__/index.ts
@@ -1,3 +1,4 @@
 export * from './getClients';
 export * from './getContracts';
 export * from './buildTests';
+export * from './generateTests';

--- a/packages/neo-one-cli/src/__e2e__/cmd/generate.test.ts
+++ b/packages/neo-one-cli/src/__e2e__/cmd/generate.test.ts
@@ -1,0 +1,40 @@
+// tslint:disable no-any
+import { generateTests } from '../../__data__';
+
+jest.setTimeout(300 * 1000);
+
+describe('generate (ts, react)', () => {
+  it('is a one stop command for local development of the ico project using typescript and the react framework.', async () => {
+    await generateTests('ico');
+  });
+});
+
+describe('generate (js, react)', () => {
+  it('is a one stop command for local development of the ico project using javascript and the react framework.', async () => {
+    await generateTests('ico-Js');
+  });
+});
+
+describe('generate (ts, angular)', () => {
+  it('is a one stop command for local development of the ico project using typescript and the angular framework.', async () => {
+    await generateTests('ico-angular');
+  });
+});
+
+describe('generate (js, angular)', () => {
+  it('is a one stop command for local development of the ico project using javascript and the angular framework.', async () => {
+    await generateTests('ico-angularJs');
+  });
+});
+
+describe('generate (ts, vue)', () => {
+  it('is a one stop command for local development of the ico project using typescript and the vue framework.', async () => {
+    await generateTests('ico-vue');
+  });
+});
+
+describe('generate (js, vue)', () => {
+  it('is a one stop command for local development of the ico project using javascript and the vue framework.', async () => {
+    await generateTests('ico-vueJs');
+  });
+});

--- a/packages/neo-one-cli/src/build/deployContract.ts
+++ b/packages/neo-one-cli/src/build/deployContract.ts
@@ -18,6 +18,7 @@ export const deployContract = async (
     throw new Error('Compilation error.');
   }
 
+  // TODO: this will be wrong now since contract script hash need sender for script completion
   const address = scriptHashToAddress(
     common.uInt160ToString(crypto.toScriptHash(Buffer.from(contract.contract.script, 'hex'))),
   );
@@ -39,7 +40,7 @@ export const deployContract = async (
 
   return {
     manifest: contract.contract.manifest,
-    address,
+    address, // TODO: this should be a "pre-address script" or something that will be used with the sender
     sourceMap,
     sourceMaps: nextSourceMaps,
     linked: {

--- a/packages/neo-one-cli/src/cmd/compile.ts
+++ b/packages/neo-one-cli/src/cmd/compile.ts
@@ -18,21 +18,25 @@ export const builder = (yargsBuilder: typeof yargs) =>
     .boolean('debug')
     .describe('debug', 'Output additional debug information.')
     .boolean('opcodes')
-    .describe('opcodes', 'Output the AVM in a human readable format for debugging (requires --debug).');
+    .describe('opcodes', 'Output the AVM in a human readable format for debugging (requires --debug).')
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
 
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const configOptions = config.contracts;
     const path = argv.path ? argv.path : configOptions.path;
     const outDir = argv.outDir ? argv.outDir : configOptions.outDir;
+    const opcodes = argv.opcodes ? argv.opcodes : configOptions.opcodes;
+    const debugIn = argv.debug ? argv.debug : configOptions.debug;
     const options = {
       json: argv.json ? argv.json : configOptions.json,
       avm: argv.avm ? argv.avm : configOptions.avm,
-      debug: argv.debug ? argv.debug : configOptions.debug,
-      opcodes: argv.opcodes ? argv.opcodes : configOptions.opcodes,
+      debug: opcodes || debugIn,
+      opcodes,
     };
     if (options.opcodes && !options.debug) {
-      throw new Error('`opcodes` flag may only be specified alongside the `debug` flag');
+      throw new Error('`opcodes` flag may only be specified alongside the `debug` flag.');
     }
     await createTasks(path, outDir, {
       json: options.json ? options.json : !options.avm,
@@ -40,5 +44,5 @@ export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
       debug: options.debug ? options.debug : false,
       opcodes: options.opcodes ? options.opcodes : false,
     }).run();
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/console.ts
+++ b/packages/neo-one-cli/src/cmd/console.ts
@@ -11,7 +11,9 @@ export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder
     .array('networks')
     .describe('networks', 'Networks to initialize before starting the REPL.')
-    .default('networks', defaultNetworks);
+    .default('networks', defaultNetworks)
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
-  start(async (_cmd, config) => startConsole(config, argv.networks));
+  start(async (_cmd, config) => startConsole(config, argv.networks), argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/deploy.ts
+++ b/packages/neo-one-cli/src/cmd/deploy.ts
@@ -6,9 +6,14 @@ import { deploy } from '../deploy';
 export const command = 'deploy';
 export const describe = 'Deploys the project using the migration file.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder.string('network').describe('network', 'Network to run the migration on.').default('network', 'test');
+  yargsBuilder
+    .string('network')
+    .describe('network', 'Network to run the migration on.')
+    .default('network', 'test')
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
     await deploy(cmd, config, argv.network);
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/generate.ts
+++ b/packages/neo-one-cli/src/cmd/generate.ts
@@ -1,19 +1,16 @@
 import { Yarguments } from '@neo-one/utils-node';
 import yargs from 'yargs';
-import { createTasks } from '../build';
 import { start } from '../common';
+import { createTasks } from '../generate';
 
-export const command = 'build';
-export const describe = 'Builds the project and deploys it to the local development network.';
+export const command = 'generate';
+export const describe = 'Compiles the contracts and generates common code.';
 export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder
-    .boolean('reset')
-    .describe('reset', 'Reset the local project.')
-    .default('reset', false)
     .string('configPath')
     .describe('configPath', 'Optional path to the config file if not in root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
-    await createTasks(cmd, config, argv.reset).run();
+    await createTasks(cmd, config).run();
   }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/index.ts
+++ b/packages/neo-one-cli/src/cmd/index.ts
@@ -4,6 +4,7 @@ import * as compile from './compile';
 import * as consoleCmd from './console';
 import * as convert from './convert';
 import * as deploy from './deploy';
+import * as generate from './generate';
 import * as info from './info';
 import * as init from './init';
 import * as newCmd from './new';
@@ -23,4 +24,5 @@ export const builder = (yargsBuilder: typeof yargs) =>
     .command(deploy)
     .command(info)
     .command(compile)
-    .command(init);
+    .command(init)
+    .command(generate);

--- a/packages/neo-one-cli/src/cmd/info.ts
+++ b/packages/neo-one-cli/src/cmd/info.ts
@@ -1,13 +1,17 @@
 import { configToSerializable } from '@neo-one/cli-common-node';
+import { Yarguments } from '@neo-one/utils-node';
 import yargs from 'yargs';
 import { start } from '../common';
 
 export const command = 'info';
 export const describe = 'Prints project configuration.';
-export const builder = (yargsBuilder: typeof yargs) => yargsBuilder;
-export const handler = () => {
+export const builder = (yargsBuilder: typeof yargs) =>
+  yargsBuilder
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
+export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     // tslint:disable-next-line no-console
     console.log(JSON.stringify(configToSerializable(config), undefined, 2));
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/init.ts
+++ b/packages/neo-one-cli/src/cmd/init.ts
@@ -42,7 +42,9 @@ export const builder = (yargsBuilder: typeof yargs) =>
       'typescript',
       'Initialize a NEO•ONE project with TypeScript. If no tsconfig is found a default one will be generated.',
     )
-    .default('typescript', false);
+    .default('typescript', false)
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const tsconfigPath = nodePath.resolve(config.contracts.path, 'tsconfig.json');
@@ -219,5 +221,5 @@ export const ExampleHelloWorld = () => {
     console.log(
       'NEO•ONE initialized, run `neo-one build` to deploy the HelloWorld smart contract to a local development network.',
     );
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/common/start.ts
+++ b/packages/neo-one-cli/src/common/start.ts
@@ -9,12 +9,12 @@ type StartFunc = (cmd: Command, config: Configuration) => Promise<StartReturn | 
 
 const startInternal = createStart(cliLogger);
 
-export const start = (startFunc: StartFunc) => {
+export const start = (startFunc: StartFunc, optionalConfigPath?: string) => {
   // tslint:disable-next-line no-object-mutation
   cliLogger.level = 'info';
 
   startInternal(async () => {
-    const config = await loadConfiguration();
+    const config = await loadConfiguration(optionalConfigPath);
 
     const cmd = {
       bin: process.argv[0],

--- a/packages/neo-one-cli/src/compile/compileContract.ts
+++ b/packages/neo-one-cli/src/compile/compileContract.ts
@@ -18,6 +18,7 @@ export const compileContract = async (
     common.uInt160ToString(crypto.toScriptHash(Buffer.from(contract.contract.script, 'hex'))),
   );
 
+  // TODO: this will be wrong now since contract script hash need sender for script completion
   const sourceMap = await contract.sourceMap;
   const nextSourceMaps = {
     ...sourceMaps,
@@ -26,6 +27,7 @@ export const compileContract = async (
 
   return {
     contract,
+    address, // TODO: this should be a "pre-address script" or something that will be used with the sender
     sourceMap,
     sourceMaps: nextSourceMaps,
     linked: {

--- a/packages/neo-one-cli/src/compile/createTasks.ts
+++ b/packages/neo-one-cli/src/compile/createTasks.ts
@@ -8,7 +8,7 @@ import { CompileWriteOptions, writeContract } from './writeContract';
 export const createTasks = (path: string, outDir: string, options: CompileWriteOptions) =>
   new Listr([
     {
-      title: 'Find Contracts',
+      title: 'Find contracts',
       task: async (ctx) => {
         const contracts = await findContracts(path);
 
@@ -16,7 +16,7 @@ export const createTasks = (path: string, outDir: string, options: CompileWriteO
       },
     },
     {
-      title: 'Compile Contracts',
+      title: 'Compile contracts',
       task: (ctx) => {
         ctx.linked = {};
         ctx.sourceMaps = {};

--- a/packages/neo-one-cli/src/generate/createTasks.ts
+++ b/packages/neo-one-cli/src/generate/createTasks.ts
@@ -1,0 +1,96 @@
+// tslint:disable no-object-mutation
+import { Configuration, rpcURL } from '@neo-one/cli-common';
+import { Contracts } from '@neo-one/smart-contract-compiler';
+import Listr from 'listr';
+import _ from 'lodash';
+import { Command } from '../types';
+import { findContracts } from './../build/findContracts';
+import { generateCode } from './../build/generateCode';
+import { generateCommonCode } from './../build/generateCommonCode';
+import { compileContract } from './../compile/compileContract';
+
+export const createTasks = (_cmd: Command, config: Configuration) =>
+  new Listr([
+    {
+      title: 'Find contracts',
+      task: async (ctx) => {
+        const contracts = await findContracts(config);
+        ctx.foundContracts = contracts;
+      },
+    },
+    {
+      title: 'Compile contracts',
+      task: (ctx) => {
+        ctx.linked = {};
+        ctx.sourceMaps = {};
+        ctx.contracts = [];
+
+        return new Listr(
+          (ctx.foundContracts as Contracts).map((contract) => ({
+            title: `Compile ${contract.name}`,
+            task: async (innerCtx) => {
+              const {
+                linked,
+                sourceMaps,
+                contract: {
+                  contract: { manifest },
+                },
+                address,
+                sourceMap,
+              } = await compileContract(contract.filePath, contract.name, innerCtx.linked, innerCtx.sourceMaps);
+              innerCtx.linked = linked;
+              innerCtx.sourceMaps = sourceMaps;
+              innerCtx.contracts.push({
+                name: contract.name,
+                filePath: contract.filePath,
+                sourceMap,
+              });
+
+              const networksDefinition = {};
+
+              await generateCode(
+                config,
+                contract.filePath,
+                contract.name,
+                manifest,
+                _.merge(
+                  {},
+                  {
+                    local: {
+                      address,
+                    },
+                  },
+                  networksDefinition,
+                ),
+              );
+            },
+          })),
+        );
+      },
+    },
+    {
+      title: 'Generate common code',
+      task: async (ctx) => {
+        // TODO: add more network definition here for non-local dev purposes?
+        // should these new definitions be in build createTasks
+        const networks = [
+          {
+            name: 'local',
+            rpcURL: `http://localhost:${config.network.port}/rpc`,
+            dev: true,
+          },
+          {
+            name: 'test',
+            rpcURL: rpcURL.test,
+            dev: false,
+          },
+          {
+            name: 'main',
+            rpcURL: rpcURL.main,
+            dev: false,
+          },
+        ];
+        await generateCommonCode(config, ctx.contracts, networks, ctx.sourceMaps);
+      },
+    },
+  ]);

--- a/packages/neo-one-cli/src/generate/index.ts
+++ b/packages/neo-one-cli/src/generate/index.ts
@@ -1,0 +1,1 @@
+export * from './createTasks';

--- a/packages/neo-one-node-protocol/src/Message.ts
+++ b/packages/neo-one-node-protocol/src/Message.ts
@@ -32,18 +32,15 @@ import {
   VersionPayload,
 } from './payload';
 
-const tryCompression = ({ command }: MessageValue) => {
-  return (
-    command === Command.Block ||
-    command === Command.Consensus ||
-    command === Command.Transaction ||
-    command === Command.Headers ||
-    command === Command.Addr ||
-    command === Command.MerkleBlock ||
-    command === Command.FilterLoad ||
-    command === Command.FilterAdd
-  );
-};
+const tryCompression = ({ command }: MessageValue) =>
+  command === Command.Block ||
+  command === Command.Consensus ||
+  command === Command.Transaction ||
+  command === Command.Headers ||
+  command === Command.Addr ||
+  command === Command.MerkleBlock ||
+  command === Command.FilterLoad ||
+  command === Command.FilterAdd;
 
 export type MessageValue =
   | { readonly command: Command.Addr; readonly payload: AddrPayload }

--- a/packages/neo-one-smart-contract-codegen/src/client/genBrowserClient.ts
+++ b/packages/neo-one-smart-contract-codegen/src/client/genBrowserClient.ts
@@ -42,7 +42,9 @@ if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true')
               `localKeyStore.addUserAccount({ network: '${localDevNetworkName}', name: '${name}', privateKey: '${wif}' }),`,
           )
           .join('\n          ')}
-      ], localKeyStore);
+      ]).catch(() => {
+        // do nothing
+      });
     }
   }
 }`;


### PR DESCRIPTION
### Description of the Change

This does multiple things to improve the CLI user experience.

1. Adds new `generate` command that will do some parts of the `build` command. It won't start a local development network but it will compile the contracts and generate the common code to integrate with dApps. This will help demonstrate more features are ready to go as we migrate to Neo3. This also provides another option for building the project without starting a dev network unnecessarily.
2. Adds an optional CLI argument to every command: `--configPath` which will override the search for a neo-one config file in the local directory and instead find it by the provided path. This is primarily for internal use as it makes it easier for us to test the CLI in a demo repo without having to publish to NPM.
3. It also does a little bit of cleanup here and there and remove one possible error case in the CLI and instead just infers a better default instead of throwing an error and making the user handle it.

### Test Plan

Tested locally manually. Started to write and update tests but they'll be obsolete with Preview5 upgrade anyway, so leaving it for now.

### Alternate Designs

None.

### Benefits

Easier test, better UX.

### Possible Drawbacks

None.

### Applicable Issues

None.
