### PR TITLE
fix(vm): keys must be primitive stack items

### DIFF
--- a/packages/neo-one-node-vm/src/opcodes.ts
+++ b/packages/neo-one-node-vm/src/opcodes.ts
@@ -21,10 +21,14 @@ import {
   InsufficientReturnValueError,
   InvalidCheckMultisigArgumentsError,
   InvalidHasKeyIndexError,
+  InvalidHasKeyKeyTypeError,
   InvalidPackCountError,
   InvalidPickItemKeyError,
+  InvalidPickItemKeyTypeError,
   InvalidRemoveIndexError,
+  InvalidRemoveKeyTypeError,
   InvalidSetItemIndexError,
+  InvalidSetItemKeyTypeError,
   InvalidTailCallReturnValueError,
   ItemTooLargeError,
   LeftNegativeError,
@@ -1719,6 +1723,9 @@ const OPCODE_PAIRS = ([
         out: 1,
         invoke: ({ context, args }) => {
           const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidPickItemKeyTypeError(context);
+          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();
@@ -1756,6 +1763,9 @@ const OPCODE_PAIRS = ([
         invoke: ({ context, args }) => {
           let newItem = args[0];
           const key = args[1];
+          if (key.isICollection) {
+            throw new InvalidSetItemKeyTypeError(context);
+          }
           if (newItem instanceof StructStackItem) {
             newItem = newItem.clone();
           }
@@ -1862,6 +1872,9 @@ const OPCODE_PAIRS = ([
         in: 2,
         invoke: ({ context, args }) => {
           const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidRemoveKeyTypeError(context);
+          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const mutableValue = args[1].asArray();
@@ -1910,6 +1923,9 @@ const OPCODE_PAIRS = ([
         out: 1,
         invoke: ({ context, args }) => {
           const key = args[0];
+          if (key.isICollection) {
+            throw new InvalidHasKeyKeyTypeError(context);
+          }
           if (args[1].isArray()) {
             const index = vmUtils.toNumber(context, key.asBigIntegerUnsafe());
             const val = args[1].asArray();

--- a/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/ArrayStackItem.ts
@@ -4,6 +4,7 @@ import { StackItemType } from './StackItemType';
 
 export class ArrayStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Array;
+  public readonly isICollection = true;
   private readonly referenceID = getNextID();
 
   public toStructuralKey(): string {

--- a/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/MapStackItem.ts
@@ -11,6 +11,7 @@ import { StackItemBase } from './StackItemBase';
 import { StackItemType } from './StackItemType';
 
 export class MapStackItem extends StackItemBase {
+  public readonly isICollection = true;
   private readonly referenceKeys: Map<string, StackItem>;
   private readonly referenceValues: Map<string, StackItem>;
   private readonly referenceID = getNextID();

--- a/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StackItemBase.ts
@@ -57,6 +57,7 @@ export interface AsStorageContextStackItemOptions {
 }
 
 export class StackItemBase implements Equatable {
+  public readonly isICollection: boolean = false;
   private mutableCount = 0;
 
   public get referenceCount(): number {

--- a/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
+++ b/packages/neo-one-node-vm/src/stackItem/StructStackItem.ts
@@ -4,6 +4,7 @@ import { StackItemType } from './StackItemType';
 
 export class StructStackItem extends ArrayLikeStackItem {
   public static readonly type = StackItemType.Struct;
+  public readonly isICollection = true;
 
   public clone(): StructStackItem {
     return new StructStackItem(this.value.map((value) => (value instanceof StructStackItem ? value.clone() : value)));


### PR DESCRIPTION
### Description of the Change

Updates constraint that keys must be primitive stack item types in maps/structs in the VM. See here for when that was implemented in the NeoVM: https://github.com/neo-project/neo-vm/pull/28.

Originally implemented in #2293 and then revert from #2320. Never deployed to production nodes or published to NPM on master-2.x branch.

### Test Plan

Tested originally in #2293.

### Alternate Designs

None. Should have caught this earlier.

### Benefits

Works on updating our master-2.x branch to be more compatible with Neo2.

### Possible Drawbacks

None.

### Applicable Issues

None.