### PR TITLE
fix(client): add back dev-tools

### DIFF
--- a/packages/neo-one-client/package.json
+++ b/packages/neo-one-client/package.json
@@ -14,7 +14,8 @@
   "sideEffects": false,
   "dependencies": {
     "@neo-one/client-common": "^3.1.0",
-    "@neo-one/client-core": "^3.1.0"
+    "@neo-one/client-core": "^3.1.0",
+    "@neo-one/developer-tools": "^3.0.0"
   },
   "devDependencies": {
     "@neo-one/build-tools": "^1.0.0",

--- a/packages/neo-one-client/src/index.ts
+++ b/packages/neo-one-client/src/index.ts
@@ -207,4 +207,4 @@ export {
   nep17,
 } from '@neo-one/client-core';
 
-// export { DeveloperTools } from '@neo-one/developer-tools'; // TODO: add back
+export { DeveloperTools } from '@neo-one/developer-tools';


### PR DESCRIPTION
### Description of the Change

See title.

### Test Plan

- `rush build -t @neo-one/developer-tools`
- `rush build -t @neo-one/client`

### Alternate Designs

None.

### Benefits

Dev tools back in client package.

### Possible Drawbacks

None.

### Applicable Issues

#2198