### PR TITLE
fix(node): fix how p2p messages are parsed

### DIFF
--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -598,7 +598,10 @@ export class Blockchain {
     this.mutableInQueue = new Set();
     this.mutableDoneRunningResolve = undefined;
     this.mutableRunning = true;
-    logger.info({ name: 'neo_blockchain_start' }, 'Neo blockchain started.');
+    logger.info(
+      { name: 'neo_blockchain_start', [Labels.NEO_BLOCK_INDEX]: this.currentBlockIndex },
+      'Neo blockchain started.',
+    );
   }
 
   private updateBlockMetadata(block: Block): void {

--- a/packages/neo-one-node-blockchain/src/Blockchain.ts
+++ b/packages/neo-one-node-blockchain/src/Blockchain.ts
@@ -804,7 +804,7 @@ export class Blockchain {
     await this.onPersist();
 
     const firstHeader = this.headerCache.tryRemoveFirst();
-    if (firstHeader !== undefined && firstHeader.index !== block.index) {
+    if (firstHeader !== undefined && firstHeader.index !== block.index - 1) {
       logger.trace({
         name: 'neo_blockchain',
         message: `Header cache index does not match block index when persisting new block. Block index: ${block.index}. Headercache index: ${firstHeader.index}`,

--- a/packages/neo-one-node-blockchain/src/__tests__/BlockchainE2E.test.ts
+++ b/packages/neo-one-node-blockchain/src/__tests__/BlockchainE2E.test.ts
@@ -15,7 +15,11 @@ describe('blockchain persist genesis block test', () => {
     const db = LevelUp(LevelDOWN(levelDBPath));
     const storage = levelupStorage({
       db,
-      context: { network: blockchainSettings.network, validatorsCount: blockchainSettings.validatorsCount },
+      context: {
+        network: blockchainSettings.network,
+        validatorsCount: blockchainSettings.validatorsCount,
+        maxValidUntilBlockIncrement: 86400000 / 1500,
+      },
     });
 
     const dispatcher = new Dispatcher({ levelDBPath });

--- a/packages/neo-one-node-protocol/src/Message.ts
+++ b/packages/neo-one-node-protocol/src/Message.ts
@@ -5,6 +5,7 @@ import {
   SerializableWire,
   SerializeWire,
 } from '@neo-one/client-common';
+import { createChild, nodeLogger } from '@neo-one/logger';
 import {
   BinaryReader,
   Block,
@@ -31,6 +32,8 @@ import {
   PingPayload,
   VersionPayload,
 } from './payload';
+
+const logger = createChild(nodeLogger, { component: 'node-protocol' });
 
 const tryCompression = ({ command }: MessageValue) =>
   command === Command.Block ||
@@ -272,7 +275,7 @@ const deserializeMessageHeader = (data: Buffer) => {
   const header = data.slice(0, 3);
   const flags = assertMessageFlags(header[0]);
   const command = assertCommand(header[1]);
-  const length = header[2];
+  const length = new BinaryReader(data, 2).readVarUIntLE(PAYLOAD_MAX_SIZE).toNumber();
 
   return { length, flags, command };
 };
@@ -312,7 +315,7 @@ export class MessageTransform extends Transform {
       callback(undefined);
     } catch (error) {
       // tslint:disable-next-line: no-console
-      // console.log(error);
+      logger.error({ name: 'neo_message_transform', error });
       callback(error);
     }
   }

--- a/packages/neo-one-node-protocol/src/Message.ts
+++ b/packages/neo-one-node-protocol/src/Message.ts
@@ -312,7 +312,7 @@ export class MessageTransform extends Transform {
       callback(undefined);
     } catch (error) {
       // tslint:disable-next-line: no-console
-      console.log(error);
+      // console.log(error);
       callback(error);
     }
   }

--- a/packages/neo-one-node-storage-levelup/src/__tests__/levelUpStorage.test.ts
+++ b/packages/neo-one-node-storage-levelup/src/__tests__/levelUpStorage.test.ts
@@ -16,7 +16,10 @@ import { storage as levelUpStorage } from '../';
 describe('levelUpStorage', () => {
   let storage: Storage;
   beforeEach(async () => {
-    storage = levelUpStorage({ db: LevelUp(MemDown()), context: { network: 1953787457, validatorsCount: 7 } });
+    storage = levelUpStorage({
+      db: LevelUp(MemDown()),
+      context: { network: 1953787457, validatorsCount: 7, maxValidUntilBlockIncrement: 86400000 / 1500 },
+    });
   });
   test('deleted items are undefined', async () => {
     const hash = common.bufferToUInt160(Buffer.from('3775292229eccdf904f16fff8e83e7cffdc0f0ce', 'hex'));

--- a/packages/neo-one-node-storage-levelup/src/__tests__/rocksDBStorage.test.ts
+++ b/packages/neo-one-node-storage-levelup/src/__tests__/rocksDBStorage.test.ts
@@ -4,11 +4,14 @@ import LevelUp from 'levelup';
 import RocksDB from 'rocksdb';
 import { storage as levelUpStorage } from '../';
 
-describe('levelUpStorage', () => {
+describe('rocksDBStorage', () => {
   let storage: Storage;
   beforeEach(async () => {
     const rocks = new RocksDB('/Users/spencercorwin/Desktop/test-location');
-    storage = levelUpStorage({ db: LevelUp(rocks), context: { network: 1953787457, validatorsCount: 7 } });
+    storage = levelUpStorage({
+      db: LevelUp(rocks),
+      context: { network: 1953787457, validatorsCount: 7, maxValidUntilBlockIncrement: 86400000 / 1500 },
+    });
   });
   test('deleted items are undefined', async () => {
     const hash = common.bufferToUInt160(Buffer.from('3775292229eccdf904f16fff8e83e7cffdc0f0ce', 'hex'));

--- a/packages/neo-one-node-storage-levelup/src/read.ts
+++ b/packages/neo-one-node-storage-levelup/src/read.ts
@@ -137,10 +137,9 @@ export function createFind$<Key, Value>({
   readonly deserializeValue: (value: Buffer) => Value;
 }): (lookup: Buffer, secondaryLookup?: Buffer) => Observable<StorageReturn<Key, Value>> {
   return (lookup: Buffer, secondaryLookup?: Buffer) =>
-    streamToObservable<StorageReturn<Buffer, Buffer>>(
-      () => db.createReadStream(getSearchRange(lookup, secondaryLookup)),
-      // TODO: might need to remove this slice here?
-    ).pipe(map(({ key, value }) => ({ key: deserializeKey(key.slice(1)), value: deserializeValue(value) })));
+    streamToObservable<StorageReturn<Buffer, Buffer>>(() =>
+      db.createReadStream(getSearchRange(lookup, secondaryLookup)),
+    ).pipe(map(({ key, value }) => ({ key: deserializeKey(key), value: deserializeValue(value) })));
 }
 
 export function createReadFindStorage<Key, Value>({

--- a/packages/neo-one-node-vm/lib/Storage/RocksDB/Snapshot.cs
+++ b/packages/neo-one-node-vm/lib/Storage/RocksDB/Snapshot.cs
@@ -46,11 +46,11 @@ namespace NEOONE.Storage.RocksDB
 
       if (direction == SeekDirection.Forward)
         for (it.Seek(fullKey); it.Valid(); it.Next())
-          yield return (it.Key()[1..], it.Value());
+          yield return (it.Key(), it.Value());
       else
         for (it.SeekForPrev(fullKey); it.Valid(); it.Prev())
         {
-          yield return (it.Key()[1..], it.Value());
+          yield return (it.Key(), it.Value());
         }
     }
 

--- a/packages/neo-one-node-vm/lib/Storage/RocksDB/Store.cs
+++ b/packages/neo-one-node-vm/lib/Storage/RocksDB/Store.cs
@@ -44,10 +44,10 @@ namespace NEOONE.Storage.RocksDB
       using var it = db.NewIterator(defaultFamily, Options.ReadDefault);
       if (direction == SeekDirection.Forward)
         for (it.Seek(fullKey); it.Valid(); it.Next())
-          yield return (it.Key()[1..], it.Value());
+          yield return (it.Key(), it.Value());
       else
         for (it.SeekForPrev(fullKey); it.Valid(); it.Prev())
-          yield return (it.Key()[1..], it.Value());
+          yield return (it.Key(), it.Value());
     }
 
     public bool Contains(byte[] key)


### PR DESCRIPTION
### Description of the Change

- Update logging for start of blockchain and for p2p message parsing errors
- Fix how P2P messages are parsed so that our stream waits for chunks accurately before trying to parse messages
- Fix the `Seek` method in Dispatcher so that the ApplicationEngine gets the correct byte array out of storage

### Test Plan

Synced RC4 Node on staging

### Alternate Designs

None.

### Benefits

Proper message parsing. Proper storage retrieval.

### Possible Drawbacks

Possibly introduced unforeseen consequences by removing the byte array slicing in Snapshot.cs and Store.cs. Dan introduced these changes way back in Preview4 and I don't know why we would want to slice off the first byte of the keys from storage.

### Applicable Issues

#2521