### PR TITLE
feat(cli): update debugger output for v1.2 of neo debug spec

### DIFF
--- a/packages/neo-one-cli/src/compile/writeContract.ts
+++ b/packages/neo-one-cli/src/compile/writeContract.ts
@@ -153,6 +153,7 @@ export const writeContract = async (
       entrypoint: '0',
       documents: debugInfo.documents,
       methods: [jmpMethod, dispatcherMethod, ...methods],
+      'static-variables': ['scope,Array,0'],
       events: manifest.abi.events.map((event, index) => ({
         id: `${lastID + index}`,
         name: `${contract.manifest.name}-${event.name}`,


### PR DESCRIPTION
### Description of the Change

- Updates debug output for v1.2 of Neo Debug Info Spec.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Fits Neo Debug Spec.

### Possible Drawbacks

The new `static-variables` output is not tied to the programmatic output of the compiler. It's hard-coded to the correct output (for now). Thus the use of static variable slots could change in our compiler down the line and the updater would have to remember to update this debugger output.

### Applicable Issues

#2451