### PR TITLE
fix(cli): fix config on windows and website

### DIFF
--- a/packages/neo-one-cli-common-node/package.json
+++ b/packages/neo-one-cli-common-node/package.json
@@ -16,6 +16,7 @@
     "@neo-one/cli-common": "^3.1.0",
     "@neo-one/client-core": "^3.1.0",
     "@neo-one/client-full-core": "^3.1.0",
+    "@neo-one/utils": "^3.1.0",
     "@types/lodash": "^4.14.138",
     "cosmiconfig": "^6.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/neo-one-cli-common-node/src/configuration.ts
+++ b/packages/neo-one-cli-common-node/src/configuration.ts
@@ -1,5 +1,6 @@
 // tslint:disable no-any
 import { CodegenFramework, CodegenLanguage, Configuration } from '@neo-one/cli-common';
+import { normalizePath } from '@neo-one/utils';
 import { cosmiconfig } from 'cosmiconfig';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
@@ -153,28 +154,28 @@ const relativizePaths = (config: Configuration) => ({
   ...config,
   artifacts: {
     ...config.artifacts,
-    path: nodePath.relative(process.cwd(), config.artifacts.path),
+    path: normalizePath(nodePath.relative(process.cwd(), config.artifacts.path)),
   },
   migration: {
     ...config.migration,
-    path: nodePath.relative(process.cwd(), config.migration.path),
+    path: normalizePath(nodePath.relative(process.cwd(), config.migration.path)),
   },
   contracts: {
     ...config.contracts,
-    outDir: nodePath.relative(process.cwd(), config.contracts.outDir),
-    path: nodePath.relative(process.cwd(), config.contracts.path),
+    outDir: normalizePath(nodePath.relative(process.cwd(), config.contracts.outDir)),
+    path: normalizePath(nodePath.relative(process.cwd(), config.contracts.path)),
   },
   codegen: {
     ...config.codegen,
-    path: nodePath.relative(process.cwd(), config.codegen.path),
+    path: normalizePath(nodePath.relative(process.cwd(), config.codegen.path)),
   },
   network: {
     ...config.network,
-    path: nodePath.relative(process.cwd(), config.network.path),
+    path: normalizePath(nodePath.relative(process.cwd(), config.network.path)),
   },
   neotracker: {
     ...config.neotracker,
-    path: nodePath.relative(process.cwd(), config.neotracker.path),
+    path: normalizePath(nodePath.relative(process.cwd(), config.neotracker.path)),
   },
 });
 

--- a/packages/neo-one-website/docs/0-installation/0-quick-start.md
+++ b/packages/neo-one-website/docs/0-installation/0-quick-start.md
@@ -51,7 +51,7 @@ This tells your local C# .NET runtime to use version 3.1.401 in this repo, even 
 
 4. Follow the [installation instructions for Create React App](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) to make a new project.
 
-   - Be sure to invoke Create React App with the `--template typescript` in order to enable TypeScript support: `npx create-react-app token --template typescript`
+   - Be sure to invoke Create React App with `--template typescript` in order to enable TypeScript support: `npx create-react-app token --template typescript`
 
 5. Install NEO•ONE using either [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/)
 

--- a/packages/neo-one-website/tutorial/tutorial.md
+++ b/packages/neo-one-website/tutorial/tutorial.md
@@ -71,7 +71,7 @@ This tells your local C# .NET runtime to use version 3.1.401 in this repo, even 
 
 4. Follow the [installation instructions for Create React App](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) to make a new project.
 
-- Be sure to invoke Create React App with the `--typescript` flag in order to enable TypeScript support: `npx create-react-app token --typescript`
+- Be sure to invoke Create React App with `--template typescript` in order to enable TypeScript support: `npx create-react-app token --template typescript`
 
 5. Change your current working directory into your new `token` directory created by `create-react-app` by running `cd token` or `cd <path/to/your/new/token/directory>`
 


### PR DESCRIPTION
### Description of the Change

- Updates how we resolve paths before writing them to the final config file so that those paths will work on Windows and Unix platforms. This came up when users on Windows would try `neo-one build` and would get an error when it tried to start the development network. What was happening was it was using `fs.ensureDir()` on a file path that had `\n` in it from `.neo-one\network` (on Windows) which is obviously a newline character on Windows and thus was trying to run `mkdir` on an invalid path. By normalizing the paths we still write `.neo-one/network` even on Windows. But Windows will still use this as a valid path without reading a newline character.
- Also makes minor fixes to the website docs


### Test Plan

Tested manually in a neo-one project on macOS and Windows 10.

### Alternate Designs

None.

### Benefits

NEO•ONE works on Windows.

### Possible Drawbacks

Could have unforeseen consequences since I'm not super familiar with path delimiters in Windows.

### Applicable Issues

None.