### PR TITLE
feat(cli): add cli configpath option and do cli cleanup

### DIFF
--- a/common/changes/@neo-one/cli-common-node/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/cli-common-node/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli-common-node",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/cli-common-node",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/cli-common/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/cli-common/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli-common",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/cli-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/cli/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/cli/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/cli",
+      "comment": "Add generate command, make more user friendly.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@neo-one/cli",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-common/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-common/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-common",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-core/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-core/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-core",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-full-common/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-full-common/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-full-common",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-full-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-full-core/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-full-core/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-full-core",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-full-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-full/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-full/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-full",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-full",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client-switch/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client-switch/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-switch",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-switch",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/client/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/client/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/developer-tools/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/developer-tools/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/developer-tools",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/developer-tools",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-bin/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-bin/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-bin",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-bin",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-blockchain/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-blockchain/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-blockchain",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-blockchain",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-consensus/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-consensus/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-consensus",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-consensus",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-core/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-core/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-core",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-core",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-neo-settings/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-neo-settings/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-neo-settings",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-neo-settings",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-protocol/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-protocol/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-protocol",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-protocol",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-rpc-handler/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-rpc-handler/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-rpc-handler",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-rpc-handler",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-storage-cache/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-storage-cache/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-storage-cache",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-storage-cache",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-storage-common/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-storage-common/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-storage-common",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-storage-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node-storage-levelup/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-storage-levelup/cli_2021-02-17-22-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@neo-one/node-storage-levelup",
-      "comment": "Pin level-js and levelup deps.",
+      "comment": "Fix minor bugs.",
       "type": "patch"
     }
   ],

--- a/common/changes/@neo-one/node-vm/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/node-vm/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/node-vm",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/node-vm",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/node/fix-web_2020-07-27-19-51.json
+++ b/common/changes/@neo-one/node/fix-web_2020-07-27-19-51.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@neo-one/node",
       "comment": "Pin level-js and levelup deps.",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@neo-one/node",

--- a/common/changes/@neo-one/smart-contract-codegen/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/smart-contract-codegen/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-codegen",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-codegen",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-compiler/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/smart-contract-compiler/cli_2021-02-17-22-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@neo-one/smart-contract-compiler",
-      "comment": "Pin level-js and levelup deps.",
+      "comment": "Fix minor bugs.",
       "type": "patch"
     }
   ],

--- a/common/changes/@neo-one/smart-contract-lib/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/smart-contract-lib/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-lib",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-lib",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-test-common/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/smart-contract-test-common/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-test-common",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-test-common",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/smart-contract-test/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/smart-contract-test/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/smart-contract-test",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/smart-contract-test",
+  "email": "spencercorwin@icloud.com"
+}

--- a/common/changes/@neo-one/suite/cli_2021-02-17-22-52.json
+++ b/common/changes/@neo-one/suite/cli_2021-02-17-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/suite",
+      "comment": "Fix minor bugs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/suite",
+  "email": "spencercorwin@icloud.com"
+}

--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -190,13 +190,13 @@ ${exportConfig} {
     // NEO•ONE will look for smart contracts in this directory.
     path: '${config.contracts.path}',
     // Set this to true if you want the compile command to output JSON.
-    // json: ${true},
+    json: ${true},
     // Set this to true if you want the compile command to output AVM.
-    // avm: ${false},
+    avm: ${false},
     // Set this to true if you want the compile command to output additional debug information.
-    // debug: ${false},
+    debug: ${false},
     // Set this to true if you want the compile command to output the AVM in a human-readable format for debugging (requires debug: true).
-    // opcodes: ${false},
+    opcodes: ${false},
   },
   artifacts: {
     // NEO•ONE will store build and deployment artifacts that should be checked in to vcs in this directory.
@@ -338,7 +338,19 @@ const validateConfig = async (rootDir: string, configIn: any): Promise<Configura
 // tslint:disable-next-line no-let
 let cachedConfig: Configuration | undefined;
 
-export const loadConfiguration = async (): Promise<Configuration> => {
+export const loadConfiguration = async (optionalConfigPath?: string): Promise<Configuration> => {
+  if (cachedConfig === undefined && optionalConfigPath !== undefined) {
+    register({
+      compilerOptions: {
+        module: 'commonjs',
+        allowJs: true,
+      },
+    });
+    const obj = await import(optionalConfigPath);
+    const output = obj.default === undefined ? obj : obj.default;
+
+    cachedConfig = await validateConfig(nodePath.dirname(optionalConfigPath), output === null ? {} : output);
+  }
   if (cachedConfig === undefined) {
     const explorer = cosmiconfig('neo-one', {
       loaders: {

--- a/packages/neo-one-cli/src/cmd/build.ts
+++ b/packages/neo-one-cli/src/cmd/build.ts
@@ -6,9 +6,14 @@ import { start } from '../common';
 export const command = 'build';
 export const describe = 'Builds the project and deploys it to the local development network.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder.boolean('reset').describe('reset', 'Reset the local project.').default('reset', false);
+  yargsBuilder
+    .boolean('reset')
+    .describe('reset', 'Reset the local project.')
+    .default('reset', false)
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
     await createTasks(cmd, config, argv.reset).run();
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/compile.ts
+++ b/packages/neo-one-cli/src/cmd/compile.ts
@@ -18,21 +18,25 @@ export const builder = (yargsBuilder: typeof yargs) =>
     .boolean('debug')
     .describe('debug', 'Output additional debug information.')
     .boolean('opcodes')
-    .describe('opcodes', 'Output the AVM in a human readable format for debugging (requires --debug).');
+    .describe('opcodes', 'Output the AVM in a human readable format for debugging (requires --debug).')
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
 
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const configOptions = config.contracts;
     const path = argv.path ? argv.path : configOptions.path;
     const outDir = argv.outDir ? argv.outDir : configOptions.outDir;
+    const opcodes = argv.opcodes ? argv.opcodes : configOptions.opcodes;
+    const debugIn = argv.debug ? argv.debug : configOptions.debug;
     const options = {
       json: argv.json ? argv.json : configOptions.json,
       avm: argv.avm ? argv.avm : configOptions.avm,
-      debug: argv.debug ? argv.debug : configOptions.debug,
-      opcodes: argv.opcodes ? argv.opcodes : configOptions.opcodes,
+      debug: opcodes || debugIn,
+      opcodes,
     };
     if (options.opcodes && !options.debug) {
-      throw new Error('`opcodes` flag may only be specified alongside the `debug` flag');
+      throw new Error('`opcodes` flag may only be specified alongside the `debug` flag.');
     }
     await createTasks(path, outDir, {
       json: options.json ? options.json : !options.avm,
@@ -40,5 +44,5 @@ export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
       debug: options.debug ? options.debug : false,
       opcodes: options.opcodes ? options.opcodes : false,
     }).run();
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/console.ts
+++ b/packages/neo-one-cli/src/cmd/console.ts
@@ -11,7 +11,9 @@ export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder
     .array('networks')
     .describe('networks', 'Networks to initialize before starting the REPL.')
-    .default('networks', defaultNetworks);
+    .default('networks', defaultNetworks)
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
-  start(async (_cmd, config) => startConsole(config, argv.networks));
+  start(async (_cmd, config) => startConsole(config, argv.networks), argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/deploy.ts
+++ b/packages/neo-one-cli/src/cmd/deploy.ts
@@ -6,9 +6,14 @@ import { deploy } from '../deploy';
 export const command = 'deploy';
 export const describe = 'Deploys the project using the migration file.';
 export const builder = (yargsBuilder: typeof yargs) =>
-  yargsBuilder.string('network').describe('network', 'Network to run the migration on.').default('network', 'test');
+  yargsBuilder
+    .string('network')
+    .describe('network', 'Network to run the migration on.')
+    .default('network', 'test')
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (cmd, config) => {
     await deploy(cmd, config, argv.network);
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/generate.ts
+++ b/packages/neo-one-cli/src/cmd/generate.ts
@@ -1,0 +1,16 @@
+import { Yarguments } from '@neo-one/utils-node';
+import yargs from 'yargs';
+import { start } from '../common';
+import { createTasks } from '../generate';
+
+export const command = 'generate';
+export const describe = 'Compiles the contracts and generates common code.';
+export const builder = (yargsBuilder: typeof yargs) =>
+  yargsBuilder
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in root of project directory.');
+export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
+  start(async (cmd, config) => {
+    await createTasks(cmd, config).run();
+  }, argv.configPath);
+};

--- a/packages/neo-one-cli/src/cmd/index.ts
+++ b/packages/neo-one-cli/src/cmd/index.ts
@@ -4,6 +4,7 @@ import * as compile from './compile';
 import * as consoleCmd from './console';
 import * as convert from './convert';
 import * as deploy from './deploy';
+import * as generate from './generate';
 import * as info from './info';
 import * as init from './init';
 import * as newCmd from './new';
@@ -23,4 +24,5 @@ export const builder = (yargsBuilder: typeof yargs) =>
     .command(deploy)
     .command(info)
     .command(compile)
-    .command(init);
+    .command(init)
+    .command(generate);

--- a/packages/neo-one-cli/src/cmd/info.ts
+++ b/packages/neo-one-cli/src/cmd/info.ts
@@ -1,13 +1,17 @@
 import { configToSerializable } from '@neo-one/cli-common-node';
+import { Yarguments } from '@neo-one/utils-node';
 import yargs from 'yargs';
 import { start } from '../common';
 
 export const command = 'info';
 export const describe = 'Prints project configuration.';
-export const builder = (yargsBuilder: typeof yargs) => yargsBuilder;
-export const handler = () => {
+export const builder = (yargsBuilder: typeof yargs) =>
+  yargsBuilder
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
+export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     // tslint:disable-next-line no-console
     console.log(JSON.stringify(configToSerializable(config), undefined, 2));
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/cmd/init.ts
+++ b/packages/neo-one-cli/src/cmd/init.ts
@@ -36,7 +36,14 @@ export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder
     .boolean('react')
     .describe('react', 'Generate an example react component that uses the HelloWorld smart contract.')
-    .default('react', false);
+    .default('react', false)
+    .boolean('typescript')
+    .describe(
+      'typescript',
+      'Initialize a NEO•ONE project with TypeScript. If no tsconfig is found a default one will be generated.',
+    )
+    .string('configPath')
+    .describe('configPath', 'Optional path to the config file if not in the root of project directory.');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
     const tsconfigPath = nodePath.resolve(config.contracts.path, 'tsconfig.json');
@@ -155,8 +162,38 @@ export const ExampleHelloWorld = () => {
       argv.react ? writeFile(reactPath, reactContents) : Promise.resolve(),
     ]);
 
-    if (rootTSConfigContents) {
-      const rootTSConfig = JSON.parse(rootTSConfigContents);
+    if (rootTSConfigContents !== undefined || argv.typescript) {
+      // This acts as a default if there's an unparsable tsconfig present. This is taken from create-react-app tsconfig
+      let rootTSConfig = {
+        compilerOptions: {
+          target: 'es5',
+          lib: ['dom', 'dom.iterable', 'esnext'],
+          allowJs: true,
+          skipLibCheck: true,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          strict: true,
+          forceConsistentCasingInFileNames: true,
+          module: 'esnext',
+          moduleResolution: 'node',
+          resolveJsonModule: true,
+          isolatedModules: true,
+          noEmit: true,
+          jsx: 'react-jsx',
+        },
+        // tslint:disable-next-line: no-any
+      } as any;
+
+      if (rootTSConfigContents !== undefined) {
+        try {
+          rootTSConfig = JSON.parse(rootTSConfigContents);
+        } catch (e) {
+          console.log(
+            `Problem parsing the root tsconfig found at ${rootTSConfigPath}. Creating a default tsconfig. Make sure your tsconfig is JSON and try again. Parse error: ${e.message}`,
+          );
+        }
+      }
+
       const exclude = rootTSConfig.exclude === undefined ? [] : rootTSConfig.exclude;
       const excludePath = normalizePath(nodePath.relative(process.cwd(), nodePath.join(config.contracts.path, '*.ts')));
       if (!new Set(exclude).has(excludePath)) {
@@ -184,5 +221,5 @@ export const ExampleHelloWorld = () => {
     console.log(
       'NEO•ONE initialized, run `neo-one build` to deploy the HelloWorld smart contract to a local development network.',
     );
-  });
+  }, argv.configPath);
 };

--- a/packages/neo-one-cli/src/common/start.ts
+++ b/packages/neo-one-cli/src/common/start.ts
@@ -9,12 +9,12 @@ type StartFunc = (cmd: Command, config: Configuration) => Promise<StartReturn | 
 
 const startInternal = createStart(cliLogger);
 
-export const start = (startFunc: StartFunc) => {
+export const start = (startFunc: StartFunc, optionalConfigPath?: string) => {
   // tslint:disable-next-line no-object-mutation
   cliLogger.level = 'info';
 
   startInternal(async () => {
-    const config = await loadConfiguration();
+    const config = await loadConfiguration(optionalConfigPath);
 
     const cmd = {
       bin: process.argv[0],

--- a/packages/neo-one-cli/src/compile/createTasks.ts
+++ b/packages/neo-one-cli/src/compile/createTasks.ts
@@ -8,7 +8,7 @@ import { CompileWriteOptions, writeContract } from './writeContract';
 export const createTasks = (path: string, outDir: string, options: CompileWriteOptions) =>
   new Listr([
     {
-      title: 'Find Contracts',
+      title: 'Find contracts',
       task: async (ctx) => {
         const contracts = await findContracts(path);
 
@@ -16,7 +16,7 @@ export const createTasks = (path: string, outDir: string, options: CompileWriteO
       },
     },
     {
-      title: 'Compile Contracts',
+      title: 'Compile contracts',
       task: (ctx) => {
         ctx.linked = {};
         ctx.sourceMaps = {};

--- a/packages/neo-one-cli/src/generate/createTasks.ts
+++ b/packages/neo-one-cli/src/generate/createTasks.ts
@@ -1,0 +1,87 @@
+// tslint:disable no-object-mutation
+import { Configuration } from '@neo-one/cli-common';
+import { scriptHashToAddress } from '@neo-one/client';
+import { common, crypto } from '@neo-one/client-common';
+import { Contracts } from '@neo-one/smart-contract-compiler';
+import Listr from 'listr';
+import _ from 'lodash';
+import { Command } from '../types';
+import { findContracts } from './../build/findContracts';
+import { generateCode } from './../build/generateCode';
+import { generateCommonCode } from './../build/generateCommonCode';
+import { compileContract } from './../compile/compileContract';
+
+export const createTasks = (_cmd: Command, config: Configuration) =>
+  new Listr([
+    {
+      title: 'Find contracts',
+      task: async (ctx) => {
+        const contracts = await findContracts(config);
+        ctx.foundContracts = contracts;
+      },
+    },
+    {
+      title: 'Compile contracts',
+      task: (ctx) => {
+        ctx.linked = {};
+        ctx.sourceMaps = {};
+        ctx.contracts = [];
+
+        return new Listr(
+          (ctx.foundContracts as Contracts).map((contract) => ({
+            title: `Compile ${contract.name}`,
+            task: async (innerCtx) => {
+              const {
+                linked,
+                sourceMaps,
+                contract: { abi, contract: contractCompiled },
+                sourceMap,
+              } = await compileContract(contract.filePath, contract.name, innerCtx.linked, innerCtx.sourceMaps);
+              innerCtx.linked = linked;
+              innerCtx.sourceMaps = sourceMaps;
+              innerCtx.contracts.push({
+                name: contract.name,
+                filePath: contract.filePath,
+                sourceMap,
+              });
+
+              const address = scriptHashToAddress(
+                common.uInt160ToString(crypto.toScriptHash(Buffer.from(contractCompiled.script, 'hex'))),
+              );
+
+              const networksDefinition = {};
+
+              await generateCode(
+                config,
+                contract.filePath,
+                contract.name,
+                abi,
+                _.merge(
+                  {},
+                  {
+                    local: {
+                      address,
+                    },
+                  },
+                  networksDefinition,
+                ),
+              );
+            },
+          })),
+        );
+      },
+    },
+    {
+      title: 'Generate common code',
+      task: async (ctx) => {
+        const networks = [
+          {
+            name: 'local',
+            rpcURL: `http://localhost:${config.network.port}/rpc`,
+            dev: true,
+          },
+        ];
+        await generateCommonCode(config, ctx.contracts, networks, ctx.sourceMaps);
+      },
+    },
+  ]);

--- a/packages/neo-one-cli/src/generate/index.ts
+++ b/packages/neo-one-cli/src/generate/index.ts
@@ -1,0 +1,1 @@
+export * from './createTasks';


### PR DESCRIPTION
### Description of the Change

This does multiple things to improve the CLI user experience.

1. Adds new `generate` command that will do some parts of the `build` command. It won't start a local development network but it will compile the contracts and generate the common code to integrate with dApps. This also provides another option for building the project without starting a dev network unnecessarily.
2. Adds an optional CLI argument to every command: `--configPath` which will override the search for a neo-one config file in the local directory and instead find it by the provided path. This is primarily for internal use as it makes it easier for us to test the CLI in a demo repo without having to publish to NPM.
3. It also does a little bit of cleanup here and there and remove one possible error case in the CLI and instead just infers a better default instead of throwing an error and making the user handle it.

### Test Plan

Tested locally manually.

### Alternate Designs

None.

### Benefits

Easier test, better UX.

### Possible Drawbacks

None.

### Applicable Issues

None.
