### PR TITLE
fix(compiler): add paramtype to compiler and other fixes

### DIFF
--- a/packages/neo-one-client-core/src/args.ts
+++ b/packages/neo-one-client-core/src/args.ts
@@ -805,14 +805,12 @@ export const assertMethodToken = (name: string, value?: unknown): MethodToken =>
   };
 };
 
-export const assertNefFile = (name: string, value?: unknown): NefFile => {
+export const assertNefFile = (name: string, value?: unknown): Omit<NefFile, 'checksum' | 'magic'> => {
   if (!isObject(value)) {
     throw new InvalidArgumentError('NefFile', name, value);
   }
 
   return {
-    // magic: assertProperty(value, 'NefFile', 'magic', assertNumber),
-    // checksum: assertProperty(value, 'NefFile', 'checksum', assertNumber),
     compiler: assertProperty(value, 'NefFile', 'compiler', assertString),
     script: assertProperty(value, 'NefFile', 'script', assertString),
     tokens: assertProperty(value, 'NefFile', 'tokens', assertArray).map((token) =>

--- a/packages/neo-one-smart-contract-compiler/src/__data__/helpers/startNode.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__data__/helpers/startNode.ts
@@ -216,9 +216,10 @@ export const startNode = async (outerOptions: StartNodeOptions = {}): Promise<Te
 
       throwOnDiagnosticErrorOrWarning(context.diagnostics, outerOptions.ignoreWarnings);
 
-      mutableSourceMaps[
-        scriptHashToAddress(common.uInt160ToString(crypto.toScriptHash(Buffer.from(outputScript, 'hex'))))
-      ] = await sourceMap;
+      const contractAddress = scriptHashToAddress(
+        common.uInt160ToString(crypto.toScriptHash(Buffer.from(outputScript, 'hex'))),
+      );
+      mutableSourceMaps[contractAddress] = await sourceMap;
       const result = await userAccountProviders.memory.__execute(
         outputScript,
         {

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/contract.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/contract.test.ts
@@ -7,7 +7,6 @@ import {
   ContractPermission,
   MethodTokenModel,
   NefFileModel,
-  toContractParameterType,
 } from '@neo-one/client-common';
 import { helpers } from '../../../../__data__';
 import { DiagnosticCode } from '../../../../DiagnosticCode';
@@ -98,7 +97,7 @@ describe('Contract', () => {
       }
       ${method.parameters?.map((param, idxIn) => checkParam(idxIn, param, method.name)).join('') ?? ''};
 
-      assertEqual(abiMethod.returnType, ${toContractParameterType(method.returnType)});
+      assertEqual(abiMethod.returnType, ContractParameterType.${method.returnType});
       assertEqual(abiMethod.offset, ${method.offset});
       assertEqual(abiMethod.safe, ${method.safe});
     `;
@@ -145,7 +144,7 @@ describe('Contract', () => {
         ${permissions.some((perm) => perm.contract.group !== undefined) ? 'PublicKey,' : ''}
         ${groups.length > 0 ? 'ContractGroup,' : ''}
         ${permissions.length > 0 ? 'ContractPermission,' : ''}
-        ${methods.length > 0 ? 'ContractMethodDescriptor,' : ''}
+        ${methods.length > 0 ? 'ContractMethodDescriptor, ContractParameterType,' : ''}
         ${events.length > 0 ? 'ContractEventDescriptor,' : ''}
         ${
           methods.some((method) => method.parameters !== undefined && method.parameters.length > 0) ||

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/transaction.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/transaction.test.ts
@@ -4,22 +4,22 @@ import { DiagnosticCode } from '../../../../DiagnosticCode';
 describe('Transaction', () => {
   test('properties', async () => {
     const node = await helpers.startNode();
-    const block = await node.readClient.getBlock(0);
-    const transaction = block.transactions[0];
+    const { transaction } = await node.executeString(``);
     await node.executeString(
       `
       import { Transaction, Address, Hash256 } from '@neo-one/smart-contract';
 
-      const transaction = Transaction.for(Hash256.from('${block.transactions[0].hash}'));
+      const transaction = Transaction.for(Hash256.from('${transaction.hash}'));
 
       assertEqual(transaction instanceof Transaction, true);
-      assertEqual(transaction.height, ${block.index});
+      assertEqual(transaction.hash, Hash256.from('${transaction.hash}'));
       assertEqual(transaction.version, ${transaction.version});
       assertEqual(transaction.nonce, ${transaction.nonce});
       assertEqual(transaction.sender, Address.from('${transaction.sender}'));
-      assertEqual(transaction.validUntilBlock, ${transaction.validUntilBlock});
       assertEqual(transaction.systemFee, ${transaction.systemFee.toString()});
       assertEqual(transaction.networkFee, ${transaction.networkFee.toString()});
+      assertEqual(transaction.validUntilBlock, ${transaction.validUntilBlock});
+      assertEqual(transaction.height, 1);
       assertEqual(transaction.script, ${helpers.getBufferHash(transaction.script, 'base64')});
     `,
     );

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/index.ts
@@ -5,6 +5,7 @@ import { add as addGroup } from './group';
 import { add as addManifest } from './manifest';
 import { add as addMethod } from './method';
 import { add as addParameter } from './parameter';
+import { add as addParameterType } from './parameterType';
 import { add as addPermission } from './permission';
 
 // tslint:disable-next-line export-name
@@ -16,4 +17,5 @@ export const add = (builtins: Builtins): void => {
   addParameter(builtins);
   addPermission(builtins);
   addManifest(builtins);
+  addParameterType(builtins);
 };

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/parameterType.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/parameterType.ts
@@ -1,0 +1,76 @@
+import { ContractParameterTypeModel as ContractParameterType } from '@neo-one/client-common';
+import { BuiltinBase } from '../../BuiltinBase';
+import { BuiltinConstantNumberMemberValue } from '../../BuiltinConstantNumberMemberValue';
+import { Builtins } from '../../Builtins';
+
+class ContractParameterTypeValue extends BuiltinBase {}
+
+// tslint:disable-next-line export-name
+export const add = (builtins: Builtins): void => {
+  builtins.addContractValue('ContractParameterType', new ContractParameterTypeValue());
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Any',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Any),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Boolean',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Boolean),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Integer',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Integer),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'ByteArray',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.ByteArray),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'String',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.String),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Hash160',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Hash160),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Hash256',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Hash256),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'PublicKey',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.PublicKey),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Signature',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Signature),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Array',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Array),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Map',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Map),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'InteropInterface',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.InteropInterface),
+  );
+  builtins.addContractMember(
+    'ContractParameterType',
+    'Void',
+    new BuiltinConstantNumberMemberValue(ContractParameterType.Void),
+  );
+};

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
@@ -94,7 +94,7 @@ export const add = (builtins: Builtins): void => {
         // [[buffer]]
         sb.emitOp(node, 'PACK');
         // [number, [buffer]]
-        sb.emitPushInt(node, CallFlags.None);
+        sb.emitPushInt(node, CallFlags.ReadStates);
         // ['getTransaction', number, [buffer]]
         sb.emitPushString(node, 'getTransaction');
         // [buffer, 'getTransaction', number, [buffer]]

--- a/packages/neo-one-smart-contract/src/index.d.ts
+++ b/packages/neo-one-smart-contract/src/index.d.ts
@@ -442,6 +442,7 @@ export interface ContractPermission {
    * If a contract invokes a contract or method that is not declared in the manifest at runtime, the invocation will fail.
    */
   readonly methods?: readonly string[];
+  readonly [OpaqueTagSymbol0]: unique symbol;
 }
 export interface ContractPermissionConstructor {
   readonly [OpaqueTagSymbol0]: unique symbol;
@@ -462,6 +463,7 @@ export interface ContractABI {
    * Specification of the smart contract events.
    */
   readonly events: readonly ContractEventDescriptor[];
+  readonly [OpaqueTagSymbol0]: unique symbol;
 }
 export interface ContractABIConstructor {
   readonly [OpaqueTagSymbol0]: unique symbol;
@@ -492,6 +494,7 @@ export interface ContractMethodDescriptor {
    * Indicates whether the method is safe to be called by other contracts.
    */
   readonly safe: boolean;
+  readonly [OpaqueTagSymbol0]: unique symbol;
 }
 export interface ContractMethodDescriptorConstructor {
   readonly [OpaqueTagSymbol0]: unique symbol;
@@ -511,6 +514,7 @@ export interface ContractEventDescriptor {
    * Parameters of the event.
    */
   readonly parameters: readonly ContractParameterDefinition[];
+  readonly [OpaqueTagSymbol0]: unique symbol;
 }
 export interface ContractEventDescriptorConstructor {
   readonly [OpaqueTagSymbol0]: unique symbol;
@@ -529,6 +533,7 @@ export interface ContractParameterDefinition {
    * The type of the contract parameter. @see `ContractParameterType` for information on possible contract parameter types.
    */
   readonly type: ContractParameterType;
+  readonly [OpaqueTagSymbol0]: unique symbol;
 }
 export interface ContractParameterDefinitionConstructor {
   readonly [OpaqueTagSymbol0]: unique symbol;


### PR DESCRIPTION
### Description of the Change

- Adds `ContractParameterType` to compiler
- Updates manifest and transaction compiler tests

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Compiler fixes.

### Possible Drawbacks

None.

### Applicable Issues

#2388 
