### PR TITLE
fix(compiler): add methodtokens to compiler, plus minor fixes

### DIFF
--- a/packages/neo-one-client-common/src/models/NefFileModel.ts
+++ b/packages/neo-one-client-common/src/models/NefFileModel.ts
@@ -53,9 +53,9 @@ export class NefFileModel implements SerializableJSON<NefFileJSON>, Serializable
   public serializeForChecksumBase(writer: BinaryWriter): void {
     this.serializeHeader(writer);
     writer.writeUInt16LE(0);
-    writer.writeArray(this.tokens, (token) => token.serializeWire());
+    writer.writeArray(this.tokens, (token) => token.serializeWireBase(writer));
     writer.writeUInt16LE(0);
-    writer.writeVarBytesLE(this.script ?? Buffer.from([])); // TODO: script can be null?
+    writer.writeVarBytesLE(this.script);
   }
 
   public serializeWireBase(writer: BinaryWriter): void {

--- a/packages/neo-one-node-protocol/src/Node.ts
+++ b/packages/neo-one-node-protocol/src/Node.ts
@@ -279,7 +279,7 @@ export class Node implements INode {
     const { externalPort = 0 } = options;
     this.externalPort = externalPort;
     this.nonce = Math.floor(Math.random() * utils.UINT_MAX_NUMBER);
-    this.userAgent = `NEO:neo-one-js:3.0.0-rc4`;
+    this.userAgent = `NEO:neo-one-js:3.0.0`;
 
     this.mutableMemPool = {};
     this.getNewVerificationContext = () =>

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/linkedSmartContract/for.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/linkedSmartContract/for.test.ts
@@ -22,7 +22,7 @@ describe('LinkedSmartContract.for', () => {
 
     const barContract = await node.addContractFromSnippet(normalizePath(path.join('linked', 'Bar.ts')), {
       [fooFullPath]: {
-        Foo: scriptHashToAddress(fooContract.manifest.abi.hash),
+        Foo: scriptHashToAddress(fooContract.hash),
       },
     });
 
@@ -32,10 +32,8 @@ describe('LinkedSmartContract.for', () => {
       interface Contract {
         getFoo(address: Address): string;
       }
-      const expected = Address.from('${scriptHashToAddress(fooContract.manifest.abi.hash)}');
-      const contract = SmartContract.for<Contract>(Address.from('${scriptHashToAddress(
-        barContract.manifest.abi.hash,
-      )}'));
+      const expected = Address.from('${scriptHashToAddress(fooContract.hash)}');
+      const contract = SmartContract.for<Contract>(Address.from('${scriptHashToAddress(barContract.hash)}'));
       assertEqual(contract.getFoo(expected), 'foo');
     `);
   });

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/NativeContractCallValue.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/NativeContractCallValue.ts
@@ -29,6 +29,7 @@ export class NativeContractCallValue extends BuiltinMemberValue {
     sb.emitPushBuffer(node, this.hash);
     // [val]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(this.hash, this.method, 0, true, this.callFlags);
     // [val]
     sb.emitHelper(node, options, sb.helpers.wrapVal({ type: this.type }));
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/SmartContractForBase.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/SmartContractForBase.ts
@@ -123,7 +123,17 @@ export abstract class SmartContractForBase extends BuiltinMemberCall {
                 // [string, params]
                 sb.emitPushString(prop, getSetterName(propName));
 
-                this.emitInvoke(sb, func, node, prop, addressName, sb.noPushValueOptions(innerOptions));
+                this.emitInvoke(
+                  sb,
+                  func,
+                  node,
+                  prop,
+                  addressName,
+                  getSetterName(propName),
+                  1,
+                  false,
+                  sb.noPushValueOptions(innerOptions),
+                );
                 // [val]
                 sb.emitHelper(prop, innerOptions, sb.helpers.wrapUndefined);
                 // []
@@ -149,10 +159,8 @@ export abstract class SmartContractForBase extends BuiltinMemberCall {
               if (accessor) {
                 // []
                 sb.emitOp(prop, 'DROP');
-                // [number]
-                sb.emitPushInt(prop, 0);
                 // [params]
-                sb.emitOp(prop, 'NEWARRAY');
+                sb.emitOp(prop, 'NEWARRAY0');
               } else {
                 // [params]
                 handleParams(prop, paramDecls, paramTypes, innerOptions);
@@ -161,7 +169,17 @@ export abstract class SmartContractForBase extends BuiltinMemberCall {
               sb.emitPushString(prop, propName);
 
               const isVoidReturn = propReturnType !== undefined && tsUtils.type_.isVoid(propReturnType);
-              this.emitInvoke(sb, func, node, prop, addressName, innerOptions);
+              this.emitInvoke(
+                sb,
+                func,
+                node,
+                prop,
+                addressName,
+                propName,
+                accessor ? 0 : paramDecls.length,
+                !isVoidReturn,
+                innerOptions,
+              );
 
               if (isVoidReturn) {
                 sb.emitHelper(prop, innerOptions, sb.helpers.wrapUndefined);
@@ -235,6 +253,9 @@ export abstract class SmartContractForBase extends BuiltinMemberCall {
     node: ts.CallExpression,
     prop: ts.Declaration,
     addressName: Name,
+    method: string,
+    paramCount: number,
+    hasReturnValue: boolean,
     optionsIn: VisitOptions,
   ): void;
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/block.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/block.ts
@@ -46,6 +46,7 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
         // [conract]
         sb.emitSysCall(node, 'System.Contract.Call');
+        sb.addMethodToken(common.nativeHashes.Ledger, 'getBlock', 1, true, CallFlags.ReadStates);
       },
       (sb, node, options) => {
         sb.emitHelper(node, options, sb.helpers.wrapBlock);

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
@@ -35,6 +35,7 @@ class BlockchainCurrentCallerContract extends BuiltinMemberValue {
       sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
       // [conract, buffer]
       sb.emitSysCall(node, 'System.Contract.Call');
+      sb.addMethodToken(common.nativeHashes.ContractManagement, 'getContract', 1, true, CallFlags.ReadStates);
       sb.emitHelper(
         node,
         options,

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/contract.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/contract.ts
@@ -44,6 +44,7 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
         // [contract]
         sb.emitSysCall(node, 'System.Contract.Call');
+        sb.addMethodToken(common.nativeHashes.ContractManagement, 'getContract', 1, true, CallFlags.ReadStates);
       },
       (sb, node, options) => {
         sb.emitHelper(

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/linkedSmartContract/for.ts
@@ -38,6 +38,9 @@ export class LinkedSmartContractFor extends SmartContractForBase {
     node: ts.CallExpression,
     prop: ts.Declaration,
     _addressName: Name,
+    method: string,
+    paramCount: number,
+    hasReturnValue: boolean,
     _options: VisitOptions,
   ): void {
     const scriptHash = this.getScriptHash(sb, node);
@@ -69,6 +72,7 @@ export class LinkedSmartContractFor extends SmartContractForBase {
       sb.emitPushBuffer(prop, scriptHash);
       // [result]
       sb.emitSysCall(prop, 'System.Contract.Call');
+      sb.addMethodToken(scriptHash, method, paramCount, hasReturnValue, CallFlags.All);
     }
   }
 

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/destroy.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/destroy.ts
@@ -36,6 +36,7 @@ export class SmartContractDestroy extends BuiltinInstanceMemberCall {
     sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
     // [conract]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(common.nativeHashes.ContractManagement, 'destroy', 1, false, CallFlags.All);
 
     if (optionsIn.pushValue) {
       // [val]

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/smartContract/for.ts
@@ -34,6 +34,9 @@ export class SmartContractFor extends SmartContractForBase {
     node: ts.CallExpression,
     prop: ts.Declaration,
     addressName: Name,
+    method: string,
+    paramCount: number,
+    hasReturnValue: boolean,
     options: VisitOptions,
   ): void {
     if (tsUtils.argumented.getArguments(node).length < 1) {
@@ -86,6 +89,7 @@ export class SmartContractFor extends SmartContractForBase {
       sb.emitOp(node, 'SWAP');
       // [result]
       sb.emitSysCall(node, 'System.Contract.Call');
+      sb.addMethodToken(scriptHash, method, paramCount, hasReturnValue, CallFlags.All);
     }
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transaction.ts
@@ -39,6 +39,7 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
         // [height]
         sb.emitSysCall(node, 'System.Contract.Call');
+        sb.addMethodToken(common.nativeHashes.Ledger, 'getTransactionHeight', 1, true, CallFlags.ReadStates);
       },
       Types.Transaction,
       Types.Number,
@@ -91,8 +92,9 @@ export const add = (builtins: Builtins): void => {
         sb.emitPushString(node, 'getTransaction');
         // [buffer, 'getTransaction', number, [buffer]]
         sb.emitPushBuffer(node, common.nativeHashes.Ledger);
-        // [conract]
+        // [contract]
         sb.emitSysCall(node, 'System.Contract.Call');
+        sb.addMethodToken(common.nativeHashes.Ledger, 'getTransaction', 1, true, CallFlags.ReadStates);
       },
       (sb, node, options) => {
         sb.emitHelper(node, options, sb.helpers.wrapTransaction);

--- a/packages/neo-one-smart-contract-compiler/src/compile/compile.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/compile.ts
@@ -96,14 +96,14 @@ export const compile = async ({
     })
   ).concat(addDummyMethod ? [DUMMY_METHOD] : []);
 
-  const compiler = 'neo-one 3.0.0-rc4';
+  const compiler = 'neo-one 3.0.0';
 
   return {
     contract: {
       nefFile: {
         compiler,
         script,
-        tokens: [], // TODO: need to implement this
+        tokens: finalResult.tokens,
       },
       script,
       manifest: {

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinaryDeserializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinaryDeserializeHelper.ts
@@ -20,5 +20,6 @@ export class BinaryDeserializeHelper extends Helper {
     sb.emitPushBuffer(node, common.nativeHashes.StdLib);
     // [val]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(common.nativeHashes.StdLib, 'deserialize', 1, true, CallFlags.None);
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinarySerializeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/binary/BinarySerializeHelper.ts
@@ -20,5 +20,6 @@ export class BinarySerializeHelper extends Helper {
     sb.emitPushBuffer(node, common.nativeHashes.StdLib);
     // [buffer]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(common.nativeHashes.StdLib, 'serialize', 1, true, CallFlags.None);
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/IsCallerHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/IsCallerHelper.ts
@@ -45,6 +45,7 @@ export class IsCallerHelper extends Helper {
           sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
           // [maybeContract, addressBuffer]
           sb.emitSysCall(node, 'System.Contract.Call');
+          sb.addMethodToken(common.nativeHashes.ContractManagement, 'getContract', 1, true, CallFlags.ReadStates);
           sb.emitHelper(
             node,
             options,

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/UpgradeHelper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/contract/UpgradeHelper.ts
@@ -51,10 +51,10 @@ export class UpgradeHelper extends Helper {
           sb.emitPushString(node, 'update');
           // [buffer, 'update', number, arg]
           sb.emitPushBuffer(node, common.nativeHashes.ContractManagement);
-          // [conract]
-          sb.emitSysCall(node, 'System.Contract.Call');
           // []
-          sb.emitOp(node, 'DROP');
+          sb.emitSysCall(node, 'System.Contract.Call');
+          // TODO: could be three parameters if we add the last "data" method somehow
+          sb.addMethodToken(common.nativeHashes.ContractManagement, 'update', 2, false, CallFlags.All);
           // [boolean]
           sb.emitPushBoolean(node, true);
         },

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/RIPEMD160Helper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/RIPEMD160Helper.ts
@@ -20,5 +20,6 @@ export class RIPEMD160Helper extends Helper {
     sb.emitPushBuffer(node, common.nativeHashes.CryptoLib);
     // [argsHash]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(common.nativeHashes.CryptoLib, 'ripemd160', 1, true, CallFlags.None);
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/SHA256Helper.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/helper/crypto/SHA256Helper.ts
@@ -20,5 +20,6 @@ export class SHA256Helper extends Helper {
     sb.emitPushBuffer(node, common.nativeHashes.CryptoLib);
     // [argsHash]
     sb.emitSysCall(node, 'System.Contract.Call');
+    sb.addMethodToken(common.nativeHashes.CryptoLib, 'sha256', 1, true, CallFlags.None);
   }
 }

--- a/packages/neo-one-smart-contract-compiler/src/compile/sb/DiagnosticScriptBuilder.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/sb/DiagnosticScriptBuilder.ts
@@ -49,6 +49,10 @@ export class DiagnosticScriptBuilder extends BaseScriptBuilder<DiagnosticScope> 
     // do nothing
   }
 
+  public addMethodToken(): void {
+    // do nothing
+  }
+
   public emitSysCall(): void {
     // do nothing
   }

--- a/packages/neo-one-smart-contract-compiler/src/compile/sb/ScriptBuilder.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/sb/ScriptBuilder.ts
@@ -1,5 +1,5 @@
 // tslint:disable ban-types
-import { OpCode, SysCallName, UInt160 } from '@neo-one/client-common';
+import { CallFlags, OpCode, SysCallName, UInt160 } from '@neo-one/client-common';
 import { BN } from 'bn.js';
 import ts from 'typescript';
 import { Context } from '../../Context';
@@ -26,6 +26,13 @@ export interface ScriptBuilder {
   readonly helpers: Helpers;
   readonly jumpTable: JumpTable;
   readonly process: () => void;
+  readonly addMethodToken: (
+    hash: UInt160,
+    method: string,
+    paramCount: number,
+    hasReturnValue: boolean,
+    callFlags: CallFlags,
+  ) => void;
   readonly visit: (node: ts.Node, options: VisitOptions) => void;
   readonly withScope: (node: ts.Node, options: VisitOptions, func: (options: VisitOptions) => void) => void;
   readonly withProgramCounter: (func: (pc: ProgramCounterHelper) => void) => void;

--- a/packages/neo-one-smart-contract-compiler/src/compile/types.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/types.ts
@@ -1,3 +1,4 @@
+import { MethodToken } from '@neo-one/client-common';
 import { ContractRegister } from '@neo-one/client-full-core';
 import { RawSourceMap } from 'source-map';
 import ts from 'typescript';
@@ -34,6 +35,7 @@ export interface VisitOptions {
 export interface ScriptBuilderResult {
   readonly code: Buffer;
   readonly sourceMap: Promise<RawSourceMap>;
+  readonly tokens: ReadonlyArray<MethodToken>;
 }
 export interface CompileResult {
   readonly contract: ContractRegister;


### PR DESCRIPTION
### Description of the Change

- Add MethodTokens output to compiler
- Update Node's useragent and compiler's version number for MainNet
- Fix MethodToken serialize method

### Test Plan

None.

### Alternate Designs

None.

### Benefits

N3 MainNet

### Possible Drawbacks

None.

### Applicable Issues

#2449 