### PR TITLE
fix(compiler): structured storage foreach pushvalue fix

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/ForEachStructuredStorageBaseHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/ForEachStructuredStorageBaseHelper.ts
@@ -24,7 +24,7 @@ export class ForEachStructuredStorageBaseHelper extends StructuredStorageBaseHel
     sb.emitHelper(node, options, sb.helpers.createIteratorStructuredStorage({ type: this.type }));
     // []
     sb.emitHelper(node, options, sb.helpers.rawIteratorForEachBase({ each: this.each }));
-    if (options.pushValue) {
+    if (optionsIn.pushValue) {
       // [val]
       sb.emitHelper(node, options, sb.helpers.wrapUndefined);
     }


### PR DESCRIPTION
### Description of the Change

- Fix `pushValue` option in `ForEachStructuredStorage`

Before this fix there was an extra `undefined` (internal representation of undefined) being pushed to the stack unnecessarily when using the `for...of` statement with structured storage items. This caused the eventual return stack to have a stack size of 1 instead of stack size of 0 and was throwing an error when it finally hit `RET`. Before this fix `option.pushValue` was always `true`. Now it should be `false` for structured storage items.

### Test Plan

- `arrayStorage.test.ts`
- `mapStorage.test.ts`
- `setStorage.test.ts`

### Alternate Designs

None.

### Benefits

Accurate return stacks.

### Possible Drawbacks

It's possible that this is the wrong fix. I couldn't recreate the issue on the master-2.x branch because of unrelated problems. Being able to do that would have allowed me greater insight into what exactly the `pushValue` option is for. So issues related to this fix could come up later but this would be fairly easy to debug, narrow down, and then fix if it ever came up again in any related way.

### Applicable Issues

#2388