### PR TITLE
fix(compiler): fix deploy method safety to not modify callflags

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/contract/ContractInfoProcessor.ts
+++ b/packages/neo-one-smart-contract-compiler/src/contract/ContractInfoProcessor.ts
@@ -132,7 +132,7 @@ export class ContractInfoProcessor {
           classDecl: this.smartContract,
           isPublic: true,
           isMixinDeploy: false,
-          isSafe: true, // TODO: check
+          isSafe: false, // TODO: check
         },
       ]),
     };
@@ -226,7 +226,7 @@ export class ContractInfoProcessor {
           classDecl,
           decl: ctor,
           isPublic: true,
-          isSafe: true, // TODO: check
+          isSafe: false, // TODO: check
           callSignature,
           isMixinDeploy: maybeFunc !== undefined && this.context.analysis.isSmartContractMixinFunction(maybeFunc),
         },
@@ -276,7 +276,7 @@ export class ContractInfoProcessor {
             classDecl: this.smartContract,
             isPublic: true,
             isMixinDeploy: false,
-            isSafe: true, // TODO: check
+            isSafe: false, // TODO: check
           },
         ]),
       };


### PR DESCRIPTION
### Description of the Change

- Makes the deploy method not marked as "safe" since it requires to read and write storage

### Test Plan

- `arrayStorage.test.ts`

### Alternate Designs

None.

### Benefits

Can now call `deploy` method from other contracts without worrying about callflags.

### Possible Drawbacks

This could be a problem later on, but ignoring for now. Need to ultimately check and understand the safe method marker.

### Applicable Issues

#2388 