### PR TITLE
fix(compiler, doc): mixin syntax fix and template doc.

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/utils/throwOnDiagnosticErrorOrWarning.ts
+++ b/packages/neo-one-smart-contract-compiler/src/utils/throwOnDiagnosticErrorOrWarning.ts
@@ -5,7 +5,7 @@ import { getDiagnosticMessage } from './getDiagnosticMessage';
 export function throwOnDiagnosticErrorOrWarning(
   diagnostics: ReadonlyArray<ts.Diagnostic>,
   ignoreWarnings = false,
-  message: string = '',
+  message = '',
 ) {
   const errors = diagnostics.filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
   const warnings = diagnostics.filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Warning);
@@ -19,7 +19,9 @@ export function throwOnDiagnosticErrorOrWarning(
       : warnings.map((warning) => `Compilation warning: ${getDiagnosticMessage(warning)}`).join('\n');
   if (errorMessage !== undefined) {
     const error = new Error(`${errorMessage}${warningMessage === undefined ? '' : warningMessage}`);
+    // tslint:disable-next-line: no-object-mutation
     error.message = message;
+    // tslint:disable-next-line: no-object-mutation
     error.stack = errorMessage;
     throw error;
   }

--- a/packages/neo-one-ts-utils/src/class_.ts
+++ b/packages/neo-one-ts-utils/src/class_.ts
@@ -272,9 +272,10 @@ function getImplementorsWorker(
         return acc;
       }
 
-      let derived: ts.ClassDeclaration | ts.InterfaceDeclaration | undefined = node_.getFirstAncestorByKind<
-        ts.ClassDeclaration
-      >(clause, ts.SyntaxKind.ClassDeclaration);
+      let derived:
+        | ts.ClassDeclaration
+        | ts.InterfaceDeclaration
+        | undefined = node_.getFirstAncestorByKind<ts.ClassDeclaration>(clause, ts.SyntaxKind.ClassDeclaration);
       if (derived === undefined) {
         derived = node_.getFirstAncestorByKindOrThrow<ts.InterfaceDeclaration>(
           clause,
@@ -314,7 +315,13 @@ function getExtendorsWorker(
       }
 
       const clause = node_.getParent(parent) as ts.Node | undefined;
-      if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
+      // if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
+      //   return acc;
+      // }
+
+      if (clause && ts.isExpressionWithTypeArguments(clause)) {
+        // do nothing and continue.
+      } else if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
         return acc;
       }
 

--- a/packages/neo-one-ts-utils/src/class_.ts
+++ b/packages/neo-one-ts-utils/src/class_.ts
@@ -315,13 +315,11 @@ function getExtendorsWorker(
       }
 
       const clause = node_.getParent(parent) as ts.Node | undefined;
-      // if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
-      //   return acc;
-      // }
 
-      if (clause && ts.isExpressionWithTypeArguments(clause)) {
-        // do nothing and continue.
-      } else if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
+      if (
+        (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) &&
+        !(clause && ts.isExpressionWithTypeArguments(clause))
+      ) {
         return acc;
       }
 

--- a/packages/neo-one-website/docs/0-installation/5-contract-mixins.md
+++ b/packages/neo-one-website/docs/0-installation/5-contract-mixins.md
@@ -1,0 +1,141 @@
+---
+slug: contract-mixins
+title: Contract Mixins
+---
+
+NEO•ONE provides mixins for common smart contract patterns.
+
+This guide will walk you through how to use a mixin.
+
+---
+
+[[toc]]
+
+---
+
+## Requirements
+
+Install the following packages if you have not done so:
+
+```zsh
+yarn add @neo-one/client @neo-one/cli @neo-one/smart-contract @neo-one/smart-contract-test @neo-one/smart-contract-lib @neo-one/smart-contract-typescript-plugin
+```
+
+```zsh
+npm add @neo-one/client @neo-one/cli @neo-one/smart-contract @neo-one/smart-contract-test @neo-one/smart-contract-lib @neo-one/smart-contract-typescript-plugin
+```
+
+::: warning
+
+Important
+
+The package `@neo-one/smart-contract-lib` contains the mixins and is important to this guide.
+
+:::
+
+---
+
+## What Is A Mixin?
+
+A mixin is a class (abstract or non-abstract) in which some or all of its methods and/or properties are unimplemented.
+
+We use mixin as a way to insert common properties and methods (sometimes required such as in the case of meeting a token standard) into your contract.
+
+::: warning
+
+Tip
+
+You can think of our mixins as a template or a base where you can build your contracts on.
+
+:::
+
+---
+
+## Usage
+
+```typescript
+import { SmartContract } from '@neo-one/smart-contract';
+// import template of your choice from @neo-one/smart-contract-lib
+import { NEP5Token } from '@neo-one/smart-contract-lib';
+
+// Mixins
+export class YourContract extends NEP5Token(SmartContract) {
+  // 'SmartContract' here can be any other contract (abstract & non-abstract class) that extends SmartContract class
+  // 'YourContract' inherits the methods and properties defined in NEP5TokenClass returned by NEP5Token
+  // ... your smart contract code.
+}
+```
+
+If you find the syntax `NEP5Token(SmartContract)` strange, checkout this page on [Mixins](https://www.typescriptlang.org/docs/handbook/mixins.html) from the TypeScript Handbook for more details.
+
+::: warning
+
+Tip
+
+We encourage you to look at the NEP5Token mixin to understand how we are implementing a NEP5 token. Go [here](https://github.com/neo-one-suite/neo-one/blob/master-2.x/packages/neo-one-smart-contract-lib/src/NEP5Token.ts) to see the source code for the NEP5Token mixin
+
+:::
+
+---
+
+## Example
+
+The following example set uses a mixin to design a new token that follows the NEP5 token standard.
+
+::: warning
+
+Note
+
+A token standard simply defines a set of methods and properties that must exist in the token.
+
+:::
+
+`SimpleToken.ts`
+
+SimpleToken is injected with `NEP5Token`'s methods and properties.
+
+```typescript
+import { Address, Fixed, SmartContract } from '@neo-one/smart-contract';
+import { NEP5Token } from '@neo-one/smart-contract-lib';
+
+export abstract class SimpleToken extends NEP5Token(SmartContract) {
+  public readonly owner: Address;
+  public readonly decimals: 8 = 8;
+
+  public constructor(owner: Address, amount: Fixed<8>) {
+    super();
+    if (!Address.isCaller(owner)) {
+      throw new Error('Sender was not the owner.');
+    }
+    this.owner = owner;
+    this.issue(owner, amount);
+  }
+}
+```
+
+`Redtoken.ts`
+
+`RedToken` inherits methods and properties that adheres to the NEP5 token standard because of the mixin. It also inherits everything defined in `SimpleToken`.
+
+```typescript
+import { Address, Deploy, Fixed } from '@neo-one/smart-contract';
+import { SimpleToken } from './SimpleToken';
+
+export class RedToken extends SimpleToken {
+  public readonly name: string = 'RedToken';
+  public readonly symbol: string = 'RT';
+
+  public constructor(owner: Address = Deploy.senderAddress, amount: Fixed<8> = 1_000_000_00000000) {
+    super(owner, amount);
+  }
+}
+```
+
+---
+
+## Available Templates
+
+- [NEP5Token](https://github.com/neo-one-suite/neo-one/blob/master-2.x/packages/neo-one-smart-contract-lib/src/NEP5Token.ts) - [NEP5 Token Standard](https://docs.neo.org/tutorial/en-us/9-smartContract/What_is_nep5.html)
+- [ICO](https://github.com/neo-one-suite/neo-one/blob/master-2.x/packages/neo-one-smart-contract-lib/src/ICO.ts) - Initial Coin Offering.
+- Ownership/[Ownable](https://github.com/neo-one-suite/neo-one/blob/master-2.x/packages/neo-one-smart-contract-lib/src/ownership/Ownable.ts) - This mixin provides a means to assign an address as the owner of a contract. Extending this class and adding `this.ownerOnly()`; to the beginning of all public functions will throw an error anytime an address other than the primary makes requests.
+- Ownership/[Secondary](https://github.com/neo-one-suite/neo-one/blob/master-2.x/packages/neo-one-smart-contract-lib/src/ownership/Secondary.ts) - This mixin provides a means to mark an address as the primary caller of this contract. Extending this class and adding `this.primaryOnly()`; to the beginning of all public functions will throw an error anytime an address other than the primary makes requests.


### PR DESCRIPTION
### Requirements

Template support.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

ts compiler ignored contracts that use mixins syntax.
```typescript
// ...imports

export class TestToken extends NEP5Token(SmartContract){
// ...
}
```

The issue came from the following code block: 

```typescript
if (clause === undefined || !ts.isHeritageClause(clause) || !heritage.isExtends(clause)) {
  return acc;
}
```
The `NEP5Token(SmartContract)` is neither a HeritageClause nor an Extends clause. So a separate `if` seems necessary for the specific case of mixins.

### Test Plan

1. symlink `neo-one-ts-utils`
2. use mixins syntax like above
3. run compile or build to see results

### Alternate Designs

N/A

### Benefits

Able to compile contracts with mixins.

### Possible Drawbacks

Might affect other syntaxes.

### Applicable Issues

N/A