### PR TITLE
fix(deploy): fix build command

### DIFF
--- a/packages/neo-one-cli-common/src/deployContract.ts
+++ b/packages/neo-one-cli-common/src/deployContract.ts
@@ -13,7 +13,7 @@ export const deployContract = async (
   sourceMaps: SourceMaps,
   masterPrivateKey: string = constants.PRIVATE_NET_PRIVATE_KEY,
 ): Promise<AddressString> => {
-  const { client, developerClient, masterWallet } = await getClients(provider, masterPrivateKey);
+  const { client, developerClient } = await getClients(provider, masterPrivateKey);
 
   try {
     const existing = await client.read(provider.network).getContract(common.uInt160ToString(contractHash));
@@ -26,7 +26,7 @@ export const deployContract = async (
   const result = await client.publishAndDeploy(
     contract,
     manifest,
-    [masterWallet.userAccount.id.address],
+    [],
     { maxSystemFee: new BigNumber(-1), maxNetworkFee: new BigNumber(-1) },
     sourceMaps,
   );


### PR DESCRIPTION
### Description of the Change

- I mistakingly put the deployer's address as a parameter to any `build` command deployment. So anytime the `build` command is called it was passing in an argument to the deploy method even if it didn't accept one.
- But the problem is that if your contract does take in arguments for deploying then the user won't be able to during the `build` command. They will have to just set default arguments in the contract for testing. Or they will have to do the build command in separate steps.

### Test Plan

Tested locally. This is how it was originally supposed to be anyway.

### Alternate Designs

None.

### Benefits

Working build command.

### Possible Drawbacks

See second bullet point above. But that was always the case anyway.

### Applicable Issues

#2410 
#2491 