### PR TITLE
fix(deploy): fix deploy maxnetworkfee

### DIFF
--- a/packages/neo-one-cli/src/deploy/runMigration.ts
+++ b/packages/neo-one-cli/src/deploy/runMigration.ts
@@ -127,7 +127,7 @@ export const runMigration = async (
             {
               ...(action.options === undefined ? {} : action.options),
               maxSystemFee: new BigNumber(1000),
-              maxNetworkFee: new BigNumber(1),
+              maxNetworkFee: new BigNumber(-1),
             },
             sourceMaps,
           );


### PR DESCRIPTION
### Description of the Change

- Fix deployment network fee to be no max.

### Test Plan

None.

### Alternate Designs

None.

### Benefits

Deploy works without network fee limit. So deploy works.

### Possible Drawbacks

Deploy could burn a lot of GAS without user realizing it until it's too late.

### Applicable Issues

#2410 