### PR TITLE
fix(compiler): CallFlags for calling native contract

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/NativeContractCallValue.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/NativeContractCallValue.ts
@@ -1,4 +1,4 @@
-import { UInt160 } from '@neo-one/client-common';
+import { CallFlags, UInt160 } from '@neo-one/client-common';
 import { WrappableType } from '../../constants';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -20,9 +20,11 @@ export class NativeContractCallValue extends BuiltinMemberValue {
     }
     // [[]]
     sb.emitOp(node, 'NEWARRAY0');
-    // [method, []]
+    // [number, []]
+    sb.emitPushInt(node, CallFlags.None);
+    // [method, number, []]
     sb.emitPushString(node, this.method);
-    // [buffer, method, []]
+    // [buffer, method, number, []]
     sb.emitPushBuffer(node, this.hash);
     // [val]
     sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/block.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/block.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import { Types } from '../../constants';
 import { BuiltinInterface } from '../BuiltinInterface';
 import { Builtins } from '../Builtins';
@@ -37,9 +37,11 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushInt(node, 1);
         // [[buffer]]
         sb.emitOp(node, 'PACK');
-        // ['getBlock', [buffer]]
+        // [number, [buffer]]
+        sb.emitPushInt(node, CallFlags.None);
+        // ['getBlock', number, [buffer]]
         sb.emitPushString(node, 'getBlock');
-        // [buffer, 'gettransaction', [buffer]]
+        // [buffer, 'getBlock', number, [buffer]]
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
         // [conract]
         sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import { GlobalProperty, Types } from '../../constants';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -26,9 +26,11 @@ class BlockchainCurrentCallerContract extends BuiltinMemberValue {
       sb.emitPushInt(node, 1);
       // [[buffer], buffer]
       sb.emitOp(node, 'PACK');
-      // ['getContract', [buffer], buffer]
+      // [number, [buffer], buffer]
+      sb.emitPushInt(node, CallFlags.None);
+      // ['getContract', number, [buffer], buffer]
       sb.emitPushString(node, 'getContract');
-      // [buffer, 'getContract', [buffer], buffer]
+      // [buffer, 'getContract', number, [buffer], buffer]
       sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
       // [conract, buffer]
       sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/contract.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/contract.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import { Types } from '../../constants';
 import { BuiltinInterface } from '../BuiltinInterface';
 import { Builtins } from '../Builtins';
@@ -27,9 +27,11 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushInt(node, 1);
         // [[buffer]]
         sb.emitOp(node, 'PACK');
-        // ['getContract', [buffer]]
+        // [number, [buffer]]
+        sb.emitPushInt(node, CallFlags.None);
+        // ['getContract', number, [buffer]]
         sb.emitPushString(node, 'getContract');
-        // [buffer, 'getContract', [buffer]]
+        // [buffer, 'getContract', number, [buffer]]
         sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
         // [contract]
         sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
@@ -1,4 +1,4 @@
-import { UInt160 } from '@neo-one/client-common';
+import { CallFlags, UInt160 } from '@neo-one/client-common';
 import { tsUtils } from '@neo-one/ts-utils';
 import ts from 'typescript';
 import { DiagnosticCode } from '../../../../DiagnosticCode';
@@ -51,7 +51,11 @@ export class LinkedSmartContractFor extends SmartContractForBase {
       sb.emitOp(node, 'PACK');
       // [string, [string, params]]
       sb.emitOp(node, 'SWAP');
-      // [buffer, string, params]
+      // [number, string, [string, params]]
+      sb.emitPushInt(node, CallFlags.None);
+      // [string, number, [string, params]]
+      sb.emitOp(node, 'SWAP');
+      // [buffer, string, number, [string, params]]
       sb.emitPushBuffer(prop, scriptHash);
       // [result]
       sb.emitSysCall(prop, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/destroy.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/destroy.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import { tsUtils } from '@neo-one/ts-utils';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../../sb';
@@ -28,9 +28,11 @@ export class SmartContractDestroy extends BuiltinInstanceMemberCall {
     sb.emitPushInt(node, 1);
     // [[buffer]]
     sb.emitOp(node, 'PACK');
-    // ['destroy', [buffer], buffer]
+    // [number, [buffer]]
+    sb.emitPushInt(node, CallFlags.None);
+    // ['destroy', number, [buffer]]
     sb.emitPushString(node, 'destroy');
-    // [buffer, 'destroy', [buffer]]
+    // [buffer, 'destroy', number, [buffer]]
     sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
     // [conract]
     sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
@@ -1,3 +1,4 @@
+import { CallFlags } from '@neo-one/client-common/src';
 import { tsUtils } from '@neo-one/ts-utils';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../../sb';
@@ -54,13 +55,25 @@ export class SmartContractFor extends SmartContractForBase {
     if (scriptHash === undefined) {
       // [bufferVal, string, params]
       sb.scope.get(sb, arg, options, addressName);
-      // [buffer, string, params]
+      // [number, bufferVal, string, params]
+      sb.emitPushInt(node, CallFlags.None);
+      // [string, bufferVal, number, params]
+      sb.emitOp(node, 'REVERSE3');
+      // [bufferVal, string, number, params]
+      sb.emitOp(node, 'SWAP');
+      // [buffer, string, number, params]
       sb.emitHelper(prop, options, sb.helpers.unwrapBuffer);
       // [result]
       sb.emitSysCall(node, 'System.Contract.Call');
     } else {
       // [buffer, string, params]
       sb.emitPushBuffer(prop, scriptHash);
+      // [number, buffer, string, params]
+      sb.emitPushInt(node, CallFlags.None);
+      // [string, buffer, number, params]
+      sb.emitOp(node, 'REVERSE3');
+      // [buffer, string, number, params]
+      sb.emitOp(node, 'SWAP');
       // [result]
       sb.emitSysCall(node, 'System.Contract.Call');
     }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import { Types } from '../../constants';
 import { BuiltinInterface } from '../BuiltinInterface';
 import { Builtins } from '../Builtins';
@@ -31,9 +31,11 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushInt(node, 1);
         // [[txHash]]
         sb.emitOp(node, 'PACK');
-        // ['getTransactionHeight', [txHash]]
+        // [number, [txHash]]
+        sb.emitPushInt(node, CallFlags.None);
+        // ['getTransactionHeight', number, [txHash]]
         sb.emitPushString(node, 'getTransactionHeight');
-        // [buffer, 'getTransactionHeight', [txHash]]
+        // [buffer, 'getTransactionHeight', number, [txHash]]
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
         // [height]
         sb.emitSysCall(node, 'System.Contract.Call');
@@ -91,9 +93,11 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushInt(node, 1);
         // [[buffer]]
         sb.emitOp(node, 'PACK');
-        // ['getTransaction', [buffer]]
+        // [number, [buffer]]
+        sb.emitPushInt(node, CallFlags.None);
+        // ['getTransaction', number, [buffer]]
         sb.emitPushString(node, 'getTransaction');
-        // [buffer, 'getTransaction', [buffer]]
+        // [buffer, 'getTransaction', number, [buffer]]
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
         // [conract]
         sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinaryDeserializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinaryDeserializeHelper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -12,9 +12,11 @@ export class BinaryDeserializeHelper extends Helper {
     sb.emitPushInt(node, 1);
     // [[buffer]]
     sb.emitOp(node, 'PACK');
-    // ['deserialize', [buffer]]
+    // [number, [buffer]]
+    sb.emitPushInt(node, CallFlags.None);
+    // ['deserialize', number, [buffer]]
     sb.emitPushString(node, 'deserialize');
-    // [buffer, 'deserialize', [buffer]]
+    // [buffer, 'deserialize', number, [buffer]]
     sb.emitPushBuffer(node, common.nativeHashes.StdLib);
     // [val]
     sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinarySerializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinarySerializeHelper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -12,9 +12,11 @@ export class BinarySerializeHelper extends Helper {
     sb.emitPushInt(node, 1);
     // [[val]]
     sb.emitOp(node, 'PACK');
-    // ['serialize', [val]]
+    // [number, [val]]
+    sb.emitPushInt(node, CallFlags.None);
+    // ['serialize', number, [val]]
     sb.emitPushString(node, 'serialize');
-    // [buffer, 'serialize', [val]]
+    // [buffer, 'serialize', number, [val]]
     sb.emitPushBuffer(node, common.nativeHashes.StdLib);
     // [buffer]
     sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/IsCallerHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/IsCallerHelper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { GlobalProperty } from '../../constants';
 import { ScriptBuilder } from '../../sb';
@@ -37,9 +37,11 @@ export class IsCallerHelper extends Helper {
           sb.emitPushInt(node, 1);
           // [[addressBuffer], addressBuffer]
           sb.emitOp(node, 'PACK');
-          // ['getContract', [addressBuffer], addressBuffer]
+          // [number, [addressBuffer], addressBuffer]
+          sb.emitPushInt(node, CallFlags.None);
+          // ['getContract', number, [addressBuffer], addressBuffer]
           sb.emitPushString(node, 'getContract');
-          // [buffer, 'getContract', [addressBuffer], addressBuffer]
+          // [buffer, 'getContract', number, [addressBuffer], addressBuffer]
           sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
           // [maybeContract, addressBuffer]
           sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/UpgradeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/UpgradeHelper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -45,9 +45,11 @@ export class UpgradeHelper extends Helper {
           sb.emitHelper(node, options, sb.helpers.getArgument);
           // TODO: need to test this and make sure the "arg" is an array
           // first arg is nefFile and second is manifest
-          // ['update', arg]
+          // [number, arg]
+          sb.emitPushInt(node, CallFlags.None);
+          // ['update', number, arg]
           sb.emitPushString(node, 'update');
-          // [buffer, 'update', arg]
+          // [buffer, 'update', number, arg]
           sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
           // [conract]
           sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/RIPEMD160Helper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/RIPEMD160Helper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -12,9 +12,11 @@ export class RIPEMD160Helper extends Helper {
     sb.emitPushInt(node, 1);
     // [[argsBuffer]]
     sb.emitOp(node, 'PACK');
-    // ['ripemd160', [argsBuffer]]
+    // [number, [argsBuffer]]
+    sb.emitPushInt(node, CallFlags.None);
+    // ['ripemd160', number, [argsBuffer]]
     sb.emitPushString(node, 'ripemd160');
-    // [buffer, 'ripemd160', [argsBuffer]]
+    // [buffer, 'ripemd160', number, [argsBuffer]]
     sb.emitPushBuffer(node, common.nativeHashes.CryptoLib);
     // [argsHash]
     sb.emitSysCall(node, 'System.Contract.Call');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/SHA256Helper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/SHA256Helper.ts
@@ -1,4 +1,4 @@
-import { common } from '@neo-one/client-common';
+import { CallFlags, common } from '@neo-one/client-common';
 import ts from 'typescript';
 import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
@@ -12,9 +12,11 @@ export class SHA256Helper extends Helper {
     sb.emitPushInt(node, 1);
     // [[argsBuffer]]
     sb.emitOp(node, 'PACK');
-    // ['sha256', [argsBuffer]]
+    // [number, [argsBuffer]]
+    sb.emitPushInt(node, CallFlags.None);
+    // ['sha256', number, [argsBuffer]]
     sb.emitPushString(node, 'sha256');
-    // [buffer, 'ripemd160', [argsBuffer]]
+    // [buffer, 'ripemd160', number, [argsBuffer]]
     sb.emitPushBuffer(node, common.nativeHashes.CryptoLib);
     // [argsHash]
     sb.emitSysCall(node, 'System.Contract.Call');


### PR DESCRIPTION
### Requirements
CallContract API changed.

### Description of the Change

added call flags before calling contracts.

### Test Plan

tested locally.

### Alternate Designs

N/A

### Benefits

N/A

### Possible Drawbacks

Currently setting the call flags to `None`. Should check the correct type of flag to replace them.

### Applicable Issues

N/A