### PR TITLE
fix: client-switch source map initialization issue with Jest

### DIFF
--- a/packages/neo-one-client-switch/src/node/createConsoleLogMessages.ts
+++ b/packages/neo-one-client-switch/src/node/createConsoleLogMessages.ts
@@ -1,8 +1,16 @@
 import { RawAction } from '@neo-one/client-common';
 import { createConsoleLogMessages as createConsoleLogMessagesBase, LogOptions, SourceMaps } from '../common';
+import { initializeSourceMap } from './initializeSourceMap';
 
 export const createConsoleLogMessages = async (
   actions: readonly RawAction[],
   sourceMaps: SourceMaps,
   options: LogOptions,
-): Promise<readonly string[]> => createConsoleLogMessagesBase(actions, sourceMaps, options);
+): Promise<readonly string[]> => {
+  if (process.env.NODE_ENV === 'production' && process.env.NEO_ONE_DEV !== 'true') {
+    return [];
+  }
+  initializeSourceMap();
+
+  return createConsoleLogMessagesBase(actions, sourceMaps, options);
+};

--- a/packages/neo-one-client-switch/src/node/initializeSourceMap.ts
+++ b/packages/neo-one-client-switch/src/node/initializeSourceMap.ts
@@ -1,3 +1,13 @@
+import { SourceMapConsumer } from 'source-map';
+
+// tslint:disable-next-line no-let
+let initialized = false;
 export const initializeSourceMap = () => {
-  // do nothing in node.js
+  if (!initialized) {
+    initialized = true;
+    // tslint:disable-next-line no-any
+    (SourceMapConsumer as any).initialize({
+      'lib/mappings.wasm': 'https://unpkg.com/source-map@0.7.3/lib/mappings.wasm',
+    });
+  }
 };

--- a/packages/neo-one-client-switch/src/node/processActionsAndMessage.ts
+++ b/packages/neo-one-client-switch/src/node/processActionsAndMessage.ts
@@ -1,4 +1,12 @@
 import { processActionsAndMessage as processActionsAndMessageBase, ProcessActionsAndMessageOptions } from '../common';
+import { initializeSourceMap } from './initializeSourceMap';
 
-export const processActionsAndMessage = async (options: ProcessActionsAndMessageOptions): Promise<string> =>
-  processActionsAndMessageBase(options);
+export const processActionsAndMessage = async (options: ProcessActionsAndMessageOptions): Promise<string> => {
+  if (process.env.NODE_ENV === 'production' && process.env.NEO_ONE_DEV !== 'true') {
+    return options.message;
+  }
+
+  initializeSourceMap();
+
+  return processActionsAndMessageBase(options);
+};

--- a/packages/neo-one-client-switch/src/node/processConsoleLogMessages.ts
+++ b/packages/neo-one-client-switch/src/node/processConsoleLogMessages.ts
@@ -1,7 +1,9 @@
 import { processConsoleLogMessages as processConsoleLogMessagesBase, ProcessConsoleLogOptions } from '../common';
+import { initializeSourceMap } from './initializeSourceMap';
 
 export const processConsoleLogMessages = async (options: ProcessConsoleLogOptions): Promise<void> => {
   if (process.env.NODE_ENV !== 'production' || process.env.NEO_ONE_DEV === 'true') {
+    initializeSourceMap();
     await processConsoleLogMessagesBase(options);
   }
 };


### PR DESCRIPTION
### Description of the Change
Changed neo-one-client-switch/src/node to mirror ../src/browser due to issue with source map initialization when running tests with Jest.

### Test Plan

Followed the installation steps in neo-one's tutorial to set up the environment and get the required packages to develop and test smart contract. Errors were thrown when running smart contract tests as shown below:

![Screen Shot 2021-02-11 at 3 02 57 PM](https://user-images.githubusercontent.com/30916803/107714424-19d6fc00-6c82-11eb-8937-46eb9af282b2.png)

Console traced down Jest uses cjs/node.

I made changes to the compiled js in cjs/node folder to mirror that of cjs/browser and smart contract tests passed normally.

### Alternate Designs

None

### Benefits

Eliminate issues that developers might run into when testing smart contracts locally.

### Possible Drawbacks

N/A

### Applicable Issues

N/A
