### PR TITLE
fix(cli): remove nt feature from n3 cli

### DIFF
--- a/packages/neo-one-cli/src/cmd/start/neotracker.ts
+++ b/packages/neo-one-cli/src/cmd/start/neotracker.ts
@@ -13,6 +13,7 @@ export const builder = (yargsBuilder: typeof yargs) =>
   yargsBuilder.boolean('reset').describe('reset', 'Reset the NEO Tracker database.').default('reset', false);
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async (_cmd, config) => {
+    throw new Error('This feature is not yet implemented');
     const running = await isRunning(config.neotracker.port);
     if (running) {
       if (argv.reset) {

--- a/packages/neo-one-smart-contract-compiler/src/compile/expression/ElementAccessExpressionCompiler.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/expression/ElementAccessExpressionCompiler.ts
@@ -91,51 +91,53 @@ export class ElementAccessExpressionCompiler extends NodeCompiler<ts.ElementAcce
       isOptionalChain ? processUndefined(innerOptions) : throwTypeError(innerOptions);
     };
 
-    const createHandleProp = (
-      handleString: (options: VisitOptions) => void,
-      handleNumber: (options: VisitOptions) => void,
-      handleSymbol: (options: VisitOptions) => void,
-    ) => (innerOptions: VisitOptions) => {
-      // [propVal, objectVal]
-      sb.visit(prop, innerOptions);
-      sb.emitHelper(
-        prop,
-        innerOptions,
-        sb.helpers.forBuiltinType({
-          type: propType,
-          array: throwInnerTypeError,
-          arrayStorage: throwInnerTypeError,
-          boolean: throwInnerTypeError,
-          buffer: throwInnerTypeError,
-          null: throwInnerTypeError,
-          number: handleNumber,
-          object: throwInnerTypeError,
-          string: handleString,
-          symbol: handleSymbol,
-          undefined: throwInnerTypeError,
-          map: throwInnerTypeError,
-          mapStorage: throwInnerTypeError,
-          set: throwInnerTypeError,
-          setStorage: throwInnerTypeError,
-          error: throwInnerTypeError,
-          forwardValue: throwInnerTypeError,
-          iteratorResult: throwInnerTypeError,
-          iterable: throwInnerTypeError,
-          iterableIterator: throwInnerTypeError,
-          transaction: throwInnerTypeError,
-          attribute: throwInnerTypeError,
-          contract: throwInnerTypeError,
-          block: throwInnerTypeError,
-          contractManifest: throwInnerTypeError,
-          contractABI: throwInnerTypeError,
-          contractMethod: throwInnerTypeError,
-          contractEvent: throwInnerTypeError,
-          contractParameter: throwInnerTypeError,
-          contractGroup: throwInnerTypeError,
-          contractPermission: throwInnerTypeError,
-        }),
-      );
-    };
+    const createHandleProp =
+      (
+        handleString: (options: VisitOptions) => void,
+        handleNumber: (options: VisitOptions) => void,
+        handleSymbol: (options: VisitOptions) => void,
+      ) =>
+      (innerOptions: VisitOptions) => {
+        // [propVal, objectVal]
+        sb.visit(prop, innerOptions);
+        sb.emitHelper(
+          prop,
+          innerOptions,
+          sb.helpers.forBuiltinType({
+            type: propType,
+            array: throwInnerTypeError,
+            arrayStorage: throwInnerTypeError,
+            boolean: throwInnerTypeError,
+            buffer: throwInnerTypeError,
+            null: throwInnerTypeError,
+            number: handleNumber,
+            object: throwInnerTypeError,
+            string: handleString,
+            symbol: handleSymbol,
+            undefined: throwInnerTypeError,
+            map: throwInnerTypeError,
+            mapStorage: throwInnerTypeError,
+            set: throwInnerTypeError,
+            setStorage: throwInnerTypeError,
+            error: throwInnerTypeError,
+            forwardValue: throwInnerTypeError,
+            iteratorResult: throwInnerTypeError,
+            iterable: throwInnerTypeError,
+            iterableIterator: throwInnerTypeError,
+            transaction: throwInnerTypeError,
+            attribute: throwInnerTypeError,
+            contract: throwInnerTypeError,
+            block: throwInnerTypeError,
+            contractManifest: throwInnerTypeError,
+            contractABI: throwInnerTypeError,
+            contractMethod: throwInnerTypeError,
+            contractEvent: throwInnerTypeError,
+            contractParameter: throwInnerTypeError,
+            contractGroup: throwInnerTypeError,
+            contractPermission: throwInnerTypeError,
+          }),
+        );
+      };
 
     const createProcessBuiltin = (name: string) => {
       const handleStringBase = (innerInnerOptions: VisitOptions) => {


### PR DESCRIPTION
### Description of the Change

Add an error thrown when a user tries to use the CLI command `neo-one start neotracker`, which isn't implemented yet.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Best UX.

### Possible Drawbacks

None.

### Applicable Issues

#2428