### PR TITLE
Fix: type filter selection

### DIFF
--- a/packages/neo-one-website/src/components/reference/TypeFilter.tsx
+++ b/packages/neo-one-website/src/components/reference/TypeFilter.tsx
@@ -25,7 +25,7 @@ export const TypeFilter = ({ selected, onChange, ...props }: Props) => (
     {...props}
     formatOptionLabel={createFormatOptionLabel}
     placeholder="Select Type"
-    value={selected}
+    value={[`${selected}`]}
     options={TYPE_FILTER_OPTIONS}
     onChange={onChange}
   />


### PR DESCRIPTION
### Description of the Change

Select component in TypeFilter.ts did not persist the selection of type (it only displays placeholder text regardless). This change alters the component slightly to display the selected type inside to confirm to users what was selected.
Before:
![Screen Shot 2021-02-09 at 3 58 07 PM](https://user-images.githubusercontent.com/30916803/107444611-b87f2380-6aef-11eb-9bbe-b8e3accdb9ea.png)
After:
![Screen Shot 2021-02-09 at 4 01 53 PM](https://user-images.githubusercontent.com/30916803/107444825-2c213080-6af0-11eb-99b0-e446b9634966.png)

### Test Plan

Tested locally


### Alternate Designs

Currently no alternate design

### Benefits

Improved UI.

### Possible Drawbacks

None currently.

### Applicable Issues
None.
