### PR TITLE
fix(compiler): remove createMapIterator in some places

### DIFF
--- a/packages/neo-one-client-core/src/sc/common.ts
+++ b/packages/neo-one-client-core/src/sc/common.ts
@@ -117,13 +117,13 @@ export const getForwardValues = ({
   );
 };
 
-const createForwardValueArgs = (
-  parameters: readonly ABIParameter[],
-  events: readonly ContractEventDescriptorClient[],
-) => (
-  // tslint:disable-next-line no-any readonly-array
-  ...args: any[]
-) => getForwardValues({ parameters, events, args });
+const createForwardValueArgs =
+  (parameters: readonly ABIParameter[], events: readonly ContractEventDescriptorClient[]) =>
+  (
+    // tslint:disable-next-line no-any readonly-array
+    ...args: any[]
+  ) =>
+    getForwardValues({ parameters, events, args });
 
 export const convertActions = ({
   actions,
@@ -161,38 +161,40 @@ export const filterLogs = (actions: ReadonlyArray<Event | Log>): readonly Log[] 
 const isInvokeReceipt = (value: any): value is InvokeReceipt<ContractParameter> =>
   typeof value === 'object' && value.result !== undefined && value.events !== undefined && value.logs !== undefined;
 
-const createForwardValueReturn = (returnType: ABIReturn, forwardEvents: readonly ContractEventDescriptorClient[]) => (
-  receiptOrValue: InvokeReceipt<ContractParameter> | ContractParameter,
-  // tslint:disable-next-line no-any
-): any => {
-  if (isInvokeReceipt(receiptOrValue)) {
-    const actions = convertActions({
-      actions: receiptOrValue.raw.actions,
-      events: forwardEvents,
-    });
-    const foundForwardEvents = filterEvents(actions);
-    const events = _.uniqBy(
-      _.sortBy(receiptOrValue.events.concat(foundForwardEvents), [(event: Event) => event.index]),
-      (event: Event) => event.index,
-    );
-    if (receiptOrValue.result.state === 'HALT') {
-      const value = convertContractParameter({ type: returnType, parameter: receiptOrValue.result.value });
+const createForwardValueReturn =
+  (returnType: ABIReturn, forwardEvents: readonly ContractEventDescriptorClient[]) =>
+  (
+    receiptOrValue: InvokeReceipt<ContractParameter> | ContractParameter,
+    // tslint:disable-next-line no-any
+  ): any => {
+    if (isInvokeReceipt(receiptOrValue)) {
+      const actions = convertActions({
+        actions: receiptOrValue.raw.actions,
+        events: forwardEvents,
+      });
+      const foundForwardEvents = filterEvents(actions);
+      const events = _.uniqBy(
+        _.sortBy(receiptOrValue.events.concat(foundForwardEvents), [(event: Event) => event.index]),
+        (event: Event) => event.index,
+      );
+      if (receiptOrValue.result.state === 'HALT') {
+        const value = convertContractParameter({ type: returnType, parameter: receiptOrValue.result.value });
 
-      return {
-        ...receiptOrValue,
-        events,
-        result: {
-          ...receiptOrValue.result,
-          value,
-        },
-      };
+        return {
+          ...receiptOrValue,
+          events,
+          result: {
+            ...receiptOrValue.result,
+            value,
+          },
+        };
+      }
+
+      return { ...receiptOrValue, events };
     }
 
-    return { ...receiptOrValue, events };
-  }
-
-  return convertContractParameter({ type: returnType, parameter: receiptOrValue });
-};
+    return convertContractParameter({ type: returnType, parameter: receiptOrValue });
+  };
 
 export const getParametersObject = ({
   abiParameters,

--- a/packages/neo-one-client-core/src/sc/createSmartContract.ts
+++ b/packages/neo-one-client-core/src/sc/createSmartContract.ts
@@ -138,7 +138,13 @@ export const getParamsAndOptions = ({
   readonly transfer?: Transfer;
   readonly hash?: Hash256String;
 } => {
-  const { requiredArgs, forwardOptions, options: optionsIn, transfer, hash } = getParamAndOptionsResults({
+  const {
+    requiredArgs,
+    forwardOptions,
+    options: optionsIn,
+    transfer,
+    hash,
+  } = getParamAndOptionsResults({
     parameters,
     args,
   });
@@ -186,33 +192,35 @@ export const getParamsAndOptions = ({
   };
 };
 
-const createCall = ({
-  definition,
-  client,
-  func: { name, parameters = [], returnType, receive = false },
-}: {
-  readonly definition: SmartContractDefinition;
-  readonly client: Client;
-  readonly func: ContractMethodDescriptorClient;
-  // tslint:disable-next-line no-any
-}) => async (...args: any[]): Promise<Return | undefined> => {
-  const { params, network, address } = getParamsAndOptions({
+const createCall =
+  ({
     definition,
-    parameters,
-    args,
-    receive,
     client,
-  });
+    func: { name, parameters = [], returnType, receive = false },
+  }: {
+    readonly definition: SmartContractDefinition;
+    readonly client: Client;
+    readonly func: ContractMethodDescriptorClient;
+    // tslint:disable-next-line no-any
+  }) =>
+  async (...args: any[]): Promise<Return | undefined> => {
+    const { params, network, address } = getParamsAndOptions({
+      definition,
+      parameters,
+      args,
+      receive,
+      client,
+    });
 
-  // TODO: this needs to be reverted when we change how we call contracts
-  const receipt = await client.__call(network, address, name, [name, ...params]);
+    // TODO: this needs to be reverted when we change how we call contracts
+    const receipt = await client.__call(network, address, name, [name, ...params]);
 
-  return common.convertCallResult({
-    returnType,
-    receipt,
-    sourceMaps: definition.sourceMaps,
-  });
-};
+    return common.convertCallResult({
+      returnType,
+      receipt,
+      sourceMaps: definition.sourceMaps,
+    });
+  };
 
 const createInvoke = ({
   definition,

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/block.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/block.test.ts
@@ -1,27 +1,57 @@
 import { helpers } from '../../../../__data__';
 import { DiagnosticCode } from '../../../../DiagnosticCode';
 
+const properties = `
+  public readonly properties = {
+    groups: [],
+    permissions: [],
+    trusts: "*",
+  };
+`;
+
 describe('Block', () => {
   test('properties', async () => {
     const node = await helpers.startNode();
     const block = await node.readClient.getBlock(0);
+    const contract = await node.addContract(`
+      import { Block, Hash256, Address, SmartContract } from '@neo-one/smart-contract';
+
+      const test = () => {
+        const genesisHash = Hash256.from('${block.header.hash}');
+        Block.for(0);
+        Block.for(genesisHash);
+        let block = Block.for(0);
+        block = Block.for(genesisHash);
+
+        assertEqual(block.hash, genesisHash);
+        assertEqual(block.version, ${block.header.version});
+        assertEqual(block.previousHash, Hash256.from('${block.header.previousBlockHash}'));
+        assertEqual(block.index, ${block.header.index});
+        assertEqual(block.primaryIndex, ${block.header.primaryIndex});
+        assertEqual(block.merkleRoot, Hash256.from('${block.header.merkleRoot}'));
+        assertEqual(block.time, ${block.header.time});
+        assertEqual(block.nextConsensus, Address.from('${block.header.nextConsensus}'));
+        assertEqual(block.transactionsLength, 0);
+        assertEqual(block instanceof Block, true);
+      }
+
+      export class BlockContract extends SmartContract {
+        ${properties}
+
+        public run(): void {
+          test();
+        }
+      }
+    `);
+
     await node.executeString(`
-      import { Block, Hash256, Address } from '@neo-one/smart-contract';
+      import { Address, SmartContract } from '@neo-one/smart-contract';
 
-      const genesisHash = Hash256.from('${block.hash}');
-      Block.for(0);
-      Block.for(genesisHash);
-      let block = Block.for(0);
-      block = Block.for(genesisHash);
-
-      assertEqual(block.hash, genesisHash);
-      assertEqual(block.version, ${block.version});
-      assertEqual(block.previousHash, Hash256.from('${block.previousBlockHash}'));
-      assertEqual(block.index, ${block.index});
-      assertEqual(block.time, ${block.time});
-      assertEqual(block.nextConsensus, Address.from('${block.nextConsensus}'));
-      assertEqual(block.transactionsLength, 5);
-      assertEqual(block instanceof Block, true);
+      interface Contract {
+        run(): void;
+      }
+      const contract = SmartContract.for<Contract>(Address.from('${contract.address}'));
+      contract.run();
     `);
   });
 

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/set/index.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/set/index.test.ts
@@ -11,6 +11,14 @@ describe('Set', () => {
     `);
   });
 
+  test('can create new set with args', async () => {
+    await helpers.executeString(`
+      const x = new Set<string>(['neo']);
+
+      assertEqual(x.has('neo'), true);
+    `);
+  });
+
   test('cannot be extended', async () => {
     await helpers.compileString(
       `

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/BuiltinSlotInstanceMemberCall.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/BuiltinSlotInstanceMemberCall.ts
@@ -34,10 +34,8 @@ export class BuiltinSlotInstanceMemberCall extends BuiltinInstanceMemberCall {
     sb.emitPushInt(node, this.slot);
     // [callable]
     sb.emitOp(node, 'PICKITEM');
-    // [0, callable]
-    sb.emitPushInt(node, 0);
     // [argsarr, callable]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [callable, argsarr]
     sb.emitOp(node, 'SWAP');
     // [val]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/array/concat.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/array/concat.ts
@@ -30,10 +30,8 @@ export class ArrayConcat extends BuiltinInstanceMemberCall {
     };
 
     const handleOther = () => {
-      // [number, val]
-      sb.emitPushInt(node, 0);
       // [arr, val]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [arr, val, arr]
       sb.emitOp(node, 'TUCK');
       // [val, arr, arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/set/index.ts
@@ -51,7 +51,7 @@ class SetValue extends BuiltinNew {
       sb.emitHelper(
         node,
         options,
-        sb.helpers.arrReduce({
+        sb.helpers.arrReduceWithoutIterator({
           each: () => {
             // [map, val, map]
             sb.emitOp(node, 'TUCK');

--- a/packages/neo-one-smart-contract-compiler/src/compile/getSmartContractInfo.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/getSmartContractInfo.ts
@@ -3,7 +3,7 @@ import {
   ContractGroup,
   ContractMethodDescriptorClient,
   ContractPermission,
-  UInt160Hex,
+  ContractPermissionDescriptor,
   WildcardContainer,
 } from '@neo-one/client-common';
 import { tsUtils } from '@neo-one/ts-utils';
@@ -134,7 +134,7 @@ export interface SmartContractInfoManifest {
   readonly supportedStandards: readonly string[];
   readonly abi: SmartContractInfoABI;
   readonly permissions: readonly ContractPermission[];
-  readonly trusts: WildcardContainer<UInt160Hex>;
+  readonly trusts: WildcardContainer<ContractPermissionDescriptor>;
 }
 
 export interface SmartContractInfo {

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrConcatHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrConcatHelper.ts
@@ -9,34 +9,20 @@ export class ArrConcatHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
     const options = sb.pushValueOptions(optionsIn);
 
-    // [map, result]
-    sb.emitHelper(node, options, sb.helpers.arrToMap);
-    // [enumerator, result]
-    sb.emitHelper(node, options, sb.helpers.createMapIterator);
-    // [result]
+    // [accum, right]
+    sb.emitOp(node, 'SWAP');
+    // [arr]
     sb.emitHelper(
       node,
       options,
-      sb.helpers.forLoop({
-        condition: () => {
-          // [enumerator, result, enumerator]
-          sb.emitOp(node, 'TUCK');
-          // [boolean, result, enumerator]
-          sb.emitSysCall(node, 'System.Iterator.Next');
-        },
+      sb.helpers.arrReduceWithoutIterator({
         each: () => {
-          // [result, enumerator, result]
-          sb.emitOp(node, 'TUCK');
-          // [enumerator, result, enumerator, result]
-          sb.emitOp(node, 'OVER');
-          // [value, result, enumerator, result]
-          sb.emitHelper(node, options, sb.helpers.getMapIteratorValue);
-          // [enumerator, result]
+          // [accum, accum, val]
+          sb.emitOp(node, 'DUP');
+          // [val, accum, accum]
+          sb.emitOp(node, 'ROT');
+          // [accum]
           sb.emitOp(node, 'APPEND');
-        },
-        cleanup: () => {
-          // [result]
-          sb.emitOp(node, 'NIP');
         },
       }),
     );

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrEveryFuncHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrEveryFuncHelper.ts
@@ -13,69 +13,85 @@ export class ArrEveryFuncHelper extends Helper {
     sb.emitHelper(node, options, sb.helpers.getCallable({}));
     // [arr, callable]
     sb.emitOp(node, 'SWAP');
-    // [map, callable]
-    sb.emitHelper(node, options, sb.helpers.arrToMap);
-    // [enumerator, callable]
-    sb.emitHelper(node, options, sb.helpers.createMapIterator);
-    // [idx, enumerator, callable]
+    // [idx, arr, callable]
     sb.emitPushInt(node, 0);
-    // [result, idx, enumerator, callable]
+    // [result, idx, arr, callable]
     sb.emitPushBoolean(node, true);
-    // [enumerator, result, idx, callable]
+    // [arr, result, idx, callable]
+    sb.emitOp(node, 'ROT');
+    // [arr, arr, result, idx, callable]
+    sb.emitOp(node, 'DUP');
+    // [size, arr, result, idx, callable]
+    sb.emitOp(node, 'SIZE');
+    // [result, size, arr, idx, callable]
+    sb.emitOp(node, 'ROT');
+    // [arr, result, size, idx, callable]
     sb.emitOp(node, 'ROT');
     sb.emitHelper(
       node,
       options,
       sb.helpers.forLoop({
         condition: () => {
-          // [result, enumerator, result, idx, callable]
+          // [idx, size, result, arr, callable]
+          sb.emitOp(node, 'REVERSE4');
+          // [size, idx, size, result, arr, callable]
           sb.emitOp(node, 'OVER');
-          // [enumerator, result, enumerator, result, idx, callable]
+          // [idx, size, idx, size, result, arr, callable]
           sb.emitOp(node, 'OVER');
-          // [boolean, result, enumerator, result, idx, callable]
-          sb.emitSysCall(node, 'System.Iterator.Next');
-          // [boolean, enumerator, result, idx, callable]
+          // [boolean, idx, size, result, arr, callable]
+          sb.emitOp(node, 'GT');
+          // [size, idx, boolean, result, arr, callable]
+          sb.emitOp(node, 'REVERSE3');
+          // [result, boolean, idx, size, arr, callable]
+          sb.emitOp(node, 'REVERSE4');
+          // [result, boolean, result, idx, size, arr, callable]
+          sb.emitOp(node, 'TUCK');
+          // [boolean, result, idx, size, arr, callable]
           sb.emitOp(node, 'BOOLAND');
         },
         each: (innerOptions) => {
-          // [enumerator, idx, callable]
-          sb.emitOp(node, 'NIP');
-          // [enumerator, enumerator, idx, callable]
-          sb.emitOp(node, 'DUP');
-          // [value, enumerator, idx, callable]
-          sb.emitHelper(node, options, sb.helpers.getMapIteratorValue);
-          // [2, value, enumerator, idx, callable]
+          // [idx, size, arr, callable]
+          sb.emitOp(node, 'DROP');
+          // [2, idx, size, arr, callable]
           sb.emitPushInt(node, 2);
-          // [idx, value, enumerator, idx, callable]
+          // [arr, idx, size, arr, callable]
           sb.emitOp(node, 'PICK');
-          // [idx, value, enumerator, idx, callable]
+          // [idx, arr, idx, size, arr, callable]
+          sb.emitOp(node, 'OVER');
+          // [val, idx, size, arr, callable]
+          sb.emitOp(node, 'PICKITEM');
+          // [idx, val, idx, size, arr, callable]
+          sb.emitOp(node, 'OVER');
+          // [idxVal, val, idx, size, arr, callable]
           sb.emitHelper(node, options, sb.helpers.wrapNumber);
-          // [value, idx, enumerator, idx, callable]
+          // [val, idxVal, idx, size, arr, callable]
           sb.emitOp(node, 'SWAP');
-          // [2, value, idx, enumerator, idx, callable]
+          // [2, val, idxVal, idx, size, arr, callable]
           sb.emitPushInt(node, 2);
-          // [argsarr, enumerator, idx, callable]
+          // [argsarr, idx, size, arr, callable]
           sb.emitOp(node, 'PACK');
-          // [3, argsarr, enumerator, idx, callable]
-          sb.emitPushInt(node, 3);
-          // [callable, argsarr, enumerator, idx, callable]
+          // [4, argsarr, idx, size, arr, callable]
+          sb.emitPushInt(node, 4);
+          // [callable, argsarr, idx, size, arr, callable]
           sb.emitOp(node, 'PICK');
-          // [val, enumerator, idx, callable]
+          // [val, idx, size, arr, callable]
           sb.emitHelper(node, sb.pushValueOptions(innerOptions), sb.helpers.call);
-          // [result, enumerator, idx, callable]
+          // [result, idx, size, arr, callable]
           sb.emitHelper(node, sb.pushValueOptions(innerOptions), sb.helpers.unwrapBoolean);
-          // [idx, result, enumerator, callable]
+          // [size, result, idx, arr, callable]
           sb.emitOp(node, 'ROT');
-          // [idx, result, enumerator, callable]
+          // [idx, size, result, arr, callable]
+          sb.emitOp(node, 'ROT');
+          // [idx, size, result, arr, callable]
           sb.emitOp(node, 'INC');
-          // [result, idx, enumerator, callable]
-          sb.emitOp(node, 'SWAP');
-          // [enumerator, result, idx, callable]
-          sb.emitOp(node, 'ROT');
+          // [arr, result, size, idx, callable]
+          sb.emitOp(node, 'REVERSE4');
         },
         cleanup: () => {
-          // [result, idx, callable]
-          sb.emitOp(node, 'DROP');
+          // [result, size, arr, callable]
+          sb.emitOp(node, 'NIP');
+          // [result, arr, callable]
+          sb.emitOp(node, 'NIP');
           // [result, callable]
           sb.emitOp(node, 'NIP');
           // [result]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrEveryWithoutIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrEveryWithoutIteratorHelper.ts
@@ -1,0 +1,107 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+export interface ArrEveryHelperOptions {
+  readonly map?: (options: VisitOptions) => void;
+}
+
+// TODO: this has not been tested because it's not used anywhere
+// Input: [arr]
+// Output: [boolean]
+export class ArrEveryWithoutIteratorHelper extends Helper {
+  private readonly map: (options: VisitOptions) => void;
+
+  public constructor(options: ArrEveryHelperOptions) {
+    super();
+    this.map =
+      options.map === undefined
+        ? () => {
+            // do nothing
+          }
+        : options.map;
+  }
+
+  public emit(sb: ScriptBuilder, node: ts.Node, optionsIn: VisitOptions): void {
+    const options = sb.pushValueOptions(optionsIn);
+
+    // [result, arr]
+    sb.emitPushBoolean(node, true);
+    // [arr, result, arr]
+    sb.emitOp(node, 'OVER');
+    // [size, result, arr]
+    sb.emitOp(node, 'SIZE');
+    // [0, size, result, arr]
+    sb.emitPushInt(node, 0);
+    // [boolean]
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.forLoop({
+        condition: () => {
+          // [size, idx, result, arr]
+          sb.emitOp(node, 'SWAP');
+          // [size, idx, size, result, arr]
+          sb.emitOp(node, 'TUCK');
+          // [idx, size, idx, size, result, arr]
+          sb.emitOp(node, 'OVER');
+          // [size > idx, idx, size, result, arr]
+          sb.emitOp(node, 'GT');
+          // [3, size > idx, idx, size, result, arr]
+          sb.emitPushInt(node, 3);
+          // [result, size > idx, idx, size, result, arr]
+          sb.emitOp(node, 'PICK');
+          // [boolean, idx, size, result, arr]
+          sb.emitOp(node, 'BOOLAND');
+        },
+        each: (innerOptions) => {
+          // [2, idx, size, result, arr]
+          sb.emitPushInt(node, 2);
+          // [result, idx, size, arr]
+          sb.emitOp(node, 'ROLL');
+          // [idx, size, arr]
+          sb.emitOp(node, 'DROP');
+          // [arr, idx, size]
+          sb.emitOp(node, 'ROT');
+          // [idx, arr, idx, size]
+          sb.emitOp(node, 'OVER');
+          // [arr, idx, arr, idx, size]
+          sb.emitOp(node, 'OVER');
+          // [idx, arr, arr, idx, size]
+          sb.emitOp(node, 'SWAP');
+          // [val, arr, idx, size]
+          sb.emitOp(node, 'PICKITEM');
+          // [result, arr, idx, size]
+          // tslint:disable-next-line: no-map-without-usage
+          this.map(sb.pushValueOptions(innerOptions));
+          // [arr, result, idx, size]
+          sb.emitOp(node, 'SWAP');
+          // [size, idx, result, arr]
+          sb.emitOp(node, 'REVERSE4');
+        },
+        incrementor: () => {
+          // [idx, size, result, arr]
+          sb.emitOp(node, 'SWAP');
+          // [idx, size, result, arr]
+          sb.emitOp(node, 'INC');
+          // [size, idx, result, arr]
+          sb.emitOp(node, 'SWAP');
+        },
+        cleanup: () => {
+          // [size, result, arr]
+          sb.emitOp(node, 'DROP');
+          // [result, arr]
+          sb.emitOp(node, 'DROP');
+          // [result]
+          sb.emitOp(node, 'NIP');
+
+          if (!optionsIn.pushValue) {
+            // []
+            sb.emitOp(node, 'DROP');
+          }
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrFilterFuncHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrFilterFuncHelper.ts
@@ -23,10 +23,8 @@ export class ArrFilterFuncHelper extends Helper {
     sb.emitOp(node, 'ROLL');
     // [size, callable, ...arr]
     sb.emitOp(node, 'SWAP');
-    // [0, size, callable, ...arr]
-    sb.emitPushInt(node, 0);
     // [arr, size, callable, ...arr]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [size, arr, callable, ...arr]
     sb.emitOp(node, 'SWAP');
     // [idx, size, arr, callable, ...arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrFilterHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrFilterHelper.ts
@@ -52,10 +52,8 @@ export class ArrFilterHelper extends Helper {
     if (this.withIndex) {
       // [iterator]
       sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [0, iterator]
-      sb.emitPushInt(node, 0);
       // [accum, iterator]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,
@@ -80,10 +78,8 @@ export class ArrFilterHelper extends Helper {
     } else {
       // [enumerator]
       sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [0, enumerator]
-      sb.emitPushInt(node, 0);
       // [accum, enumerator]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrLeftHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrLeftHelper.ts
@@ -20,10 +20,8 @@ export class ArrLeftHelper extends Helper {
     sb.emitOp(node, 'OVER');
     // [size, start, arr]
     sb.emitOp(node, 'SIZE');
-    // [0, size, start, arr]
-    sb.emitPushInt(node, 0);
     // [outputArr, size, start, arr]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [start, outputArr, size, arr]
     sb.emitOp(node, 'ROT');
     // [size, idx, outputArr, arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrMapHelper.ts
@@ -21,25 +21,20 @@ export class ArrMapHelper extends Helper {
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
-    // [map]
-    sb.emitHelper(node, options, sb.helpers.arrToMap);
     if (this.withIndex) {
-      // [iterator]
-      sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [accum, iterator]
+      // [accum, arr]
       sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,
         options,
-        sb.helpers.rawIteratorReduce({
+        sb.helpers.arrReduceWithoutIterator({
+          withIndex: true,
           each: (innerOptions) => {
-            // [val, accum, idx]
-            sb.emitOp(node, 'ROT');
-            // [idx, val, accum]
+            // [idx, accum, val]
             sb.emitOp(node, 'ROT');
             // [val, idx, accum]
-            sb.emitOp(node, 'SWAP');
+            sb.emitOp(node, 'ROT');
             // [val, accum]
             // tslint:disable-next-line no-map-without-usage
             this.map(innerOptions);
@@ -53,15 +48,13 @@ export class ArrMapHelper extends Helper {
         }),
       );
     } else {
-      // [enumerator]
-      sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [accum, enumerator]
+      // [accum, arr]
       sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,
         options,
-        sb.helpers.rawEnumeratorReduce({
+        sb.helpers.arrReduceWithoutIterator({
           each: (innerOptions) => {
             // [accum, val, accum]
             sb.emitOp(node, 'TUCK');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrMapHelper.ts
@@ -26,10 +26,8 @@ export class ArrMapHelper extends Helper {
     if (this.withIndex) {
       // [iterator]
       sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [0, iterator]
-      sb.emitPushInt(node, 0);
       // [accum, iterator]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,
@@ -57,10 +55,8 @@ export class ArrMapHelper extends Helper {
     } else {
       // [enumerator]
       sb.emitHelper(node, options, sb.helpers.createMapIterator);
-      // [0, enumerator]
-      sb.emitPushInt(node, 0);
       // [accum, enumerator]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [accum]
       sb.emitHelper(
         node,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrRangeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrRangeHelper.ts
@@ -29,10 +29,8 @@ export class ArrRangeHelper extends Helper {
     sb.emitOp(node, 'NEWARRAY');
     // [enumerator]
     sb.emitHelper(node, options, sb.helpers.createMapIterator);
-    // [number, enumerator]
-    sb.emitPushInt(node, 0);
     // [arr, enumerator]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [enumerator, arr]
     sb.emitOp(node, 'SWAP');
     // [number, enumerator, arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrReduceWithoutIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrReduceWithoutIteratorHelper.ts
@@ -1,0 +1,93 @@
+import ts from 'typescript';
+import { ScriptBuilder } from '../../sb';
+import { VisitOptions } from '../../types';
+import { Helper } from '../Helper';
+
+export interface ArrReduceWithoutIteratorHelperOptions {
+  readonly each: (options: VisitOptions) => void;
+  readonly withIndex?: boolean;
+}
+
+// Input: [accum, arr]
+// Output: [accum]
+export class ArrReduceWithoutIteratorHelper extends Helper {
+  private readonly each: (options: VisitOptions) => void;
+  private readonly withIndex: boolean;
+
+  public constructor(options: ArrReduceWithoutIteratorHelperOptions) {
+    super();
+    this.each = options.each;
+    this.withIndex = options.withIndex || false;
+  }
+
+  public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
+    // [arr, accum]
+    sb.emitOp(node, 'SWAP');
+    // [arr, arr, accum]
+    sb.emitOp(node, 'DUP');
+    // [size, arr, accum]
+    sb.emitOp(node, 'SIZE');
+    // [0, size, arr, accum]
+    sb.emitPushInt(node, 0);
+    // [accum]
+    sb.emitHelper(
+      node,
+      options,
+      sb.helpers.forLoop({
+        condition: () => {
+          // [size, idx, arr, accum]
+          sb.emitOp(node, 'SWAP');
+          // [size, idx, size, arr, accum]
+          sb.emitOp(node, 'TUCK');
+          // [idx, size, idx, size, arr, accum]
+          sb.emitOp(node, 'OVER');
+          // [size > idx, idx, size, arr, accum]
+          sb.emitOp(node, 'GT');
+        },
+        each: () => {
+          // [2, idx, size, arr, accum]
+          sb.emitPushInt(node, 2);
+          // [arr, idx, size, arr, accum]
+          sb.emitOp(node, 'PICK');
+          // [idx, arr, idx, size, arr, accum]
+          sb.emitOp(node, 'OVER');
+          // [val, idx, size, arr, accum]
+          sb.emitOp(node, 'PICKITEM');
+          // [idx, val, idx, size, arr, accum]
+          sb.emitOp(node, 'OVER');
+          // [5, idx, val, idx, size, arr, accum]
+          sb.emitPushInt(node, 5);
+          // [accum, idx, val, idx, size, arr]
+          sb.emitOp(node, 'ROLL');
+          if (this.withIndex) {
+            // [val, accum, idx, idx, size, arr]
+            sb.emitOp(node, 'ROT');
+            // [accum, val, idx, idx, size, arr]
+            sb.emitOp(node, 'SWAP');
+          } else {
+            // [accum, val, idx, size, arr]
+            sb.emitOp(node, 'NIP');
+          }
+          // [accum, idx, size, arr]
+          this.each(options);
+          // [arr, size, idx, accum]
+          sb.emitOp(node, 'REVERSE4');
+          // [idx, size, arr, accum]
+          sb.emitOp(node, 'REVERSE3');
+        },
+        incrementor: () => {
+          // [idx, size, arr, accum]
+          sb.emitOp(node, 'INC');
+        },
+        cleanup: () => {
+          // [size, arr, accum]
+          sb.emitOp(node, 'DROP');
+          // [arr, accum]
+          sb.emitOp(node, 'DROP');
+          // [accum]
+          sb.emitOp(node, 'DROP');
+        },
+      }),
+    );
+  }
+}

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrToStringHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/ArrToStringHelper.ts
@@ -43,7 +43,7 @@ export class ArrToStringHelper extends TypedHelper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         withIndex: true,
         each: (innerOptions) => {
           sb.emitHelper(

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/index.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/arr/index.ts
@@ -13,6 +13,7 @@ export * from './ArrMapHelper';
 export * from './ArrRangeHelper';
 export * from './ArrReduceFuncHelper';
 export * from './ArrReduceHelper';
+export * from './ArrReduceWithoutIteratorHelper';
 export * from './ArrSomeFuncHelper';
 export * from './ArrSomeHelper';
 export * from './ArrToStringHelper';

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/common/ArrSliceHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/common/ArrSliceHelper.ts
@@ -115,10 +115,8 @@ export class ArrSliceHelper extends Helper {
 
     // [end, idx, arr]
     sb.emitOp(node, 'SWAP');
-    // [0, end, idx, arr]
-    sb.emitPushInt(node, 0);
     // [outputArr, end, idx, arr]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [idx, outputArr, end, arr]
     sb.emitOp(node, 'ROT');
     // [end, idx, outputArr, arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/common/GenericLogSerializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/common/GenericLogSerializeHelper.ts
@@ -42,10 +42,8 @@ export class GenericLogSerializeHelper extends Helper {
     const handleMap = (innerOptions: VisitOptions) => {
       // [map]
       sb.emitHelper(node, innerOptions, sb.helpers.unwrapMap);
-      // [0, map]
-      sb.emitPushInt(node, 0);
       // [arr, map]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       sb.emitHelper(
         node,
         innerOptions,
@@ -80,10 +78,8 @@ export class GenericLogSerializeHelper extends Helper {
     const handleSet = (innerOptions: VisitOptions) => {
       // [map]
       sb.emitHelper(node, innerOptions, sb.helpers.unwrapSet);
-      // [0, map]
-      sb.emitPushInt(node, 0);
       // [arr, map]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       sb.emitHelper(
         node,
         innerOptions,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/createHelpers.ts
@@ -21,6 +21,8 @@ import {
   ArrReduceFuncHelper,
   ArrReduceHelper,
   ArrReduceHelperOptions,
+  ArrReduceWithoutIteratorHelper,
+  ArrReduceWithoutIteratorHelperOptions,
   ArrSomeFuncHelper,
   ArrSomeHelper,
   ArrSomeHelperOptions,
@@ -456,6 +458,7 @@ export interface Helpers {
   readonly arrForEachFunc: ArrForEachFuncHelper;
   readonly arrRange: (options: ArrRangeHelperOptions) => ArrRangeHelper;
   readonly arrReduce: (options: ArrReduceHelperOptions) => ArrReduceHelper;
+  readonly arrReduceWithoutIterator: (options: ArrReduceWithoutIteratorHelperOptions) => ArrReduceWithoutIteratorHelper;
   readonly arrReduceFunc: ArrReduceFuncHelper;
   readonly arrSomeFunc: ArrSomeFuncHelper;
   readonly arrSome: (options: ArrSomeHelperOptions) => ArrSomeHelper;
@@ -933,6 +936,7 @@ export const createHelpers = (prevHelpers?: Helpers): Helpers => {
     arrForEachFunc: new ArrForEachFuncHelper(),
     arrRange: (options) => new ArrRangeHelper(options),
     arrReduce: (options) => new ArrReduceHelper(options),
+    arrReduceWithoutIterator: (options) => new ArrReduceWithoutIteratorHelper(options),
     arrReduceFunc: new ArrReduceFuncHelper(),
     arrSomeFunc: new ArrSomeFuncHelper(),
     arrSome: (options) => new ArrSomeHelper(options),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
@@ -56,10 +56,8 @@ export class ArgumentsHelper extends Helper<ts.CallExpression | ts.NewExpression
     }
 
     if (args.some((arg) => ts.isSpreadElement(arg))) {
-      // [0]
-      sb.emitPushInt(node, 0);
       // [arr]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [arr]
       args.forEach((arg) => {
         const handleArrayLike = () => {

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ArgumentsHelper.ts
@@ -77,7 +77,7 @@ export class ArgumentsHelper extends Helper<ts.CallExpression | ts.NewExpression
           sb.emitHelper(
             arg,
             innerOptions,
-            sb.helpers.arrReduce({
+            sb.helpers.arrReduceWithoutIterator({
               each: handleArrayLike,
             }),
           );

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/InvokeCallHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/InvokeCallHelper.ts
@@ -41,10 +41,8 @@ export class InvokeCallHelper extends Helper {
       sb.helpers.getCallable({ bindThis: this.bindThis, overwriteThis: this.overwriteThis }),
     );
     if (this.noArgs) {
-      // [0, func]
-      sb.emitPushInt(node, 0);
       // [argsarray, func]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [func, argsarray]
       sb.emitOp(node, 'SWAP');
     }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/InvokeConstructHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/InvokeConstructHelper.ts
@@ -27,10 +27,8 @@ export class InvokeConstructHelper extends Helper {
     // [func, ?argsarray]
     sb.emitHelper(node, options, sb.helpers.bindFunctionThis({ overwrite: true }));
     if (this.noArgs) {
-      // [0, func]
-      sb.emitPushInt(node, 0);
       // [argsarray, func]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [func, argsarray]
       sb.emitOp(node, 'SWAP');
     }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ParametersHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/function/ParametersHelper.ts
@@ -36,10 +36,8 @@ export class ParametersHelper extends Helper {
     parameters =
       parameters.length > 0 && tsUtils.node.getName(parameters[0]) === 'this' ? parameters.slice(1) : parameters;
     if (this.asArgsArr) {
-      // [0, argsarr]
-      sb.emitPushInt(node, 0);
       // [outputarr, argsarr]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [argsarr, outputarr]
       sb.emitOp(node, 'SWAP');
     }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/global/CreateGlobalObjectHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/global/CreateGlobalObjectHelper.ts
@@ -60,10 +60,8 @@ export class CreateGlobalObjectHelper extends Helper {
     sb.emitOp(node, 'DUP');
     // [number, map, map]
     sb.emitPushInt(node, GlobalProperty.Modules);
-    // [number, number, map, map]
-    sb.emitPushInt(node, 0);
     // [arr, number, map, map]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [map]
     sb.emitOp(node, 'SETITEM');
     // [map, map]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/IterableIteratorForEachHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/IterableIteratorForEachHelper.ts
@@ -27,10 +27,8 @@ export class IterableIteratorForEachHelper extends Helper {
     sb.emitPushInt(node, IterableIteratorSlots.next);
     // [callable]
     sb.emitOp(node, 'PICKITEM');
-    // [0, argsarr, callable]
-    sb.emitPushInt(node, 0);
     // [argsarr, callable]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     sb.emitHelper(
       node,
       options,
@@ -58,10 +56,8 @@ export class IterableIteratorForEachHelper extends Helper {
           sb.emitPushInt(node, IteratorResultSlots.value);
           // [val, callable]
           sb.emitOp(node, 'PICKITEM');
-          // [0, val, callable]
-          sb.emitPushInt(node, 0);
           // [argsarr, val, callable]
-          sb.emitOp(node, 'NEWARRAY');
+          sb.emitOp(node, 'NEWARRAY0');
           // [val, argsarr, callable]
           sb.emitOp(node, 'SWAP');
           // [argsarr, callable]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/IterableIteratorReduceHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterableIterator/IterableIteratorReduceHelper.ts
@@ -29,10 +29,8 @@ export class IterableIteratorReduceHelper extends Helper {
     sb.emitPushInt(node, IterableIteratorSlots.next);
     // [callable, accum]
     sb.emitOp(node, 'PICKITEM');
-    // [0, argsarr, callable, accum]
-    sb.emitPushInt(node, 0);
     // [argsarr, callable, accum]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [accum, argsarr, callable]
     sb.emitOp(node, 'ROT');
     sb.emitHelper(
@@ -74,10 +72,8 @@ export class IterableIteratorReduceHelper extends Helper {
           sb.emitPushInt(node, IteratorResultSlots.value);
           // [val, accum, callable]
           sb.emitOp(node, 'PICKITEM');
-          // [0, val, accum, callable]
-          sb.emitPushInt(node, 0);
           // [argsarr, val, accum, callable]
-          sb.emitOp(node, 'NEWARRAY');
+          sb.emitOp(node, 'NEWARRAY0');
           // [val, argsarr, accum, callable]
           sb.emitOp(node, 'SWAP');
           // [accum, val, argsarr, callable]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawEnumeratorFilterHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/iterator/RawEnumeratorFilterHelper.ts
@@ -44,10 +44,8 @@ export class RawEnumeratorFilterHelper extends Helper {
       );
     };
 
-    // [0, enumerator]
-    sb.emitPushInt(node, 0);
     // [accum, enumerator]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [accum]
     sb.emitHelper(
       node,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapForEachWithoutIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapForEachWithoutIteratorHelper.ts
@@ -28,6 +28,7 @@ export class MapForEachWithoutIteratorHelper extends Helper {
     sb.emitOp(node, 'SIZE');
     // [idx, size, arr]
     sb.emitPushInt(node, 0);
+    // []
     sb.emitHelper(
       node,
       loopOptions,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapMapHelper.ts
@@ -18,15 +18,13 @@ export class MapMapHelper extends Helper {
   }
 
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
-    // [iterator]
-    sb.emitHelper(node, options, sb.helpers.createMapIterator);
-    // [accum, iterator]
+    // [accum, map]
     sb.emitOp(node, 'NEWMAP');
     // [accum]
     sb.emitHelper(
       node,
       options,
-      sb.helpers.rawIteratorReduce({
+      sb.helpers.mapReduceWithoutIterator({
         each: (innerOptions) => {
           // [accum, accum, key, val]
           sb.emitOp(node, 'DUP');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapReduceWithoutIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapReduceWithoutIteratorHelper.ts
@@ -30,6 +30,7 @@ export class MapReduceWithoutIteratorHelper extends Helper {
     sb.emitOp(node, 'SIZE');
     // [idx, size, keysArr, map, accum]
     sb.emitPushInt(node, 0);
+    // [accum]
     sb.emitHelper(
       node,
       options,
@@ -67,25 +68,29 @@ export class MapReduceWithoutIteratorHelper extends Helper {
           sb.emitOp(node, 'SWAP');
           // [6, key, value, idx, size, keysArr, map, accum]
           sb.emitPushInt(node, 6);
-          // [accum, key, value, idx, size, keysArr, map, accum]
-          sb.emitOp(node, 'PICK');
-          // [accum, idx, size, keysArr, map, accum]
+          // [accum, key, value, idx, size, keysArr, map]
+          sb.emitOp(node, 'ROLL');
+          // [accum, idx, size, keysArr, map]
           this.each(options);
+          // [5, accum, idx, size, keysArr, map]
+          sb.emitPushInt(node, 5);
+          // [map, keysArr, size, idx, accum]
+          sb.emitOp(node, 'REVERSEN');
           // [idx, size, keysArr, map, accum]
-          sb.emitOp(node, 'DROP');
+          sb.emitOp(node, 'REVERSE4');
         },
         incrementor: () => {
           // [idx, size, keysArr, map, accum]
           sb.emitOp(node, 'INC');
         },
         cleanup: () => {
+          // [size, keysArr, map, accum]
+          sb.emitOp(node, 'DROP');
           // [keysArr, map, accum]
           sb.emitOp(node, 'DROP');
           // [map, accum]
           sb.emitOp(node, 'DROP');
           // [accum]
-          sb.emitOp(node, 'DROP');
-          // []
           sb.emitOp(node, 'DROP');
         },
       }),

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapToNestedArrWithoutIteratorHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/MapToNestedArrWithoutIteratorHelper.ts
@@ -9,6 +9,7 @@ export class MapToNestedArrWithoutIteratorHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
     // [accum, map]
     sb.emitOp(node, 'NEWARRAY0');
+    // [accum]
     sb.emitHelper(
       node,
       options,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/NestedArrToMapHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/NestedArrToMapHelper.ts
@@ -12,7 +12,7 @@ export class NestedArrToMapHelper extends Helper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         each: () => {
           // [map, [key, val], map]
           sb.emitOp(node, 'TUCK');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/map/UnusedMapHasKeyHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/map/UnusedMapHasKeyHelper.ts
@@ -3,6 +3,14 @@ import { ScriptBuilder } from '../../sb';
 import { VisitOptions } from '../../types';
 import { Helper } from '../Helper';
 
+// These "unused" map helpers were originally created as a way to get around a change
+// made to the NeoVM which prohibited Compound type stack items from being used as keys
+// in map stack items. But every "object" in our compiled code was a struct with a type
+// as the first item and the value as the second item. We contemplated but abandoned this
+// solution below to have a two maps within a struct. One map to store type information on a key
+// and other map to store value information for a the same key. This solution was abandoned for
+// instead just binary serializing and binary deserializing keys.
+
 // Input: [keyVal, map] - Note that "map" here is actually a struct [typeMap, valueMap]
 // Output: [hasKey]
 export class UnusedMapHasKeyHelper extends Helper {

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/AtStructuredStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/AtStructuredStorageHelper.ts
@@ -29,7 +29,7 @@ export class AtStructuredStorageHelper extends KeyStructuredStorageBaseHelper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         each: (innerOptions) => {
           // [struct]
           sb.emitHelper(node, innerOptions, sb.helpers.handlePrefixArrayStructuredStorage);

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CacheStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CacheStorageHelper.ts
@@ -44,7 +44,7 @@ export class CacheStorageHelper extends Helper {
           sb.emitHelper(
             node,
             options,
-            sb.helpers.mapForEach({
+            sb.helpers.mapForEachWithoutIterator({
               each: () => {
                 // [context, keyBuffer, valBuffer]
                 sb.emitSysCall(node, 'System.Storage.GetContext');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CreateStructuredStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/CreateStructuredStorageHelper.ts
@@ -26,10 +26,8 @@ export class CreateStructuredStorageHelper extends StructuredStorageBaseHelper {
       return;
     }
 
-    // [0]
-    sb.emitPushInt(node, 0);
     // [arr]
-    sb.emitOp(node, 'NEWARRAY');
+    sb.emitOp(node, 'NEWARRAY0');
     // [size, arr]
     sb.emitPushInt(node, 0);
     // [prefix, size, arr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteCacheStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteCacheStorageHelper.ts
@@ -44,7 +44,7 @@ export class DeleteCacheStorageHelper extends Helper {
           sb.emitHelper(
             node,
             options,
-            sb.helpers.mapForEach({
+            sb.helpers.mapForEachWithoutIterator({
               each: () => {
                 // [context, keyBuffer, valBuffer]
                 sb.emitSysCall(node, 'System.Storage.GetContext');

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteIteratorCacheStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/DeleteIteratorCacheStorageHelper.ts
@@ -40,12 +40,16 @@ export class DeleteIteratorCacheStorageHelper extends Helper {
           sb.emitOp(node, 'NUMEQUAL');
         },
         whenTrue: () => {
+          // [map]
+          sb.emitHelper(node, options, sb.helpers.arrToMap);
           // []
           sb.emitHelper(
             node,
             options,
-            sb.helpers.arrForEach({
+            sb.helpers.mapForEachWithoutIterator({
               each: () => {
+                // [valBuffer]
+                sb.emitOp(node, 'DROP');
                 // [context, valBuffer]
                 sb.emitSysCall(node, 'System.Storage.GetContext');
                 // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetKeyStructuredStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetKeyStructuredStorageHelper.ts
@@ -20,6 +20,8 @@ export class GetKeyStructuredStorageHelper extends KeyStructuredStorageBaseHelpe
         knownType: this.knownKeyType,
       }),
     );
+    // [valKeyMap, val]
+    sb.emitHelper(node, options, sb.helpers.arrToMap);
     // [val, valKeyArr]
     sb.emitOp(node, 'SWAP');
     // [struct, valKeyArr]
@@ -32,8 +34,10 @@ export class GetKeyStructuredStorageHelper extends KeyStructuredStorageBaseHelpe
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.mapReduceWithoutIterator({
         each: () => {
+          // [prefix, val]
+          sb.emitOp(node, 'NIP');
           // [val, prefix]
           sb.emitOp(node, 'SWAP');
           // [buffer, prefix]
@@ -43,7 +47,7 @@ export class GetKeyStructuredStorageHelper extends KeyStructuredStorageBaseHelpe
         },
       }),
     );
-    // [bytestring]
+    // [prefix]
     sb.emitOp(node, 'CONVERT', Buffer.from([StackItemType.ByteString]));
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetStorageBaseHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/GetStorageBaseHelper.ts
@@ -29,8 +29,12 @@ export class GetStorageBaseHelper extends Helper {
           sb.emitSysCall(node, 'System.Iterator.Next');
         },
         whenTrue: () => {
+          // [[key, value]]
+          sb.emitSysCall(node, 'System.Iterator.Value');
+          // [1, [key, value]]
+          sb.emitPushInt(node, 1);
           // [value]
-          sb.emitHelper(node, options, sb.helpers.getMapIteratorValue);
+          sb.emitOp(node, 'PICKITEM');
         },
         whenFalse: () => {
           // []

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/IterStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/IterStorageHelper.ts
@@ -58,7 +58,7 @@ export class IterStorageHelper extends Helper {
     // It's important that these arrays are in this order before being concatenated
     // so that the cached values are read later in the iteration when converting the
     // concatenated array into a map. If there are duplicate keys in the map then the later
-    // ones the cache will override the previous ones from storage
+    // ones in the cache will override the previous ones from storage
     // [cacheArr, storageArr]
     sb.emitHelper(node, options, sb.helpers.mapToNestedArr);
     // [nestedArr]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/SetStructuredStorageHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/storage/SetStructuredStorageHelper.ts
@@ -30,7 +30,7 @@ export class SetStructuredStorageHelper extends KeyStructuredStorageBaseHelper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         each: (innerOptions) => {
           // [struct]
           sb.emitHelper(node, innerOptions, sb.helpers.handlePrefixArrayStructuredStorage);

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/UnwrapCopyStructHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/UnwrapCopyStructHelper.ts
@@ -29,7 +29,7 @@ export abstract class UnwrapCopyStructHelper extends UnwrapHelper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         withIndex: true,
         each: () => {
           // [accum, accum, val, idx]

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/array/CreateArrayHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/array/CreateArrayHelper.ts
@@ -8,10 +8,8 @@ import { Helper } from '../../Helper';
 export class CreateArrayHelper extends Helper {
   public emit(sb: ScriptBuilder, node: ts.Node, options: VisitOptions): void {
     if (options.pushValue) {
-      // [0]
-      sb.emitPushInt(node, 0);
       // [arr]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [val]
       sb.emitHelper(node, options, sb.helpers.wrapArray);
     }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/types/buffer/ConcatBufferHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/types/buffer/ConcatBufferHelper.ts
@@ -19,7 +19,7 @@ export class ConcatBufferHelper extends Helper {
     sb.emitHelper(
       node,
       options,
-      sb.helpers.arrReduce({
+      sb.helpers.arrReduceWithoutIterator({
         withIndex: false,
         each: (innerOptions) => {
           // [bufferVal, accum]

--- a/packages/neo-one-smart-contract-compiler/src/compile/scope/ResolvedScope.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/scope/ResolvedScope.ts
@@ -182,10 +182,8 @@ export class ResolvedScope implements Scope {
       sb.emitHelper(node, sb.pushValueOptions(options), sb.helpers.wrapUndefined);
       // [this, global]
       sb.emitHelper(node, sb.pushValueOptions(options), sb.helpers.wrapUndefined);
-      // [0, this, global]
-      sb.emitPushInt(node, 0);
       // [scopes, this, global]
-      sb.emitOp(node, 'NEWARRAY');
+      sb.emitOp(node, 'NEWARRAY0');
       // [3, scopes, this, global]
       sb.emitPushInt(node, 3);
       // [[scopes, this, global]]

--- a/packages/neo-one-smart-contract-test/src/__data__/tokenUtils.ts
+++ b/packages/neo-one-smart-contract-test/src/__data__/tokenUtils.ts
@@ -137,17 +137,13 @@ export const testToken = async ({
       }
       expect(event.parameters.amount.toString()).toEqual(transferValue.toString());
 
-      const [
-        transferMasterBalance,
-        transferAccountBalance,
-        transferTotalSupply,
-        transferZeroBalance,
-      ] = await Promise.all([
-        smartContract.balanceOf(masterAccountID.address),
-        smartContract.balanceOf(account0.address),
-        smartContract.totalSupply(),
-        smartContract.balanceOf(privateKeyToAddress(ZERO.PRIVATE_KEY)),
-      ]);
+      const [transferMasterBalance, transferAccountBalance, transferTotalSupply, transferZeroBalance] =
+        await Promise.all([
+          smartContract.balanceOf(masterAccountID.address),
+          smartContract.balanceOf(account0.address),
+          smartContract.totalSupply(),
+          smartContract.balanceOf(privateKeyToAddress(ZERO.PRIVATE_KEY)),
+        ]);
 
       const remainingValue = issueValue.minus(transferValue);
       expect(transferMasterBalance.toString()).toEqual(remainingValue.toString());

--- a/packages/neo-one-smart-contract-test/src/__tests__/__snapshots__/TestToken.test.ts.snap
+++ b/packages/neo-one-smart-contract-test/src/__tests__/__snapshots__/TestToken.test.ts.snap
@@ -82,7 +82,7 @@ Array [
 ]
 `;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: contract hash 1`] = `"0xcaf8bc2be457bb9608fbc0389e2231d8e8a6a865"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: contract hash 1`] = `"0xcb8f588dc44ec1361cdd5371119e7af6a0c89db8"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: contract methods 1`] = `
 Array [
@@ -353,8 +353,8 @@ Array [
 ]
 `;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"88904180"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: deploy consumed 1`] = `"73148300"`;
 
 exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: nef tokens 1`] = `Array []`;
 
-exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"127470820"`;
+exports[`TestToken properties + issue + balanceOf + totalSupply + transfer: transfer consume 1`] = `"90319720"`;


### PR DESCRIPTION
### Description of the Change

- Replace any new empty array creations with `NEWARRAY0` instead of pushing 0 and then calling `NEWARRAY`
- Try to replace the use of iterators (ones created with `createMapIterator` helper) everywhere. Usually by using a new reduce helper or a forLoop helper.
- Update compiler test `block.test.ts`

### Test Plan

Various array and map builtin compiler tests.

### Alternate Designs

None.

### Benefits

Removes the use of very expensive and non-constant storage iterators which were/are being created with `createMapIterator` helper. That helper was created as a work-around to the removal of the iterator APIs from the VM. But it turned out that this was not a great solution since it modified contract storage, causing nearly all contract methods to use storage (and thus not be "constant" methods) and caused contract call prices to go way up.

### Possible Drawbacks

None.

### Applicable Issues

#2410 
