### PR TITLE
fix(compiler): fix calling contracts with void return and more

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/block.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/block.test.ts
@@ -2,7 +2,7 @@ import { helpers } from '../../../../__data__';
 import { DiagnosticCode } from '../../../../DiagnosticCode';
 
 describe('Block', () => {
-  test.only('properties', async () => {
+  test('properties', async () => {
     const node = await helpers.startNode();
     const block = await node.readClient.getBlock(0);
     await node.executeString(`

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { helpers, keys } from '../../../../__data__';
 
 describe('Blockchain', () => {
-  test.only('currentHeight', async () => {
+  test('currentHeight', async () => {
     const node = await helpers.startNode();
 
     await node.executeString(`

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/mapStorage.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/mapStorage.test.ts
@@ -184,7 +184,7 @@ describe('MapStorage', () => {
     `);
   });
 
-  test.only('multi-tier', async () => {
+  test('multi-tier', async () => {
     const node = await helpers.startNode();
 
     const contract = await node.addContract(`
@@ -285,7 +285,7 @@ describe('MapStorage', () => {
     `);
   });
 
-  test('multi-tier - level 0', async () => {
+  test.only('multi-tier - level 0', async () => {
     const node = await helpers.startNode();
 
     const contract = await node.addContract(`

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/InvokeSmartContractHelper0.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/helper/contract/InvokeSmartContractHelper0.test.ts
@@ -9,7 +9,7 @@ const properties = `
 `;
 
 describe('InvokeSmartContractHelper', () => {
-  test.only('basic class no constructor', async () => {
+  test('basic class no constructor', async () => {
     const node = await helpers.startNode();
     const contract = await node.addContract(`
       import { SmartContract } from '@neo-one/smart-contract';

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
@@ -52,7 +52,7 @@ export class LinkedSmartContractFor extends SmartContractForBase {
       // [string, [string, params]]
       sb.emitOp(node, 'SWAP');
       // [number, string, [string, params]]
-      sb.emitPushInt(node, CallFlags.None);
+      sb.emitPushInt(node, CallFlags.All);
       // [string, number, [string, params]]
       sb.emitOp(node, 'SWAP');
       // [buffer, string, number, [string, params]]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/parameter.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/manifest/parameter.ts
@@ -1,7 +1,6 @@
 import { Types } from '../../../constants';
 import { BuiltinInterface } from '../../BuiltinInterface';
 import { Builtins } from '../../Builtins';
-import { BuiltinInstanceIndexArrayValue } from '../BuiltinInstanceIndexArrayValue';
 import { BuiltinInstanceIndexValue } from '../BuiltinInstanceIndexValue';
 import { ValueInstanceOf } from '../ValueInstanceOf';
 
@@ -27,6 +26,6 @@ export const add = (builtins: Builtins): void => {
   builtins.addContractMember(
     'ContractParameterDefinition',
     'type',
-    new BuiltinInstanceIndexArrayValue(1, Types.ContractParameter, Types.Number),
+    new BuiltinInstanceIndexValue(1, Types.ContractParameter, Types.Number),
   );
 };

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
@@ -56,7 +56,7 @@ export class SmartContractFor extends SmartContractForBase {
       // [bufferVal, string, params]
       sb.scope.get(sb, arg, options, addressName);
       // [number, bufferVal, string, params]
-      sb.emitPushInt(node, CallFlags.None);
+      sb.emitPushInt(node, CallFlags.All);
       // [string, bufferVal, number, params]
       sb.emitOp(node, 'REVERSE3');
       // [bufferVal, string, number, params]
@@ -69,7 +69,7 @@ export class SmartContractFor extends SmartContractForBase {
       // [buffer, string, params]
       sb.emitPushBuffer(prop, scriptHash);
       // [number, buffer, string, params]
-      sb.emitPushInt(node, CallFlags.None);
+      sb.emitPushInt(node, CallFlags.All);
       // [string, buffer, number, params]
       sb.emitOp(node, 'REVERSE3');
       // [buffer, string, number, params]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/HandleNormalHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/HandleNormalHelper.ts
@@ -57,7 +57,7 @@ export class HandleNormalHelper extends Helper {
             }),
           );
           sb.emitHelper(decl, innerOptions, sb.helpers.invokeSmartContractMethod({ method: decl }));
-          sb.emitHelper(decl, innerOptions, sb.helpers.unwrapValRecursive({ type: returnType }));
+          sb.emitHelper(decl, innerOptions, sb.helpers.unwrapValRecursive({ dropVoid: true, type: returnType }));
         });
 
         return;
@@ -68,7 +68,11 @@ export class HandleNormalHelper extends Helper {
 
         sb.emitPushString(decl, propInfo.name);
         sb.emitHelper(decl, options, sb.helpers.getCommonStorage);
-        sb.emitHelper(decl, options, sb.helpers.unwrapValRecursive({ type: sb.context.analysis.getType(decl) }));
+        sb.emitHelper(
+          decl,
+          options,
+          sb.helpers.unwrapValRecursive({ dropVoid: true, type: sb.context.analysis.getType(decl) }),
+        );
 
         return;
       }
@@ -82,7 +86,7 @@ export class HandleNormalHelper extends Helper {
 
             sb.withScope(decl, options, (innerOptions) => {
               sb.emitHelper(decl, innerOptions, sb.helpers.invokeSmartContractMethod({ method: decl }));
-              sb.emitHelper(decl, innerOptions, sb.helpers.unwrapValRecursive({ type: propertyType }));
+              sb.emitHelper(decl, innerOptions, sb.helpers.unwrapValRecursive({ dropVoid: true, type: propertyType }));
             });
           }
         } else {


### PR DESCRIPTION
### Description of the Change

- Fixes calling contract methods with a void return
- Fixes contract manifest compiler API tests
- Fixes contract params in compiler
- Removes `test.only`

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Compiler fixes.

### Possible Drawbacks

None.

### Applicable Issues

#2388 