### PR TITLE
feat(node): update node-offline chainfile sync for n3

### DIFF
--- a/packages/neo-one-node-bin/src/cmd.ts
+++ b/packages/neo-one-node-bin/src/cmd.ts
@@ -8,14 +8,17 @@ const start = createStart(nodeLogger);
 
 export const command = 'neo-one-node';
 export const describe = 'Start a NEO•ONE node.';
-export const builder = (yargsBuilder: typeof yargs) => yargsBuilder.string('chain-file').string('dump-chain-file');
+export const builder = (yargsBuilder: typeof yargs) =>
+  yargsBuilder.string('chain-file').boolean('readStart').string('dump-chain-file').boolean('writeStart');
 export const handler = (argv: Yarguments<ReturnType<typeof builder>>) => {
   start(async () => {
     const options = getOptions();
     const fullNode = new FullNode({
       options,
+      readStart: argv.readStart,
       chainFile: argv['chain-file'],
       dumpChainFile: argv['dump-chain-file'],
+      writeStart: argv.writeStart,
     });
     await fullNode.start();
 

--- a/packages/neo-one-node/src/startFullNode.ts
+++ b/packages/neo-one-node/src/startFullNode.ts
@@ -36,6 +36,8 @@ export interface Options {
 export interface FullNodeOptions {
   readonly options: Options;
   readonly chainFile?: string;
+  readonly readStart?: boolean;
+  readonly writeStart?: boolean;
   readonly dumpChainFile?: string;
   readonly leveldown?: AbstractLevelDOWN;
 }
@@ -61,6 +63,8 @@ export const startFullNode = async ({
     rpc: rpcOptions = {},
   },
   chainFile,
+  readStart,
+  writeStart,
   dumpChainFile,
   leveldown: customLeveldown,
 }: FullNodeOptions): Promise<Disposable> => {
@@ -124,6 +128,7 @@ export const startFullNode = async ({
       await loadChain({
         chain: { format: 'raw', path: chainFile },
         blockchain,
+        readStart,
       });
     }
 
@@ -131,6 +136,7 @@ export const startFullNode = async ({
       await dumpChain({
         path: dumpChainFile,
         blockchain,
+        writeStart,
       });
     }
 


### PR DESCRIPTION
### Description of the Change

- Updates chainfile sync and chainfile dump with "write start" and "read start". We now have the option to write/read the start block of the chainfile with the first four bytes. So it's possible that a chainfile has the start index instead of just the count first instead of the number of blocks. This allows for that now.

### Test Plan

Tested manually. Works.

### Alternate Designs

None.

### Benefits

Proper chainfile sync/dump in N3.

### Possible Drawbacks

None.

### Applicable Issues

#2410 
#2157 