### PR TITLE
Adding quotes to mkdir command

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -63,7 +63,7 @@
       "summary": "Compile & serve editor server (only in dev mode)",
       "description": "Build and run the NEO•ONE editor server",
       "safeForSimultaneousRushProcesses": true,
-      "shellCommand": "mkdir -p ./dist/server && touch ./dist/server/index.js && cross-env NODE_OPTIONS=\"--max-old-space-size=3072\" node ./packages/neo-one-build-tools-web/dist/compile --watch --bundle server"
+      "shellCommand": "mkdir \"./dist/server\" && touch ./dist/server/index.js && cross-env NODE_OPTIONS=\"--max-old-space-size=3072\" node ./packages/neo-one-build-tools-web/dist/compile --watch --bundle server"
     },
     {
       "commandKind": "global",


### PR DESCRIPTION
### Description of the Change
I've added double quotes to the 'mkdir' command on the command-line.json file. Now it works on Windows.

### Test Plan
I've run the command `rush serve-server` and it is working on Windows. NOTE: I've removed the '-p' flag. We need to test this command on macOS to ensure it still works as expected.
