### PR TITLE
fix(node): fix p2p error and add logging

### DIFF
--- a/packages/neo-one-node-core/src/Signer.ts
+++ b/packages/neo-one-node-core/src/Signer.ts
@@ -19,8 +19,10 @@ export class Signer extends SignerModel implements SerializableJSON<SignerJSON> 
     if (witnessScopeHasFlag(scopes, WitnessScopeModel.Global) && scopes !== WitnessScopeModel.Global) {
       throw new InvalidFormatError('Only the global scope should have the global flag');
     }
-    const allowedContracts = hasCustomContracts(scopes) ? reader.readArray(reader.readUInt160, this.maxSubItems) : [];
-    const allowedGroups = hasCustomGroups(scopes) ? reader.readArray(reader.readECPoint, this.maxSubItems) : [];
+    const allowedContracts = hasCustomContracts(scopes)
+      ? reader.readArray(() => reader.readUInt160(), this.maxSubItems)
+      : [];
+    const allowedGroups = hasCustomGroups(scopes) ? reader.readArray(() => reader.readECPoint(), this.maxSubItems) : [];
 
     return new Signer({
       account,

--- a/packages/neo-one-node-protocol/src/Message.ts
+++ b/packages/neo-one-node-protocol/src/Message.ts
@@ -311,6 +311,8 @@ export class MessageTransform extends Transform {
       mutableMessages.forEach((message) => this.push(message));
       callback(undefined);
     } catch (error) {
+      // tslint:disable-next-line: no-console
+      console.log(error);
       callback(error);
     }
   }

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -535,8 +535,8 @@ export class Node implements INode {
         })
       : undefined;
 
-    const verackMessage = Message.create({ command: Command.Verack });
-    this.sendMessage(peer, verackMessage);
+    this.sendMessage(peer, Message.create({ command: Command.Verack }));
+
     const nextMessage = await peer.receiveMessage(30000);
     if (nextMessage.value.command !== Command.Verack) {
       throw new NegotiationError(nextMessage, 'Expected Verack');


### PR DESCRIPTION
### Description of the Change

- Fixes a simple JS function binding bug that was very difficult to find due to logging P2P errors.
- Adds a simple log to catch this type of thing more easily in the future.

### Test Plan

Continued node sync locally works.

### Alternate Designs

The new logging in `MessageTransform` can and should be better but didn't have time to work that in correctly now and just added a `console.log`.

### Benefits

Node working. And better error logging.

### Possible Drawbacks

None.

### Applicable Issues

#2480 
#2410