### PR TITLE
fix(revert): revert breaking VM changes. move to dev branch

### DIFF
--- a/packages/neo-one-node-vm/src/opcodes.ts
+++ b/packages/neo-one-node-vm/src/opcodes.ts
@@ -21,14 +21,10 @@ import {
   InsufficientReturnValueError,
   InvalidCheckMultisigArgumentsError,
   InvalidHasKeyIndexError,
-  InvalidHasKeyKeyTypeError,
   InvalidPackCountError,
   InvalidPickItemKeyError,
-  InvalidPickItemKeyTypeError,
   InvalidRemoveIndexError,
-  InvalidRemoveKeyTypeError,
   InvalidSetItemIndexError,
-  InvalidSetItemKeyTypeError,
   InvalidTailCallReturnValueError,
   ItemTooLargeError,
   LeftNegativeError,
@@ -1723,9 +1719,6 @@ const OPCODE_PAIRS = ([
         out: 1,
         invoke: ({ context, args }) => {
           const key = args[0];
-          if (key.isICollection) {
-            throw new InvalidPickItemKeyTypeError(context);
-          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();
@@ -1763,9 +1756,6 @@ const OPCODE_PAIRS = ([
         invoke: ({ context, args }) => {
           let newItem = args[0];
           const key = args[1];
-          if (key.isICollection) {
-            throw new InvalidSetItemKeyTypeError(context);
-          }
           if (newItem instanceof StructStackItem) {
             newItem = newItem.clone();
           }
@@ -1872,9 +1862,6 @@ const OPCODE_PAIRS = ([
         in: 2,
         invoke: ({ context, args }) => {
           const key = args[0];
-          if (key.isICollection) {
-            throw new InvalidRemoveKeyTypeError(context);
-          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const mutableValue = args[1].asArray();
@@ -1923,9 +1910,6 @@ const OPCODE_PAIRS = ([
         out: 1,
         invoke: ({ context, args }) => {
           const key = args[0];
-          if (key.isICollection) {
-            throw new InvalidHasKeyKeyTypeError(context);
-          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();

--- a/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
@@ -4,7 +4,6 @@ import { StackItemType } from './StackItemType';
 
 export class ArrayStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Array;
-  public readonly isICollection = true;
   private readonly referenceID = getNextID();
 
   public toStructuralKey(): string {

--- a/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
@@ -11,7 +11,6 @@ import { StackItemBase } from './StackItemBase';
 import { StackItemType } from './StackItemType';
 
 export class MapStackItem extends StackItemBase {
-  public readonly isICollection = true;
   private readonly referenceKeys: Map<string, StackItem>;
   private readonly referenceValues: Map<string, StackItem>;
   private readonly referenceID = getNextID();

--- a/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
@@ -57,7 +57,6 @@ export interface AsStorageContextStackItemOptions {
 }
 
 export class StackItemBase implements Equatable {
-  public readonly isICollection: boolean = false;
   private mutableCount = 0;
 
   public get referenceCount(): number {

--- a/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
@@ -4,7 +4,6 @@ import { StackItemType } from './StackItemType';
 
 export class StructStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Struct;
-  public readonly isICollection = true;
 
   public clone(): StructStackItem {
     return new StructStackItem(this.value.map((value) => (value instanceof StructStackItem ? value.clone() : value)));


### PR DESCRIPTION
### Description of the Change

Revert the changes made to the VM in #2293. That PR was made to try to fix some VM inconsistencies between NEO•ONE's v2 node and the official Neo node. But after recent review it seems that the better path is to keep our master-2.x branch "clean" in the sense that we don't want to put any breaking changes on that branch until ALL the inconsistencies are fixed. That way we can easily publish non-breaking versions of NEO•ONE for 2.x with updates, bug fixes, etc. while not breaking our node.

When we have time we can make all the necessary updates to the 2.x branch with all the node updates and thus all the breaking changes at once. Then we can reassure ourselves and our users the NEO•ONE 2.x works with Neo2.

I'll move these changes to a new PR to a new 2.x dev branch called `master-2.x-update`

### Test Plan

None.

### Alternate Designs

None.

### Benefits

See description.

### Possible Drawbacks

None.

### Applicable Issues

None.
