### PR TITLE
fix(release): bump smart-contract-test version

### DIFF
--- a/packages/neo-one-cli/CHANGELOG.json
+++ b/packages/neo-one-cli/CHANGELOG.json
@@ -75,7 +75,7 @@
             "comment": "Updating dependency \"@neo-one/smart-contract\" from `^2.7.0` to `^3.1.0`"
           },
           {
-            "comment": "Updating dependency \"@neo-one/smart-contract-test\" from `^2.7.1` to `^2.8.0`"
+            "comment": "Updating dependency \"@neo-one/smart-contract-test\" from `^2.7.1` to `^3.1.0`"
           }
         ]
       }

--- a/packages/neo-one-cli/package.json
+++ b/packages/neo-one-cli/package.json
@@ -59,7 +59,7 @@
     "@angular/core": "^8.2.7",
     "@neo-one/build-tools": "^1.0.0",
     "@neo-one/smart-contract": "^3.1.0",
-    "@neo-one/smart-contract-test": "^2.8.0",
+    "@neo-one/smart-contract-test": "^3.1.0",
     "@neotracker/core": "1.4.1",
     "@types/bn.js": "^4.11.5",
     "@types/fs-extra": "^8.0.0",

--- a/packages/neo-one-smart-contract-test/package.json
+++ b/packages/neo-one-smart-contract-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo-one/smart-contract-test",
-  "version": "2.8.0",
+  "version": "3.1.0",
   "description": "NEO•ONE TypeScript smart contract test harness.",
   "main": "./dist/cjs/index",
   "module": "./dist/esm/index",


### PR DESCRIPTION
Bump one more package to 3.1.0- smart-contract-test.