### PR TITLE
fix(compiler): quick fix for key too large error

### DIFF
--- a/packages/neo-one-client-common/src/common.ts
+++ b/packages/neo-one-client-common/src/common.ts
@@ -252,6 +252,8 @@ const nativeHashes = {
   NameService: hexToUInt160(nativeScriptHashes.NameService),
 };
 
+const MAP_STACK_ITEM_MAX_KEY_SIZE = 64;
+
 export const common = {
   D8,
   NEO_ADDRESS_VERSION: 0x35,
@@ -278,6 +280,7 @@ export const common = {
   FIVE_THOUSAND_FIXED8,
   TEN_THOUSAND_FIXED8,
   ONE_HUNDRED_MILLION_FIXED8,
+  MAP_STACK_ITEM_MAX_KEY_SIZE,
   uInt160ToBuffer,
   add0x,
   strip0x,

--- a/packages/neo-one-node-core/src/StackItems/MapStackItem.ts
+++ b/packages/neo-one-node-core/src/StackItems/MapStackItem.ts
@@ -1,11 +1,11 @@
-import { StackItemType } from '@neo-one/client-common';
+import { common, StackItemType } from '@neo-one/client-common';
 import { ContractParameter, MapContractParameter } from '../contractParameter';
 import { CircularReferenceError } from './errors';
 import { StackItemBase } from './StackItemBase';
 import { PrimitiveStackItem, StackItem } from './StackItems';
 
 export class MapStackItem extends StackItemBase {
-  public static readonly maxKeySize = 64;
+  public static readonly maxKeySize = common.MAP_STACK_ITEM_MAX_KEY_SIZE;
 
   public readonly dictionary: Map<PrimitiveStackItem, StackItem>;
 

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/common/SliceKeyHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/common/SliceKeyHelper.ts
@@ -1,0 +1,36 @@
+import { common, StackItemType } from '@neo-one/client-common';
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+// Input: [keyBuffer]
+// Output: [keyBuffer]
+export class SliceKeyHelper extends Helper {
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.if({
+        condition: () => {
+          // [keyBuffer, keyBuffer]
+          sb.emitOp(node, 'DUP');
+          // [size, keyBuffer]
+          sb.emitOp(node, 'SIZE');
+          // [maxSize, size, keyBuffer]
+          sb.emitPushInt(node, common.MAP_STACK_ITEM_MAX_KEY_SIZE);
+          // [bool, keyBuffer]
+          sb.emitOp(node, 'GT');
+        },
+        whenTrue: () => {
+          // [maxSize, keyBuffer]
+          sb.emitPushInt(node, common.MAP_STACK_ITEM_MAX_KEY_SIZE);
+          // [keyBuffer]
+          sb.emitOp(node, 'LEFT');
+          // [keyBuffer]
+          sb.emitOp(node, 'CONVERT', Buffer.from([StackItemType.ByteString]));
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/common/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/common/index.ts
@@ -7,3 +7,4 @@ export * from './GenericLogSerializeHelper';
 export * from './serialize';
 export * from './CloneStructHelper';
 export * from './SetArrValToObjectPropertyHelper';
+export * from './SliceKeyHelper';

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -46,6 +46,7 @@ import {
   GenericLogSerializeHelper,
   SetArrValToObjectPropertyHelper,
   SetArrValToObjectPropertyHelperOptions,
+  SliceKeyHelper,
 } from './common';
 import {
   BreakHelper,
@@ -544,6 +545,7 @@ export interface Helpers {
   readonly exp: ExpHelper;
   readonly consoleLog: ConsoleLogHelper;
   readonly debugLog: (options: DebugLogHelperOptions) => DebugLogHelper;
+  readonly sliceKey: SliceKeyHelper;
 
   readonly equalsEqualsEquals: (options: EqualsEqualsEqualsHelperOptions) => EqualsEqualsEqualsHelper;
   readonly equalsEquals: (options: EqualsEqualsHelperOptions) => EqualsEqualsHelper;
@@ -1008,6 +1010,7 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     exp: new ExpHelper(),
     consoleLog: new ConsoleLogHelper(),
     debugLog: (options) => new DebugLogHelper(options),
+    sliceKey: new SliceKeyHelper(),
 
     equalsEqualsEquals: (options) => new EqualsEqualsEqualsHelper(options),
     equalsEquals: (options) => new EqualsEqualsHelper(options),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteStorageBaseHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteStorageBaseHelper.ts
@@ -8,6 +8,8 @@ import { Helper } from '../Helper';
 export class DeleteStorageBaseHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     const options = sb.pushValueOptions(optionsIn);
+    // [keyBuffer]
+    sb.emitHelper(node, options, sb.helpers.sliceKey);
     // [storage, keyBuffer]
     sb.emitHelper(node, options, sb.helpers.cacheStorage);
     // [keyBuffer, storage, keyBuffer]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetStorageHelper.ts
@@ -13,6 +13,8 @@ export class GetStorageHelper extends Helper {
       return;
     }
 
+    // [keyBuffer]
+    sb.emitHelper(node, options, sb.helpers.sliceKey);
     // [map, keyBuffer]
     sb.emitHelper(node, options, sb.helpers.deleteCacheStorage);
     // [keyBuffer, map, keyBuffer]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/PutStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/PutStorageHelper.ts
@@ -8,6 +8,8 @@ import { Helper } from '../Helper';
 export class PutStorageHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     const options = sb.pushValueOptions(optionsIn);
+    // [keyBuffer, valBuffer]
+    sb.emitHelper(node, options, sb.helpers.sliceKey);
     // [keyBuffer, valBuffer, keyBuffer]
     sb.emitOp(node, 'TUCK');
     // [map, keyBuffer, valBuffer, keyBuffer]


### PR DESCRIPTION
### Description of the Change

- Adds `SliceKeyHelper` to compiler as a quick fix for when keys are too large in map stack items. This problem primarily occurs when a user is trying to use MapStorage with a key which is an array of items like addresses, which is a common use case that we promote in our templates and tutorials. This is a temporary fix as it's not an ideal solution.

Note that it breaks some other APIs like iterating through Set and Map storage keys and breaks the `.at()` method for both as well. Possibly breaks other APIs as well.

### Test Plan

- `mapStorage.test.ts`
- `TestToken.test.ts`

### Alternate Designs

None for now.

### Benefits

NEP17 template working as written.

### Possible Drawbacks

Possibly breaks other APIs and introduces unforeseen bugs.

### Applicable Issues

#2388 