### PR TITLE
fix(compiler): fix parsing/validation of trusts array in contract props

### DIFF
--- a/packages/neo-one-client-common/src/common.ts
+++ b/packages/neo-one-client-common/src/common.ts
@@ -29,6 +29,16 @@ const UINT160_BUFFER_BYTES = 20;
 
 const isUInt160 = (value: {}): value is UInt160 => value instanceof Buffer && value.length === UINT160_BUFFER_BYTES;
 
+const stringIsValidUInt160 = (value: string): boolean => {
+  try {
+    stringToUInt160(value);
+  } catch {
+    return false;
+  }
+
+  return true;
+};
+
 const asUInt160 = (value: {}): UInt160 => {
   if (isUInt160(value)) {
     return value;
@@ -64,6 +74,16 @@ const ZERO_UINT256 = Buffer.alloc(UINT256_BUFFER_BYTES, 0) as UInt256;
 const MAX_UINT256 = Buffer.alloc(UINT256_BUFFER_BYTES, 0xff) as UInt256;
 
 const isUInt256 = (value: {}): value is UInt256 => value instanceof Buffer && value.length === UINT256_BUFFER_BYTES;
+
+const stringIsValidUInt256 = (value: string): boolean => {
+  try {
+    stringToUInt256(value);
+  } catch {
+    return false;
+  }
+
+  return true;
+};
 
 const asUInt256 = (value: {}): UInt256 => {
   if (isUInt256(value)) {
@@ -104,6 +124,16 @@ const ECPOINT_INFINITY = Buffer.from([ECPOINT_INFINITY_BYTE]) as ECPointInfinity
 
 const isECPoint = (value: {}): value is ECPoint =>
   value instanceof Buffer && (value.length === ECPOINT_BUFFER_BYTES || value.equals(ECPOINT_INFINITY));
+
+const stringIsValidECPoint = (value: string): boolean => {
+  try {
+    stringToECPoint(value);
+  } catch {
+    return false;
+  }
+
+  return true;
+};
 
 const asECPoint = (value: {}): ECPoint => {
   if (isECPoint(value)) {
@@ -290,10 +320,13 @@ export const common = {
   stringToUInt160,
   uInt160Equal,
   isUInt160,
+  stringIsValidUInt160,
   bufferToUInt160,
   isUInt256,
+  stringIsValidUInt256,
   asUInt256,
   isECPoint,
+  stringIsValidECPoint,
   asECPoint,
   uInt256ToBuffer,
   bufferToUInt256,

--- a/packages/neo-one-client-full-common/src/__data__/models.ts
+++ b/packages/neo-one-client-full-common/src/__data__/models.ts
@@ -110,7 +110,7 @@ export const contractPermissionModel = (
 ) => new ContractPermissionModel({ contract: contractPermissionDescriptorModel(hashOrGroupType), methods });
 
 export const contractManifestModel = (
-  name: string = 'name1',
+  name = 'name1',
   groups: readonly ContractGroupModel[] = [contractGroupModel()],
   abi: ContractABIModel = contractAbiModel(),
   permissions: readonly ContractPermissionModel[] = [contractPermissionModel('uint160', ['method1'])],

--- a/packages/neo-one-client-full-common/src/models/manifest/ContractPermissionDescriptorModel.ts
+++ b/packages/neo-one-client-full-common/src/models/manifest/ContractPermissionDescriptorModel.ts
@@ -12,6 +12,16 @@ export interface ContractPermissionDescriptorModelAdd {
 }
 
 export class ContractPermissionDescriptorModel implements SerializableJSON<ContractPermissionDescriptorJSON> {
+  public static hashOrGroupFromString(stringIn: string): UInt160 | ECPoint | Wildcard {
+    if (common.stringIsValidUInt160(stringIn)) {
+      return common.stringToUInt160(stringIn);
+    }
+    if (common.stringIsValidECPoint(stringIn)) {
+      return common.stringToECPoint(stringIn);
+    }
+
+    return '*';
+  }
   public readonly hashOrGroup: UInt160 | ECPoint | Wildcard;
 
   public constructor({ hashOrGroup }: ContractPermissionDescriptorModelAdd = {}) {

--- a/packages/neo-one-smart-contract-compiler/src/compile/getSmartContractInfo.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/getSmartContractInfo.ts
@@ -144,7 +144,6 @@ export interface SmartContractInfo {
   readonly manifest: SmartContractInfoManifest;
 }
 
-// TODO: should name be in SmartContractInfoManifest?
 export const getSmartContractInfo = (context: Context, sourceFile: ts.SourceFile): SmartContractInfo => {
   const smartContract = getSmartContract(context, sourceFile);
   const contractInfo = smartContract === undefined ? undefined : getContractInfo(context, smartContract);

--- a/packages/neo-one-smart-contract-compiler/src/contract/ManifestSmartContractProcessor.ts
+++ b/packages/neo-one-smart-contract-compiler/src/contract/ManifestSmartContractProcessor.ts
@@ -1,6 +1,7 @@
 import {
   ABIParameter,
   ABIReturn,
+  common,
   ContractEventDescriptorClient,
   ContractGroup,
   ContractPermission,
@@ -9,6 +10,7 @@ import {
   WildcardContainer,
 } from '@neo-one/client-common';
 import { NEO_ONE_METHOD_RESERVED_PARAM } from '@neo-one/client-core';
+import { ContractPermissionDescriptorModel } from '@neo-one/client-full-common';
 import { tsUtils } from '@neo-one/ts-utils';
 import { utils } from '@neo-one/utils';
 import _ from 'lodash';
@@ -70,7 +72,13 @@ export class ManifestSmartContractProcessor {
   }
 
   private processTrusts(): WildcardContainer<ContractPermissionDescriptor> {
-    return this.properties.trusts;
+    return common.isWildcard(this.properties.trusts)
+      ? '*'
+      : this.properties.trusts.map((trust) =>
+          new ContractPermissionDescriptorModel({
+            hashOrGroup: ContractPermissionDescriptorModel.hashOrGroupFromString(trust),
+          }).serializeJSON(),
+        );
   }
 
   private processSupportedStandards(): readonly string[] {

--- a/packages/neo-one-smart-contract-compiler/src/contract/getContractProperties.ts
+++ b/packages/neo-one-smart-contract-compiler/src/contract/getContractProperties.ts
@@ -155,7 +155,7 @@ export const getContractProperties = (context: Context, smartContract: ts.ClassD
         }
 
         // tslint:disable-next-line: no-array-mutation
-        finalGroupsArray.push((newObjToPush as unknown) as ContractGroup);
+        finalGroupsArray.push(newObjToPush as unknown as ContractGroup);
       });
 
       // tslint:disable-next-line: no-object-mutation
@@ -360,7 +360,7 @@ export const getContractProperties = (context: Context, smartContract: ts.ClassD
         }
 
         // tslint:disable-next-line: no-array-mutation
-        finalPermissionsArray.push((permissionObject as unknown) as ContractPermission);
+        finalPermissionsArray.push(permissionObject as unknown as ContractPermission);
       });
 
       // tslint:disable-next-line: no-object-mutation
@@ -413,11 +413,10 @@ export const getContractProperties = (context: Context, smartContract: ts.ClassD
 
         const literalString = tsUtils.literal.getLiteralValue(elem);
 
-        try {
-          common.stringToUInt160(literalString);
+        if (common.stringIsValidUInt160(literalString) || common.stringIsValidECPoint(literalString)) {
           // tslint:disable-next-line: no-array-mutation
           finalTrustsArray.push(literalString);
-        } catch {
+        } else {
           context.reportError(
             elem,
             DiagnosticCode.InvalidContractProperties,


### PR DESCRIPTION
### Description of the Change

- Fixes #2479

### Test Plan

Not tested.

### Alternate Designs

None.

### Benefits

The `trusts` property is now properly parsed for the correct client format.

### Possible Drawbacks

Not thoroughly tested. Could lead to compiler errors.

### Applicable Issues

#2479 
#2410 