### PR TITLE
fix(compiler): replace iter.concat api and more

### DIFF
--- a/packages/neo-one-client-common/src/models/vm.ts
+++ b/packages/neo-one-client-common/src/models/vm.ts
@@ -192,6 +192,7 @@ export enum Op {
   ISNULL = 0xd8,
   ISTYPE = 0xd9,
   CONVERT = 0xdb,
+  PRINT = 0xff,
 }
 
 export type OpCode = keyof typeof Op;
@@ -251,10 +252,6 @@ export enum SysCall {
   'System.Storage.Find' = 'System.Storage.Find',
   'System.Storage.Put' = 'System.Storage.Put',
   'System.Storage.Delete' = 'System.Storage.Delete',
-  'System.Binary.Base58Encode' = 'System.Binary.Base58Encode',
-  'System.Binary.Base58Decode' = 'System.Binary.Base58Decode',
-  'System.Binary.Itoa' = 'System.Binary.Itoa',
-  'System.Binary.Atoi' = 'System.Binary.Atoi',
 }
 
 export enum SysCallHashNum {
@@ -290,10 +287,6 @@ export enum SysCallHashNum {
   'System.Storage.Find' = 0xdf30b89a,
   'System.Storage.Put' = 0xe63f1884,
   'System.Storage.Delete' = 0x2f58c5ed,
-  'System.Binary.Base58Encode' = 0x3f57b067,
-  'System.Binary.Base58Decode' = 0x6df79237,
-  'System.Binary.Itoa' = 0x7be3ba7d,
-  'System.Binary.Atoi' = 0x1c3840eb,
 }
 
 export type SysCallName = keyof typeof SysCall;

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -169,6 +169,7 @@ import {
 import { CreateIteratorResultHelper } from './iteratorResult';
 import { KeyedHelper } from './KeyedHelper';
 import {
+  IteratorToMapHelper,
   MapDeleteHelper,
   MapEveryHelper,
   MapEveryHelperOptions,
@@ -182,6 +183,8 @@ import {
   MapReduceHelperOptions,
   MapSomeHelper,
   MapSomeHelperOptions,
+  MapToNestedArrHelper,
+  NestedArrToMapHelper,
 } from './map';
 import {
   AddEmptyModuleHelper,
@@ -690,6 +693,9 @@ export interface Helpers {
   readonly mapMap: (options: MapMapHelperOptions) => MapMapHelper;
   readonly mapReduce: (options: MapReduceHelperOptions) => MapReduceHelper;
   readonly mapSome: (options: MapSomeHelperOptions) => MapSomeHelper;
+  readonly mapToNestedArr: MapToNestedArrHelper;
+  readonly nestedArrToMap: NestedArrToMapHelper;
+  readonly iteratorToMap: IteratorToMapHelper;
 
   // storage
   readonly cacheStorage: CacheStorageHelper;
@@ -1139,6 +1145,9 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     mapMap: (options) => new MapMapHelper(options),
     mapReduce: (options) => new MapReduceHelper(options),
     mapSome: (options) => new MapSomeHelper(options),
+    mapToNestedArr: new MapToNestedArrHelper(),
+    nestedArrToMap: new NestedArrToMapHelper(),
+    iteratorToMap: new IteratorToMapHelper(),
 
     // storage
     cacheStorage: new CacheStorageHelper(),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/IteratorToMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/IteratorToMapHelper.ts
@@ -1,0 +1,28 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+// Input: [iterator]
+// Output: [map]
+export class IteratorToMapHelper extends Helper {
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    // [map, iterator]
+    sb.emitOp(node, 'NEWMAP');
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.rawIteratorReduce({
+        // going in: [accum, key, val]
+        each: () => {
+          // [map, map, key, val]
+          sb.emitOp(node, 'DUP');
+          // [val, key, map, map]
+          sb.emitOp(node, 'REVERSE4');
+          // [map]
+          sb.emitOp(node, 'SETITEM');
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapToNestedArrHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapToNestedArrHelper.ts
@@ -1,0 +1,53 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+// Input: [map]
+// Output: [...[key, val]]
+export class MapToNestedArrHelper extends Helper {
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    // [accum, map]
+    sb.emitOp(node, 'NEWARRAY0');
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.mapReduce({
+        each: () => {
+          // [val, arr, key]
+          sb.emitOp(node, 'ROT');
+          // [key, val, arr]
+          sb.emitOp(node, 'ROT');
+          // [num, key, val, arr]
+          sb.emitPushInt(node, 2);
+          // [struct, key, val, arr]
+          sb.emitOp(node, 'NEWSTRUCT');
+          // [struct, key, struct, val, arr]
+          sb.emitOp(node, 'TUCK');
+          // [0, struct, key, struct, val, arr]
+          sb.emitPushInt(node, 0);
+          // [key, 0, struct, struct, val, arr]
+          sb.emitOp(node, 'ROT');
+          // [struct, val, arr]
+          sb.emitOp(node, 'SETITEM');
+          // [struct, val, struct, arr]
+          sb.emitOp(node, 'TUCK');
+          // [1, struct, val, struct, arr]
+          sb.emitPushInt(node, 1);
+          // [val, 1, struct, struct, arr]
+          sb.emitOp(node, 'ROT');
+          // [struct, arr]
+          sb.emitOp(node, 'SETITEM');
+          // [arr, struct]
+          sb.emitOp(node, 'SWAP');
+          // [arr, arr, struct]
+          sb.emitOp(node, 'DUP');
+          // [struct, arr, arr]
+          sb.emitOp(node, 'ROT');
+          // [arr]
+          sb.emitOp(node, 'APPEND');
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/NestedArrToMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/NestedArrToMapHelper.ts
@@ -1,0 +1,33 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+// Input: [...[key, val]]
+// Output: [map]
+export class NestedArrToMapHelper extends Helper {
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    // [map, nestedArr]
+    sb.emitOp(node, 'NEWMAP');
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.arrReduce({
+        each: () => {
+          // [map, [key, val], map]
+          sb.emitOp(node, 'TUCK');
+          // [[key, val], map, map]
+          sb.emitOp(node, 'SWAP');
+          // [size, key, val, map, map]
+          sb.emitOp(node, 'UNPACK');
+          // [key, val, map, map]
+          sb.emitOp(node, 'DROP');
+          // [val, key, map, map]
+          sb.emitOp(node, 'SWAP');
+          // [map]
+          sb.emitOp(node, 'SETITEM');
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/index.ts
@@ -5,3 +5,6 @@ export * from './MapForEachHelper';
 export * from './MapMapHelper';
 export * from './MapReduceHelper';
 export * from './MapSomeHelper';
+export * from './MapToNestedArrHelper';
+export * from './NestedArrToMapHelper';
+export * from './IteratorToMapHelper';

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/IterStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/IterStorageHelper.ts
@@ -1,3 +1,4 @@
+import { StackItemType } from '@neo-one/client-common';
 import ts from 'typescript';
 import { FindOptions } from '../../../types';
 import { ScriptBuilder } from '../../sb';
@@ -16,18 +17,22 @@ export class IterStorageHelper extends Helper {
     sb.emitPushInt(node, FindOptions.None);
     // [keyBuffer, number, keyBuffer]
     sb.emitOp(node, 'SWAP');
-    // [context, keyBuffer, number keyBuffer]
+    // [context, keyBuffer, number, keyBuffer]
     sb.emitSysCall(node, 'System.Storage.GetReadOnlyContext');
     // [iterator, keyBuffer]
     sb.emitSysCall(node, 'System.Storage.Find');
-    // [keyBuffer, iterator]
+    // [map, keyBuffer]
+    sb.emitHelper(node, options, sb.helpers.iteratorToMap);
+    // [storageArr, keyBuffer]
+    sb.emitHelper(node, options, sb.helpers.mapToNestedArr);
+    // [keyBuffer, storageArr]
     sb.emitOp(node, 'SWAP');
     const key = sb.scope.addUnique();
-    // [iterator]
+    // [storageArr]
     sb.scope.set(sb, node, options, key);
-    // [map, iterator]
+    // [map, storageArr]
     sb.emitHelper(node, options, sb.helpers.cacheStorage);
-    // [map, iterator]
+    // [map, storageArr]
     sb.emitHelper(
       node,
       options,
@@ -43,14 +48,24 @@ export class IterStorageHelper extends Helper {
           sb.emitOp(node, 'SIZE');
           // [keyBuffer, expectedKeyBuffer]
           sb.emitOp(node, 'LEFT');
+          // [keyBuffer, expectedKeyBuffer]
+          sb.emitOp(node, 'CONVERT', Buffer.from([StackItemType.ByteString]));
           // [boolean]
           sb.emitOp(node, 'EQUAL');
         },
       }),
     );
-    // [iterator, iterator]
-    sb.emitSysCall(node, 'System.Iterator.Create');
+    // It's important that these arrays are in this order before being concatenated
+    // so that the cached values are read later in the iteration when converting the
+    // concatenated array into a map. If there are duplicate keys in the map then the later
+    // ones the cache will override the previous ones from storage
+    // [cacheArr, storageArr]
+    sb.emitHelper(node, options, sb.helpers.mapToNestedArr);
+    // [nestedArr]
+    sb.emitHelper(node, options, sb.helpers.arrConcat);
+    // [map]
+    sb.emitHelper(node, options, sb.helpers.nestedArrToMap);
     // [iterator]
-    sb.emitSysCall(node, 'System.Iterator.Concat');
+    sb.emitSysCall(node, 'System.Iterator.Create');
   }
 }


### PR DESCRIPTION
### Description of the Change

- Replaces `System.Iterator.Concat` API with a workaround composed of new helpers: `MapToNestedArrHelper`, `NestedArrToMapHelper`, `IteratorToMapHelper`
- Removes old syscall APIs in the SysCall enum
- Adds `PRINT` opcode for good for now for easier debugging
- Splits up tests in `mapStorages.test.ts` and in `arrayStorage.test.ts` so that the test contract doesn't exceed the max transaction script size
- Adds tests in `mapStorage.test.ts`, `arrayStorage.test.ts` to cover corner cases described in Possible Drawbacks below.

### Test Plan

- `mapStorage.test.ts`
- `arrayStorage.test.ts`

### Alternate Designs

None.

### Benefits

Gets compiler to compile when iterating over structured storage.

### Possible Drawbacks

Possibly unforeseen or untested consequences to this change. Seems good enough for now though. The one main potential issue is overlapping keys when trying to combine two different structured storage representations in `IterStorageHelper`. One representation comes from cache storage (which is effectively pre-committed storage changes) and one comes from the storage that is loaded from blockchain storage. It's possible that cache storage incorrectly overwrites the same key from blockchain storage. This could cause data to be lost in a difficult to detect way.

### Applicable Issues

#2388 
