### PR TITLE
fix(compiler): fixup how linked smart contracts are called

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
@@ -43,13 +43,23 @@ export class LinkedSmartContractFor extends SmartContractForBase {
     const scriptHash = this.getScriptHash(sb, node);
     if (scriptHash !== undefined) {
       // TODO: remove this and change how we call smart contracts, including our own
-      // [string, params, string]
-      sb.emitOp(node, 'TUCK');
-      // [2, string, params, string]
-      sb.emitPushInt(node, 2);
-      // [[string, params], string]
+      // [params, string]
+      sb.emitOp(node, 'SWAP');
+      // [size, ...params, string]
+      sb.emitOp(node, 'UNPACK');
+      // [size, size, ...params, string]
+      sb.emitOp(node, 'DUP');
+      // [size + 1, size, ...params, string]
+      sb.emitOp(node, 'INC');
+      // [string, size, ...params, string]
+      sb.emitOp(node, 'PICK');
+      // [size, string, ...params, string]
+      sb.emitOp(node, 'SWAP');
+      // [size + 1, string, ...params, string]
+      sb.emitOp(node, 'INC');
+      // [params, string]
       sb.emitOp(node, 'PACK');
-      // [string, [string, params]]
+      // [string, params]
       sb.emitOp(node, 'SWAP');
       // [number, string, [string, params]]
       sb.emitPushInt(node, CallFlags.All);

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
@@ -44,13 +44,23 @@ export class SmartContractFor extends SmartContractForBase {
     const arg = tsUtils.argumented.getArguments(node)[0];
     const scriptHash = sb.context.analysis.extractLiteralAddress(arg);
     // TODO: remove this and change how we call smart contracts, including our own
-    // [string, params, string]
-    sb.emitOp(node, 'TUCK');
-    // [2, string, params, string]
-    sb.emitPushInt(node, 2);
-    // [[string, params], string]
+    // [params, string]
+    sb.emitOp(node, 'SWAP');
+    // [size, ...params, string]
+    sb.emitOp(node, 'UNPACK');
+    // [size, size, ...params, string]
+    sb.emitOp(node, 'DUP');
+    // [size + 1, size, ...params, string]
+    sb.emitOp(node, 'INC');
+    // [string, size, ...params, string]
+    sb.emitOp(node, 'PICK');
+    // [size, string, ...params, string]
+    sb.emitOp(node, 'SWAP');
+    // [size + 1, string, ...params, string]
+    sb.emitOp(node, 'INC');
+    // [params, string]
     sb.emitOp(node, 'PACK');
-    // [string, [string, params]]
+    // [string, params]
     sb.emitOp(node, 'SWAP');
     if (scriptHash === undefined) {
       // [bufferVal, string, params]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/global/CreateGlobalObjectHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/global/CreateGlobalObjectHelper.ts
@@ -9,24 +9,38 @@ import { Helper } from '../Helper';
 export class CreateGlobalObjectHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     // TODO: remove this section when fixing how we call contracts
-    // [length, method, ...args]
-    sb.emitOp(node, 'DEPTH');
-    // [...argsReversed, method]
-    sb.emitOp(node, 'REVERSEN');
-    // [length, ...argsReversed, method]
-    sb.emitOp(node, 'DEPTH');
-    // [length - 1, ...argsReversed, method]
-    sb.emitOp(node, 'DEC');
-    // [...args, method]
-    sb.emitOp(node, 'REVERSEN');
-    // [length, ...args, method]
-    sb.emitOp(node, 'DEPTH');
-    // [length - 1, ...args, method]
-    sb.emitOp(node, 'DEC');
-    // [[args], method]
-    sb.emitOp(node, 'PACK');
-    // [method, [args]]
-    sb.emitOp(node, 'SWAP');
+    sb.emitHelper(
+      node,
+      optionsIn,
+      sb.helpers.if({
+        condition: () => {
+          // [depth]
+          sb.emitOp(node, 'DEPTH');
+          // [notZero]
+          sb.emitOp(node, 'NZ');
+        },
+        whenTrue: () => {
+          // [length, method, ...args]
+          sb.emitOp(node, 'DEPTH');
+          // [...argsReversed, method]
+          sb.emitOp(node, 'REVERSEN');
+          // [length, ...argsReversed, method]
+          sb.emitOp(node, 'DEPTH');
+          // [length - 1, ...argsReversed, method]
+          sb.emitOp(node, 'DEC');
+          // [...args, method]
+          sb.emitOp(node, 'REVERSEN');
+          // [length, ...args, method]
+          sb.emitOp(node, 'DEPTH');
+          // [length - 1, ...args, method]
+          sb.emitOp(node, 'DEC');
+          // [[args], method]
+          sb.emitOp(node, 'PACK');
+          // [method, [args]]
+          sb.emitOp(node, 'SWAP');
+        },
+      }),
+    );
     // TODO: remove end
     // [length, ...args]
     sb.emitOp(node, 'DEPTH');


### PR DESCRIPTION
### Description of the Change

- Fixes left over changes needed from previous commit which changed/fixed how contracts are called
- This applies those changes to linked smart contracts
- Also fixes a previously not considered case where a method would be called with no arguments. This fix is made in `CreateGlobalObjectHelper`

### Test Plan

Run any compiler test that called a method on another contract.

### Alternate Designs

None.

### Benefits

Correctly call linked smart contracts.

### Possible Drawbacks

Possible unforeseen corner cases with `CreateGlobalObjectHelper`.

### Applicable Issues

#2388