### PR TITLE
fix(compiler): fixup transfer amount, current time apis

### DIFF
--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/__snapshots__/blockchain.test.ts.snap
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/__snapshots__/blockchain.test.ts.snap
@@ -11,6 +11,17 @@ exports[`Blockchain set currentBlockTime 1`] = `
 "
 `;
 
+exports[`Blockchain set currentBlockTimeMilliseconds 1`] = `
+"snippetCode.ts (4,18): Cannot assign to 'currentBlockTimeMilliseconds' because it is a read-only property.
+
+      2 |       import { Blockchain } from '@neo-one/smart-contract';
+      3 | 
+    > 4 |       Blockchain.currentBlockTimeMilliseconds = 10;
+        |                  ^
+      5 |     
+"
+`;
+
 exports[`Blockchain set currentCallerContract 1`] = `
 "snippetCode.ts (4,18): Cannot assign to 'currentCallerContract' because it is a read-only property.
 

--- a/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
+++ b/packages/neo-one-smart-contract-compiler/src/__tests__/compile/builtins/contract/blockchain.test.ts
@@ -97,6 +97,28 @@ describe('Blockchain', () => {
     );
   });
 
+  test('currentBlockTimeMilliseconds', async () => {
+    const node = await helpers.startNode();
+
+    await node.executeString(`
+      import { Blockchain } from '@neo-one/smart-contract';
+
+      Blockchain.currentBlockTimeMilliseconds;
+      assertEqual(Blockchain.currentBlockTimeMilliseconds > 0, true);
+    `);
+  });
+
+  test('set currentBlockTimeMilliseconds', async () => {
+    await helpers.compileString(
+      `
+      import { Blockchain } from '@neo-one/smart-contract';
+
+      Blockchain.currentBlockTimeMilliseconds = 10;
+    `,
+      { type: 'error' },
+    );
+  });
+
   test('currentTransaction', async () => {
     const node = await helpers.startNode();
 

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/BuiltinInstanceIndexValue.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/BuiltinInstanceIndexValue.ts
@@ -10,6 +10,7 @@ export class BuiltinInstanceIndexValue extends BuiltinInstanceMemberValue {
     private readonly valueType: WrappableType,
     private readonly type: WrappableType,
     private readonly shouldWrap: boolean = true,
+    private readonly modifier?: (sb: ScriptBuilder, node: MemberLikeExpression, options: VisitOptions) => void,
   ) {
     super();
   }
@@ -21,6 +22,9 @@ export class BuiltinInstanceIndexValue extends BuiltinInstanceMemberValue {
     sb.emitPushInt(node, this.index);
     // [property]
     sb.emitOp(node, 'PICKITEM');
+    if (this.modifier !== undefined) {
+      this.modifier(sb, node, options);
+    }
     if (this.shouldWrap) {
       // [val]
       sb.emitHelper(node, options, sb.helpers.wrapVal({ type: this.type }));

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/blockchain.ts
@@ -60,13 +60,29 @@ class BlockchainCurrentCallerContract extends BuiltinMemberValue {
   }
 }
 
+class BlockchainCurrentBlockTime extends BuiltinMemberValue {
+  protected emit(sb: ScriptBuilder, node: MemberLikeExpression, options: VisitOptions): void {
+    if (options.pushValue) {
+      // [time]
+      sb.emitSysCall(node, 'System.Runtime.GetTime');
+      // [1000, time]
+      sb.emitPushInt(node, 1000);
+      // [time]
+      sb.emitOp(node, 'DIV');
+      // [val]
+      sb.emitHelper(node, options, sb.helpers.wrapNumber);
+    }
+  }
+}
+
 // tslint:disable-next-line export-name
 export const add = (builtins: Builtins): void => {
   builtins.addContractValue('Blockchain', new BlockchainValue());
   builtins.addContractInterface('BlockchainConstructor', new BlockchainConstructorInterface());
+  builtins.addContractMember('BlockchainConstructor', 'currentBlockTime', new BlockchainCurrentBlockTime());
   builtins.addContractMember(
     'BlockchainConstructor',
-    'currentBlockTime',
+    'currentBlockTimeMilliseconds',
     new SysCallMemberValue('System.Runtime.GetTime', Types.Number),
   );
   builtins.addContractMember(

--- a/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transfer.ts
+++ b/packages/neo-one-smart-contract-compiler/src/compile/builtins/contract/transfer.ts
@@ -16,7 +16,17 @@ export const add = (builtins: Builtins): void => {
   builtins.addContractMember(
     'Transfer',
     'amount',
-    new BuiltinInstanceIndexValue(1, Types.Transfer, Types.Number, false),
+    // Here we are just converting the amount to a Fixed8 number
+    new BuiltinInstanceIndexValue(1, Types.Transfer, Types.Number, false, (sb, node, options) => {
+      // [amount]
+      sb.emitHelper(node, options, sb.helpers.unwrapNumber);
+      // [10^8, amount]
+      sb.emitPushInt(node, 10 ** 8);
+      // [amount]
+      sb.emitOp(node, 'MUL');
+      // [amount]
+      sb.emitHelper(node, options, sb.helpers.wrapNumber);
+    }),
   );
   builtins.addContractMember('Transfer', 'from', new BuiltinInstanceIndexValue(2, Types.Transfer, Types.Buffer, false));
   builtins.addContractMember(

--- a/packages/neo-one-smart-contract-test/src/__data__/contracts/TestICO.ts
+++ b/packages/neo-one-smart-contract-test/src/__data__/contracts/TestICO.ts
@@ -1,4 +1,4 @@
-import { Address, Fixed, Integer, SmartContract } from '@neo-one/smart-contract';
+import { Address, constant, Fixed, Integer, SmartContract } from '@neo-one/smart-contract';
 import { ICO, NEP17Token } from '@neo-one/smart-contract-lib';
 
 export class TestICO extends ICO(NEP17Token(SmartContract)) {
@@ -19,6 +19,7 @@ export class TestICO extends ICO(NEP17Token(SmartContract)) {
     this.icoStartTimeSeconds = startTimeSeconds;
   }
 
+  @constant
   public getICOAmount(): Fixed<8> {
     return 5000_00000000;
   }

--- a/packages/neo-one-smart-contract-test/src/__tests__/TestICO.test.ts
+++ b/packages/neo-one-smart-contract-test/src/__tests__/TestICO.test.ts
@@ -22,7 +22,7 @@ describe('TestICO', () => {
         crypto.addPublicKey(common.stringToPrivateKey(MINTER.PRIVATE_KEY), common.stringToECPoint(MINTER.PUBLIC_KEY));
         const deployResult = await smartContract.deploy(
           masterAccountID.address,
-          new BigNumber(Math.round(Date.now() / 1)), // TODO: this was 1000 but that didn't work for the ICO. Check this out
+          new BigNumber(Math.round(Date.now() / 1000)),
         );
         const deployReceipt = await deployResult.confirmed({ timeoutMS: 2500 });
         if (deployReceipt.result.state !== 'HALT') {
@@ -56,7 +56,7 @@ describe('TestICO', () => {
                 to: privateKeyToAddress(MINTER.PRIVATE_KEY),
               },
               {
-                amount: new BigNumber(154460781), // TODO: why is the GAS required so large?
+                amount: new BigNumber(164460781), // TODO: why is the GAS required so large? Because of https://github.com/neo-one-suite/neo-one/issues/2448
                 asset: Hash160.GAS,
                 to: privateKeyToAddress(MINTER.PRIVATE_KEY),
               },
@@ -85,8 +85,7 @@ describe('TestICO', () => {
         expect(mintReceipt.result.gasConsumed.toString()).toMatchSnapshot('mint consumed');
         expect(mintReceipt.result.value).toBeUndefined();
         expect(mintReceipt.events).toHaveLength(3);
-        const event = mintReceipt.events[2]; // TODO: not totally sure it's the 3rd item
-        // TODO: also check the first two events
+        const event = mintReceipt.events[2];
         expect(event.name).toEqual('Transfer');
         expect(event.parameters.from).toBeUndefined();
         expect(event.parameters.to).toEqual(minter.userAccount.id.address);
@@ -95,15 +94,15 @@ describe('TestICO', () => {
           throw new Error('For TS');
         }
         const firstBalance = firstMint.times(10).toString();
-        expect(event.parameters.amount.toString()).toEqual(firstBalance); // TODO: value returned is 8 decimal places off
+        expect(event.parameters.amount.toString()).toEqual(firstBalance);
 
         const [minterBalance, mintTotalSupply] = await Promise.all([
           smartContract.balanceOf(minter.userAccount.id.address),
           smartContract.totalSupply(),
         ]);
 
-        expect(minterBalance.toString(10)).toEqual(firstBalance); // TODO: value returned is 8 decimal places off
-        expect(mintTotalSupply.toString(10)).toEqual(firstBalance); // TODO: value returned is 8 decimal places off
+        expect(minterBalance.toString(10)).toEqual(firstBalance);
+        expect(mintTotalSupply.toString(10)).toEqual(firstBalance);
       },
       { deploy: false },
     );

--- a/packages/neo-one-smart-contract-test/src/__tests__/__snapshots__/TestICO.test.ts.snap
+++ b/packages/neo-one-smart-contract-test/src/__tests__/__snapshots__/TestICO.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TestICO smart contract: deploy consumed 1`] = `"54151230"`;
+exports[`TestICO smart contract: deploy consumed 1`] = `"53951230"`;
 
-exports[`TestICO smart contract: mint consumed 1`] = `"135654250"`;
+exports[`TestICO smart contract: mint consumed 1`] = `"136864310"`;

--- a/packages/neo-one-smart-contract/src/index.d.ts
+++ b/packages/neo-one-smart-contract/src/index.d.ts
@@ -906,12 +906,16 @@ export interface SetStorageConstructor {
  */
 export interface BlockchainConstructor {
   /**
-   * Time of the current `Block`.
+   * Time of the current `Block` in seconds.
    *
    * During execution, this is the timestamp of the `Block` that this `Transaction` will be included in.
    * During verification, this is the timestamp of the latest `Block` + 15 seconds which represents the earliest possible timestamp of the `Block` that this `Transaction` will be included in.
    */
   readonly currentBlockTime: number;
+  /**
+   * Time of the current `Block` in milliseconds.
+   */
+  readonly currentBlockTimeMilliseconds: number;
   /**
    * Index of the latest `Block` persisted to the blockchain.
    */
@@ -1365,7 +1369,7 @@ export interface Transfer {
   /**
    * The amount transferred.
    */
-  readonly amount: Fixed<8>;
+  readonly amount: Fixed8;
   /**
    * The `UInt160` hash of the contract.
    */


### PR DESCRIPTION
### Description of the Change

- Fixes the `Transfer.amount` API in compiler to actually be a Fixed8 value
- Clarifies the `Blockchain.currentBlockTime` API to be in seconds instead of milliseconds
- Adds `Blockchain.currentBlockTimeMilliseconds` API to be block time in milliseconds.
- Adds tests and fixes tests for these changes.

### Test Plan

Tests updated below.

### Alternate Designs

None.

### Benefits

Better, clearer, cleaner APIs.

### Possible Drawbacks

None.

### Applicable Issues

None.