### PR TITLE
Documentation improvements.

### DIFF
--- a/packages/neo-one-website/docs/0-installation/0-quick-start.md
+++ b/packages/neo-one-website/docs/0-installation/0-quick-start.md
@@ -36,18 +36,18 @@ Tip
    - Linux and Mac: [Node Version Manager](https://github.com/creationix/nvm). (`recommended`)
    - Windows: We recommend using [Chocolatey](https://chocolatey.org/). (`recommended`)
 
-2. Install [C# .NET](https://docs.microsoft.com/en-us/dotnet/) version 3.1.401
+2. Install [C# .NET](https://docs.microsoft.com/en-us/dotnet/) version 3.1.404
 3. Add a `global.json` file to the root of your project repo with this JSON:
 
 ```json
 {
   "sdk": {
-    "version": "3.1.401"
+    "version": "3.1.404"
   }
 }
 ```
 
-This tells your local C# .NET runtime to use version 3.1.401 in this repo, even if you have newer versions installed on your machine.
+This tells your local C# .NET runtime to use version 3.1.404 in this repo. Make sure you are using versions 3.1.4xx. You can view the installed SDKs by typing `dotnet --list-sdks` on the console.  To confirm you are using a compatible version, type `dotnet --version` inside the project folder.  NEO•ONE will use the latest version unless it sees the `global.json`. This is required because NEO•ONE node uses the official C# NeoVM under the hood.
 
 4. Follow the [installation instructions for Create React App](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) to make a new project.
 
@@ -63,10 +63,24 @@ yarn add @neo-one/cli@prerelease @neo-one/client@prerelease @neo-one/smart-contr
 npm install @neo-one/cli@prerelease @neo-one/client@prerelease @neo-one/smart-contract@prerelease @neo-one/smart-contract-test@prerelease @neo-one/smart-contract-lib@prerelease @neo-one/smart-contract-typescript-plugin@prerelease
 ```
 
-6. Run `yarn neo-one init` or `npx neo-one init`
+6. Add environment variables to get the NEO•ONE node working:
 
-The command above generates a sample `HelloWorld.ts` smart contract, a sample test for the contract `HelloWorld.test.ts`, a config file `.neo-one.config.ts`, and a `neo-one` folder with important modules.
+- On **Windows**:
+  - Add these environment variables to your shell environment:
+    - `EDGE_USE_CORECLR=1`
+    - `EDGE_APP_ROOT=<path/to/project>/node_modules/@neo-one/node-vm/lib/bin/Debug/netcoreapp3.0`
 
+- On **macOS**:
+  - Install `pkgconfig` on macOS with Homebrew: `brew install pkgconfig`
+    - Then add this environment variable: `PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig`
+    - You then need to re-install your node modules by deleting the `node_modules` folder and then running `npm install` again 
+
+7. Run `yarn neo-one init` or `npx neo-one init`
+
+    - The command above generates a sample `HelloWorld.ts` smart contract, a sample test for the contract `HelloWorld.test.ts`, a config file `.neo-one.config.ts`, and a `neo-one` folder with important modules.
+
+8. Test your setup using `npx neo-one start network`. The output should be something like `{"level":30,"time":1625855073745,"service":"node","service":"blockchain","name":"neo_blockchain_start","msg":"Neo blockchain started.","v":1}`. You may need to use `sudo` depending on your project configuration.
+    - If you run into problems, then please reach out to us on [Discord](https://discord.gg/S86PqDE)
 ---
 
 ## Troubleshooting

--- a/packages/neo-one-website/docs/0-installation/2-environment-setup.md
+++ b/packages/neo-one-website/docs/0-installation/2-environment-setup.md
@@ -40,7 +40,7 @@ This page describes how to setup NEO•ONE using `yarn` or `npm`.
 }
 ```
 
-This tells your local C# .NET runtime to use version 3.1.404 in this repo. Make sure you are using versions 3.1.4xx. You can find out the current installed version by typing `dotnet --version` on the console. This is required because NEO•ONE node uses the official C# NeoVM under the hood.
+This tells your local C# .NET runtime to use version 3.1.404 in this repo. Make sure you are using versions 3.1.4xx. You can view the installed SDKs by typing `dotnet --list-sdks` on the console.  To confirm you are using a compatible version, type `dotnet --version` inside the project folder.  NEO•ONE will use the latest version unless it sees the `global.json`. This is required because NEO•ONE node uses the official C# NeoVM under the hood.
 
 **You need to add environment variables to get the NEO•ONE node working.**
 
@@ -49,7 +49,7 @@ On **Windows**:
   - `EDGE_USE_CORECLR=1`
   - `EDGE_APP_ROOT=<path/to/project>/node_modules/@neo-one/node-vm/lib/bin/Debug/netcoreapp3.0`
 
-On **MacOS**:
+On **macOS**:
 - Install `pkgconfig` on macOS with Homebrew: `brew install pkgconfig`
   - Then add this environment variable: `PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig`
   - You then need to re-install your node modules by deleting the `node_modules` folder and then running `npm install` again

--- a/packages/neo-one-website/docs/0-installation/2-environment-setup.md
+++ b/packages/neo-one-website/docs/0-installation/2-environment-setup.md
@@ -18,7 +18,7 @@ This page describes how to setup NEO•ONE using `yarn` or `npm`.
 - [Node](https://nodejs.org) >= 10.16.0 (We recommend the latest version)
   - Linux and Mac: We recommend using [Node Version Manager](https://github.com/creationix/nvm).
   - Windows: We recommend using [Chocolatey](https://chocolatey.org/).
-- [C# .NET](https://docs.microsoft.com/en-us/dotnet/) version 3.1.401
+- [C# .NET](https://docs.microsoft.com/en-us/dotnet/) version 3.1.404
 
 ---
 
@@ -35,23 +35,28 @@ This page describes how to setup NEO•ONE using `yarn` or `npm`.
 ```json
 {
   "sdk": {
-    "version": "3.1.401"
+    "version": "3.1.404"
   }
 }
 ```
 
-This tells your local C# .NET runtime to use version 3.1.401 in this repo, even if you have newer versions installed on your machine.
+This tells your local C# .NET runtime to use version 3.1.404 in this repo. Make sure you are using versions 3.1.4xx. You can find out the current installed version by typing `dotnet --version` on the console. This is required because NEO•ONE node uses the official C# NeoVM under the hood.
 
-**You may need to also add environment variables** to get the NEO•ONE node working. The NEO•ONE node now uses the C# NeoVM instead of our own implementation of the NeoVM in TypeScript, which means that NEO•ONE controls C# code through some complicated mechanisms. If you run into problems with running a node (such as when running `neo-one init` or `neo-one build`) then try these steps:
+**You need to add environment variables to get the NEO•ONE node working.**
 
+On **Windows**:
 - Add these environment variables to your shell environment:
   - `EDGE_USE_CORECLR=1`
   - `EDGE_APP_ROOT=<path/to/project>/node_modules/@neo-one/node-vm/lib/bin/Debug/netcoreapp3.0`
+
+On **MacOS**:
 - Install `pkgconfig` on macOS with Homebrew: `brew install pkgconfig`
   - Then add this environment variable: `PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig`
   - You then need to re-install your node modules by deleting the `node_modules` folder and then running `npm install` again
-- Try running the NEO•ONE CLI command using `sudo`, such as: `sudo npx neo-one init`
-- If problems persist then please reach out to us on [Discord](https://discord.gg/S86PqDE)
+
+**Testing your setup:**
+- Use `npx neo-one start network`. The output should be something like `{"level":30,"time":1625855073745,"service":"node","service":"blockchain","name":"neo_blockchain_start","msg":"Neo blockchain started.","v":1}`. You may need to use `sudo` depending on your project configuration.
+- If you run into problems, then please reach out to us on [Discord](https://discord.gg/S86PqDE)
 
 To see a demonstration of environment setup go to our [YouTube channel](https://www.youtube.com/channel/UCya5J1Tt2h-kX-I3a7LOvtw) for helpful videos.
 

--- a/packages/neo-one-website/docs/1-main-concepts/02-smart-contract-basics.md
+++ b/packages/neo-one-website/docs/1-main-concepts/02-smart-contract-basics.md
@@ -31,7 +31,7 @@ If you haven't already, prepare your project by following the instructions in th
 The NEO•ONE toolchain expects all smart contracts in your project to be contained within one parent folder. By default, that folder is `one/contracts`, though this location is [configurable](/docs/config-options). The main command you'll use from the NEO•ONE toolchain is:
 
 ```bash
-neo-one build
+npx neo-one build
 ```
 
 This command compiles your smart contracts, sets up a local private network, deploys your smart contracts to that network and generates testing utilities and client APIs for interacting with your smart contract. Appending the command with `--watch` will watch for changes in your smart contracts and automatically run the build command.

--- a/packages/neo-one-website/docs/3-node/4-build-from-source.md
+++ b/packages/neo-one-website/docs/3-node/4-build-from-source.md
@@ -75,12 +75,19 @@ You can also add a `.neo-onerc` configuration file anywhere in the app directory
 
 ## Troubleshooting
 
-You may or may not run into environment problems when trying to run the node. The NEO•ONE node now uses the C# NeoVM instead of our own implementation of the NeoVM in TypeScript, which means that NEO•ONE controls C# code through some complicated mechanisms. If you run into problems with running the node then try these steps:
+Make sure you add these environment variables to get the NEO•ONE node working:
 
+On **Windows**:
 - Add these environment variables to your shell environment:
   - `EDGE_USE_CORECLR=1`
   - `EDGE_APP_ROOT=<path/to/project>/node_modules/@neo-one/node-vm/lib/bin/Debug/netcoreapp3.0`
+
+On **macOS**:
 - Install `pkgconfig` on macOS with Homebrew: `brew install pkgconfig`
   - Then add this environment variable: `PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig`
   - You then need to re-install your node modules by deleting the `node_modules` folder and then running `npm install` again
-- If problems persist then please reach out to us on [Discord](https://discord.gg/S86PqDE)
+
+**Testing your setup:**
+- Use `npx neo-one start network`. The output should be something like `{"level":30,"time":1625855073745,"service":"node","service":"blockchain","name":"neo_blockchain_start","msg":"Neo blockchain started.","v":1}`. You may need to use `sudo` depending on your project configuration.
+- If you run into problems, then please reach out to us on [Discord](https://discord.gg/S86PqDE)
+

--- a/packages/neo-one-website/tutorial/tutorial.md
+++ b/packages/neo-one-website/tutorial/tutorial.md
@@ -85,11 +85,26 @@ yarn add @neo-one/cli@prerelease @neo-one/client@prerelease @neo-one/smart-contr
 npm install @neo-one/cli@prerelease @neo-one/client@prerelease @neo-one/smart-contract@prerelease @neo-one/smart-contract-test@prerelease @neo-one/smart-contract-lib@prerelease @neo-one/smart-contract-typescript-plugin@prerelease
 ```
 
-7. Run `yarn neo-one init` or `npx neo-one init`
+7. Add environment variables to get the NEO•ONE node working:
+
+- On **Windows**:
+  - Add these environment variables to your shell environment:
+    - `EDGE_USE_CORECLR=1`
+    - `EDGE_APP_ROOT=<path/to/project>/node_modules/@neo-one/node-vm/lib/bin/Debug/netcoreapp3.0`
+
+- On **macOS**:
+  - Install `pkgconfig` on macOS with Homebrew: `brew install pkgconfig`
+    - Then add this environment variable: `PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig`
+    - You then need to re-install your node modules by deleting the `node_modules` folder and then running `npm install` again 
+
+8. Run `yarn neo-one init` or `npx neo-one init`
 
 This command initializes a NEO•ONE project with a `Hello World` smart contract under `neo-one/contracts/HelloWorld.ts`, a unit test under `src/__tests__/HelloWorld.test.ts`, and a config file,`.neo-one.config.ts`. For this tutorial, we will be building a `Token` from the ground up, so you can go ahead and delete the two `HelloWorld` files. We also recommend taking a moment to [setup your editor](/docs/environment-setup#Editor-Setup) to take advantage of inline NEO•ONE compiler diagnostics.
 
-8. Review the available [configuration options](/docs/config-options) and update your `.neo-one.config.ts` file as needed.
+9. Review the available [configuration options](/docs/config-options) and update your `.neo-one.config.ts` file as needed.
+
+10. Test your setup using `npx neo-one start network`. The output should be something like `{"level":30,"time":1625855073745,"service":"node","service":"blockchain","name":"neo_blockchain_start","msg":"Neo blockchain started.","v":1}`. You may need to use `sudo` depending on your project configuration.
+    - If you run into problems, then please reach out to us on [Discord](https://discord.gg/S86PqDE)
 
 - This tutorial uses the default options. To follow along, nothing needs to be changed.
 


### PR DESCRIPTION



### Description of the Change

Windows users need to add environment variables. It is not clear that this step is mandatory (now it is). Also updated C# version to 3.1.404 and requested the user to verify the installed .NET version.

### Test Plan

The node is now starting when we type `npx neo-one start network` on Windows.


