### PR TITLE
Fix: client-switch source map initialization issue with Jest

### DIFF
--- a/packages/neo-one-website/src/components/reference/TypeFilter.tsx
+++ b/packages/neo-one-website/src/components/reference/TypeFilter.tsx
@@ -25,7 +25,7 @@ export const TypeFilter = ({ selected, onChange, ...props }: Props) => (
     {...props}
     formatOptionLabel={createFormatOptionLabel}
     placeholder="Select Type"
-    value={selected}
+    value={[`${selected}`]}
     options={TYPE_FILTER_OPTIONS}
     onChange={onChange}
   />


### PR DESCRIPTION
### Description of the Change

Changed neo-one-client-switch/src/node to mirror ../src/browser due to issue with source map initialization when running tests with Jest.

### Test Plan
Followed the installation steps in neo-one's tutorial to set up the environment and get the required packages to develop and test smart contract. Errors were thrown when running smart contract tests as shown below:
![Screen Shot 2021-02-11 at 3 02 57 PM](https://user-images.githubusercontent.com/30916803/107709580-45ee7f00-6c7a-11eb-8ae8-c68244615f09.png)

Console traced down Jest uses cjs/node.

I made changes to the compiled js in cjs/node folder to mirror that of cjs/browser and smart contract tests passed normally.

### Alternate Designs

None.

### Benefits

Eliminate issues that developers might run into when testing smart contracts locally.

### Possible Drawbacks

N/A

### Applicable Issues

N/A