### PR TITLE
fix(rc1): minor updates for more rc1 compatibility and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NEO•ONE
 
+This branch is under heavy development during our migration to [N3](https://neo.org/). Please see the [master-2.x](https://github.com/neo-one-suite/neo-one/tree/master-2.x) branch for currently published source code.
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=shield)](#contributors)
 [![CircleCI](https://circleci.com/gh/neo-one-suite/neo-one.svg?style=shield)](https://circleci.com/gh/neo-one-suite/neo-one)
 [![codecov](https://codecov.io/gh/neo-one-suite/neo-one/branch/master/graph/badge.svg)](https://codecov.io/gh/neo-one-suite/neo-one)

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,14 @@
+# Getting Started with the NEO•ONE Codebase
+
+## Steps required to setup your complete development environment
+
+1. Install NodeJS
+2. Install RushJS
+3. Install C# dotnet v3.1.401
+4. Install rocksdb with Homebrew
+
+## Steps required to build/run the node from source
+
+1. Run `dotnet build` inside `packages/neo-one-node-vm/lib`
+2. Run `rush build` in root
+3. Run `node packages/neo-one-node-bin/bin/neo-one-node.js --config <path/to/config.json>`

--- a/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
@@ -108,10 +108,10 @@ namespace NEOONE
             }
           }
           ProtocolSettings settings = ProtocolSettings.Default;
-          // if (args.protocolSettings != null)
-          // {
-          //   settings = parseConfig(args.protocolSettings);
-          // }
+          if (args.settings != null)
+          {
+            settings = ProtocolSettings.Load(parseConfig(args.settings));
+          }
 
           return this._create(trigger, container, this.selectSnapshot(args.snapshot, false), persistingBlock, settings, gas);
 
@@ -193,7 +193,7 @@ namespace NEOONE
       }
     }
 
-    public bool _create(TriggerType trigger, IVerifiable container, DataCache snapshot, Block persistingBlock, ProtocolSettings settings, long gas)
+    private bool _create(TriggerType trigger, IVerifiable container, DataCache snapshot, Block persistingBlock, ProtocolSettings settings, long gas)
     {
       this.disposeEngine();
       this.engine = ApplicationEngine.Create(trigger, container, snapshot, persistingBlock, settings, gas);
@@ -201,13 +201,13 @@ namespace NEOONE
       return true;
     }
 
-    public VMState _execute()
+    private VMState _execute()
     {
       this.isEngineInitialized();
       return this.engine.Execute();
     }
 
-    public bool _loadScript(Script script, CallFlags flags, UInt160 hash = null, int rvcount = -1, int initialPosition = 0)
+    private bool _loadScript(Script script, CallFlags flags, UInt160 hash = null, int rvcount = -1, int initialPosition = 0)
     {
       this.isEngineInitialized();
       if (hash == null)
@@ -247,7 +247,7 @@ namespace NEOONE
       return this.engine != null ? this.engine.State : VMState.BREAK;
     }
 
-    public dynamic[] _getResultStack()
+    private dynamic[] _getResultStack()
     {
       return this.engine != null ? this.engine.ResultStack.Select((StackItem p) => ReturnHelpers.convertStackItem(p)).ToArray() : new dynamic[0];
     }

--- a/packages/neo-one-node-vm/lib/Dispatcher.Snapshot.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.Snapshot.cs
@@ -56,7 +56,7 @@ namespace NEOONE
       this.clonedSnapshot = this.snapshot.CreateSnapshot();
     }
 
-    public DataCache selectSnapshot(string snapshot, bool required = true)
+    private DataCache selectSnapshot(string snapshot, bool required = true)
     {
       switch (snapshot)
       {

--- a/packages/neo-one-node-vm/lib/Dispatcher.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.cs
@@ -13,6 +13,7 @@ namespace NEOONE
   {
 
     private ApplicationEngine engine;
+    private Neo.ProtocolSettings settings;
     private IStore store;
     private bool init = false;
     private string path;
@@ -77,7 +78,7 @@ namespace NEOONE
     {
       if (!this.init)
       {
-        Neo.ProtocolSettings.Load(config);
+        this.settings = Neo.ProtocolSettings.Load(config);
         this.resetSnapshots();
 
         this.init = true;
@@ -130,7 +131,7 @@ namespace NEOONE
 
     private NEOONE.ReturnHelpers.ProtocolSettingsReturn _getConfig()
     {
-      return new NEOONE.ReturnHelpers.ProtocolSettingsReturn(Neo.ProtocolSettings.Default);
+      return new NEOONE.ReturnHelpers.ProtocolSettingsReturn(this.settings);
     }
 
 #pragma warning disable 1998
@@ -235,6 +236,20 @@ namespace NEOONE
       {
         int MaxTransactionsPerBlock = (int)input.maxTransactionsPerBlock;
         config.Add("ProtocolConfiguration:MaxTransactionsPerBlock", MaxTransactionsPerBlock.ToString());
+      }
+      if (input.nativeUpdateHistory != null)
+      {
+        Dictionary<string, object[]> UpdateHistory = new Dictionary<string, object[]>() { };
+        foreach (KeyValuePair<string, object> item in input.nativeUpdateHistory)
+        {
+          IEnumerable<object> Value = (IEnumerable<object>)item.Value;
+          int idx = 0;
+          foreach (object obj in Value)
+          {
+            config.Add($"ProtocolConfiguration:NativeUpdateHistory:{item.Key}:{idx}", obj.ToString());
+            idx++;
+          }
+        }
       }
 
       return new ConfigurationBuilder().AddInMemoryCollection(config).Build().GetSection("ProtocolConfiguration");

--- a/packages/neo-one-node-vm/lib/ReturnHelpers.cs
+++ b/packages/neo-one-node-vm/lib/ReturnHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Neo.IO;
 using Neo.VM.Types;
@@ -190,7 +191,14 @@ namespace NEOONE
         this.memoryPoolMaxTransactions = value.MemoryPoolMaxTransactions;
         this.maxTraceableBlocks = Convert.ToInt32(value.MaxTraceableBlocks);
         this.maxTransactionsPerBlock = Convert.ToInt32(value.MaxTransactionsPerBlock);
-        this.nativeUpdateHistory = value.NativeUpdateHistory;
+
+        Dictionary<string, int[]> UpdateHistory = new Dictionary<string, int[]>();
+        foreach (KeyValuePair<string, uint[]> kvp in value.NativeUpdateHistory)
+        {
+          UpdateHistory[kvp.Key] = kvp.Value.Select(v => Convert.ToInt32(v)).ToArray();
+        }
+
+        this.nativeUpdateHistory = UpdateHistory;
       }
     }
   }

--- a/packages/neo-one-node-vm/src/__tests__/Dispatcher.test.ts
+++ b/packages/neo-one-node-vm/src/__tests__/Dispatcher.test.ts
@@ -10,7 +10,7 @@ describe('Dispatcher Tests', () => {
     dispatcher.reset();
   });
 
-  test.only('withApplicationEngine -- NOP Script', () => {
+  test('withApplicationEngine -- NOP Script', () => {
     const result = dispatcher.withApplicationEngine<{
       readonly gasconsumed: BN;
       readonly state: VMState;
@@ -84,6 +84,12 @@ describe('Dispatcher Tests', () => {
       validatorsCount: standbyValidators.length,
       millisecondsPerBlock: 15000 + 1,
       memoryPoolMaxTransactions: 50000 + 1,
+      maxTraceableBlocks: 1,
+      maxTransactionsPerBlock: 10000,
+      nativeUpdateHistory: {
+        StdLib: [1, 2, 3],
+        ContractManagement: [0],
+      },
     };
 
     const newDis = new Dispatcher({ protocolSettings: input });


### PR DESCRIPTION
### Description of the Change

Makes more updates to the node and related packages for cleanup and compatibility with RC1:

- Allows us to pass in and get out all the ProtocolSettings to/from the dispatcher correctly, including NativeUpdateHistory.
- Reverts some methods in the dispatcher that were made public for debugging reasons and reverts them back to private methods.
- Updates the README to notify that master is a dev branch.
- Fixes Blockchain so it correctly updates the standby committee.

### Test Plan

Tested in development.

### Alternate Designs

None.

### Benefits

Bug fixes, cleanup.

### Possible Drawbacks

None.

### Applicable Issues

#2388