### PR TITLE
fix(native): fix native contract ids

### DIFF
--- a/packages/neo-one-build-tests/environments/e2e/jestSetup.js
+++ b/packages/neo-one-build-tests/environments/e2e/jestSetup.js
@@ -15,6 +15,7 @@ global.console = {
   log: jest.fn(),
   error: console.error,
   warn: console.warn,
+  trace: console.trace,
   info: jest.fn(),
   debug: jest.fn(),
 };

--- a/packages/neo-one-build-tests/environments/test/jestSetup.js
+++ b/packages/neo-one-build-tests/environments/test/jestSetup.js
@@ -14,6 +14,8 @@ global.console = {
   // log: jest.fn(),
   error: console.error,
   warn: console.warn,
+  trace: console.trace,
+  debug: jest.fn(),
   info: jest.fn(),
 };
 

--- a/packages/neo-one-node-native/src/ContractManagement.ts
+++ b/packages/neo-one-node-native/src/ContractManagement.ts
@@ -20,6 +20,7 @@ export class ContractManagement extends NativeContract implements ContractManage
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'ContractManagement',
+      id: -1,
       methods: contractManagementMethods,
       settings,
     });

--- a/packages/neo-one-node-native/src/GASToken.ts
+++ b/packages/neo-one-node-native/src/GASToken.ts
@@ -7,6 +7,7 @@ export class GASToken extends FungibleToken implements GASContract {
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'GasToken',
+      id: -4,
       symbol: 'GAS',
       decimals: 8,
       methods: gasTokenMethods,

--- a/packages/neo-one-node-native/src/LedgerContract.ts
+++ b/packages/neo-one-node-native/src/LedgerContract.ts
@@ -26,6 +26,7 @@ export class LedgerContract extends NativeContract implements LedgerContractNode
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'LedgerContract',
+      id: -2,
       methods: ledgerMethods,
       settings,
     });

--- a/packages/neo-one-node-native/src/NEOToken.ts
+++ b/packages/neo-one-node-native/src/NEOToken.ts
@@ -54,6 +54,7 @@ export class NEOToken extends FungibleToken implements NEOContract {
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'NeoToken',
+      id: -3,
       symbol: 'NEO',
       decimals: 0,
       methods: neoTokenMethods,

--- a/packages/neo-one-node-native/src/NameService.ts
+++ b/packages/neo-one-node-native/src/NameService.ts
@@ -28,6 +28,7 @@ export class NameService extends NonfungibleToken implements NameServiceNode {
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'NameService',
+      id: -8,
       symbol: 'NNS',
       methods: nameServiceMethods,
       settings,

--- a/packages/neo-one-node-native/src/NativeContract.ts
+++ b/packages/neo-one-node-native/src/NativeContract.ts
@@ -13,12 +13,10 @@ import { contractMethodFromJSON, ContractMethodJSON } from './methods';
 
 export interface NativeContractAdd {
   readonly name: string;
+  readonly id: number;
   readonly methods: readonly ContractMethodJSON[];
   readonly settings: BlockchainSettings;
 }
-
-// tslint:disable-next-line: no-let
-let mutableIdCounter = 0;
 
 export abstract class NativeContract implements NativeContractNode {
   public get script(): Buffer {
@@ -31,9 +29,9 @@ export abstract class NativeContract implements NativeContractNode {
   public readonly manifest: ContractManifest;
   public readonly activeBlockIndex: number;
 
-  public constructor({ name, methods, settings }: NativeContractAdd) {
+  public constructor({ name, id, methods, settings }: NativeContractAdd) {
     this.name = name;
-    this.id = mutableIdCounter -= 1;
+    this.id = id;
 
     const builder = new ScriptBuilder();
     builder.emitPushInt(this.id);

--- a/packages/neo-one-node-native/src/OracleContract.ts
+++ b/packages/neo-one-node-native/src/OracleContract.ts
@@ -24,6 +24,7 @@ export class OracleContract extends NativeContract implements OracleContractNode
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'OracleContract',
+      id: -7,
       methods: oracleMethods,
       settings,
     });

--- a/packages/neo-one-node-native/src/Policy.ts
+++ b/packages/neo-one-node-native/src/Policy.ts
@@ -23,6 +23,7 @@ export class PolicyContract extends NativeContract implements PolicyContractNode
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'PolicyContract',
+      id: -5,
       methods: policyMethods,
       settings,
     });

--- a/packages/neo-one-node-native/src/RoleManagement.ts
+++ b/packages/neo-one-node-native/src/RoleManagement.ts
@@ -16,6 +16,7 @@ export class RoleManagement extends NativeContract implements RoleManagementNode
   public constructor(settings: BlockchainSettings) {
     super({
       name: 'RoleManagement',
+      id: -6,
       methods: roleManagementMethods,
       settings,
     });

--- a/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
@@ -193,7 +193,7 @@ namespace NEOONE
     private bool _create(TriggerType trigger, IVerifiable container, DataCache snapshot, Block persistingBlock, long gas)
     {
       this.disposeEngine();
-      this.engine = ApplicationEngine.Create(trigger, container, snapshot, persistingBlock, gas); ;
+      this.engine = ApplicationEngine.Create(trigger, container, snapshot, persistingBlock, gas);
 
       return true;
     }


### PR DESCRIPTION
### Description of the Change

Fix how Native contract IDs are set. The mutable counter would keep values in between Jest tests and thus each test would initiate it's own blockchain with a new set of IDs which would end up wrong. Now we just hard-set them.

### Test Plan

Tested locally.

### Alternate Designs

None.

### Benefits

Tests working.

### Possible Drawbacks

None.

### Applicable Issues

None.