### PR TITLE
feat(node): add block data for block action tracking

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -2,12 +2,12 @@ name: Cypress
 on:
   push:
     branches:
-      - master
+      - master-2.x
       - staging
       - trying
   pull_request:
     branches:
-      - master
+      - master-2.x
       - staging
       - trying
 jobs:

--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -159,6 +159,7 @@ export interface RawInvocationResultSuccessJSON {
 export type RawInvocationResultJSON = RawInvocationResultSuccessJSON | RawInvocationResultErrorJSON;
 
 export interface ActionBaseJSON {
+  readonly source: 'Transaction' | 'Block';
   readonly version: number;
   readonly index: string;
   readonly scriptHash: string;
@@ -423,6 +424,11 @@ export interface HeaderJSON {
 
 export interface BlockJSON extends HeaderJSON {
   readonly tx: readonly ConfirmedTransactionJSON[];
+  readonly blockData?: BlockDataJSON;
+}
+
+export interface BlockDataJSON {
+  readonly blockActions: readonly ActionJSON[];
 }
 
 export interface NetworkSettingsJSON {

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -274,6 +274,17 @@ export interface Block extends Header {
    * `Transaction`s contained in the `Block`.
    */
   readonly transactions: readonly ConfirmedTransaction[];
+  /**
+   * Extra block data produced by persisting the `Block`.
+   */
+  readonly blockData: RawBlockData;
+}
+
+export interface RawBlockData {
+  /**
+   * Actions produced by the `onPersist` and `postPersist` scrips run when persisting the `Block`.
+   */
+  readonly blockActions: readonly RawAction[];
 }
 
 /**
@@ -2217,6 +2228,10 @@ export interface RawExecutionResultError extends RawExecutionResultBase {
  * Base properties of `Event`s and `Log`s as well as their raw counterparts, `RawNotification` and `RawLog`, respectively.
  */
 export interface RawActionBase {
+  /**
+   * Indicates whether the action was produced by a `Transaction` or a `Block`.
+   */
+  readonly source: 'Block' | 'Transaction';
   /**
    * NEO network version number.
    */

--- a/packages/neo-one-client-core/src/Client.ts
+++ b/packages/neo-one-client-core/src/Client.ts
@@ -422,12 +422,12 @@ export class Client<
    */
   public smartContract<T extends SmartContract<any, any> = SmartContractAny>(
     definition: SmartContractDefinition,
-    isNEOONEContract: boolean | undefined = true,
+    isNEOONEContract: boolean,
   ): T {
     return createSmartContract({
       definition: args.assertSmartContractDefinition('definition', definition),
       client: this,
-      isNEOONEContract,
+      isNEOONEContract: args.assertBoolean('isNEOONEContract', isNEOONEContract),
       // tslint:disable-next-line no-any
     }) as any;
   }

--- a/packages/neo-one-client-core/src/__tests__/nep17.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/nep17.test.ts
@@ -8,7 +8,7 @@ import { NEOONEDataProvider, NEOONEProvider } from '../provider';
 import { LocalKeyStore, LocalMemoryStore, LocalUserAccountProvider } from '../user';
 describe('nep17', () => {
   test('abi', () => {
-    expect(nep17.abi(4)).toMatchSnapshot();
+    expect(nep17.abi(4, true)).toMatchSnapshot();
   });
 
   const smartContract: { decimals?: () => BigNumber } = {};
@@ -20,13 +20,13 @@ describe('nep17', () => {
   test('getDecimals', async () => {
     smartContract.decimals = jest.fn(() => data.bigNumbers.a);
 
-    const result = await nep17.getDecimals(client, factory.createSmartContractDefinition().networks, 'main');
+    const result = await nep17.getDecimals(client, factory.createSmartContractDefinition().networks, 'main', true);
 
     expect(result).toEqual(data.bigNumbers.a.toNumber());
   });
 
   test('createNEP17SmartContract', () => {
-    const contract = nep17.createNEP17SmartContract(client, factory.createSmartContractDefinition().networks, 8);
+    const contract = nep17.createNEP17SmartContract(client, factory.createSmartContractDefinition().networks, 8, true);
 
     expect(contract).toEqual(smartContract);
     expect(clientSmartContract.mock.calls).toMatchSnapshot();
@@ -45,7 +45,7 @@ describe('nep17', () => {
     const gas = nep17.createNEP17SmartContract(myClient, gasNetwork, 8, false);
 
     const [symbol, totalSupply] = await Promise.all([gas.symbol(), gas.totalSupply()]);
-    console.log(symbol, totalSupply);
+    console.log(symbol, totalSupply.toString());
   });
 
   test.only('nep17 with NEO', async () => {
@@ -61,6 +61,6 @@ describe('nep17', () => {
     const neo = nep17.createNEP17SmartContract(myClient, neoNetwork, 0, false);
 
     const [symbol, totalSupply] = await Promise.all([neo.symbol(), neo.totalSupply()]);
-    console.log(symbol, totalSupply);
+    console.log(symbol, totalSupply.toString());
   });
 });

--- a/packages/neo-one-client-core/src/__tests__/sc/createSmartContract.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/sc/createSmartContract.test.ts
@@ -24,9 +24,9 @@ describe('createSmartContract', () => {
   } as any;
 
   const definition = factory.createSmartContractDefinition();
-  let contract = createSmartContract({ definition, client });
+  let contract = createSmartContract({ definition, client, isNEOONEContract: true });
   beforeEach(() => {
-    contract = createSmartContract({ definition, client });
+    contract = createSmartContract({ definition, client, isNEOONEContract: true });
   });
 
   test('definition', () => {

--- a/packages/neo-one-client-core/src/nep17.ts
+++ b/packages/neo-one-client-core/src/nep17.ts
@@ -41,12 +41,9 @@ export interface NEP17SmartContract<TClient extends Client = Client> extends Sma
   ) => TransactionResult<InvokeReceipt<boolean, NEP17Event>>;
 }
 
-const DEFAULT_NEO_ONE_PARAM: ABIParameter = { type: 'String', name: NEO_ONE_METHOD_RESERVED_PARAM };
+const DEFAULT_NEO_ONE_PARAM: ABIParameter = { type: 'String', name: NEO_ONE_METHOD_RESERVED_PARAM, optional: false };
 
-const getDecimalsMethod = (
-  decimals: number,
-  isNEOONEContract: boolean | undefined = true,
-): ContractMethodDescriptorClient => ({
+const getDecimalsMethod = (decimals: number, isNEOONEContract: boolean): ContractMethodDescriptorClient => ({
   name: 'decimals',
   constant: true,
   parameters: isNEOONEContract ? [DEFAULT_NEO_ONE_PARAM] : [],
@@ -55,7 +52,7 @@ const getDecimalsMethod = (
   safe: true,
 });
 
-export const abi = (decimals: number, isNEOONEContract: boolean | undefined = true): ContractABIClient => ({
+export const abi = (decimals: number, isNEOONEContract: boolean): ContractABIClient => ({
   methods: [
     {
       name: 'name',
@@ -89,6 +86,7 @@ export const abi = (decimals: number, isNEOONEContract: boolean | undefined = tr
         {
           type: 'Hash160',
           name: 'account',
+          optional: false,
         },
       ],
       returnType: { type: 'Integer', decimals },
@@ -101,15 +99,18 @@ export const abi = (decimals: number, isNEOONEContract: boolean | undefined = tr
         {
           type: 'Hash160',
           name: 'from',
+          optional: false,
         },
         {
           type: 'Hash160',
           name: 'to',
+          optional: false,
         },
         {
           type: 'Integer',
           name: 'amount',
           decimals,
+          optional: false,
         },
         {
           type: 'Any',
@@ -128,24 +129,25 @@ export const abi = (decimals: number, isNEOONEContract: boolean | undefined = tr
         {
           type: 'Hash160',
           name: 'from',
-          optional: false,
+          optional: true,
         },
         {
           type: 'Hash160',
           name: 'to',
-          optional: false,
+          optional: true,
         },
         {
           type: 'Integer',
           name: 'amount',
           decimals,
+          optional: false,
         },
       ],
     },
   ],
 });
 
-export const manifest = (decimals: number, isNEOONEContract: boolean | undefined = true): ContractManifestClient => ({
+export const manifest = (decimals: number, isNEOONEContract: boolean): ContractManifestClient => ({
   name: 'A NEO•ONE NEP-17 Smart Contract',
   groups: [],
   supportedStandards: ['NEP-17'],
@@ -158,16 +160,19 @@ export const getDecimals = async (
   client: Client,
   networksDefinition: SmartContractNetworksDefinition,
   network: NetworkType,
-  isNEOONEContract: boolean | undefined = true,
+  isNEOONEContract: boolean,
 ): Promise<number> => {
   const decimalsBigNumber = await client
-    .smartContract({
-      networks: networksDefinition,
-      manifest: {
-        ...manifest(0, isNEOONEContract),
-        abi: { events: [], methods: [getDecimalsMethod(0)] },
+    .smartContract(
+      {
+        networks: networksDefinition,
+        manifest: {
+          ...manifest(0, isNEOONEContract),
+          abi: { events: [], methods: [getDecimalsMethod(0, isNEOONEContract)] },
+        },
       },
-    })
+      isNEOONEContract,
+    )
     .decimals({ network });
 
   return decimalsBigNumber.toNumber();
@@ -177,7 +182,7 @@ export const createNEP17SmartContract = <TClient extends Client>(
   client: TClient,
   networksDefinition: SmartContractNetworksDefinition,
   decimals: number,
-  isNEOONEContract: boolean | undefined = true,
+  isNEOONEContract: boolean,
 ): NEP17SmartContract =>
   client.smartContract<NEP17SmartContract<TClient>>(
     {

--- a/packages/neo-one-client-core/src/provider/convert.ts
+++ b/packages/neo-one-client-core/src/provider/convert.ts
@@ -6,6 +6,7 @@ import {
   AttributeJSON,
   AttributeTypeModel,
   Block,
+  BlockDataJSON,
   BlockJSON,
   CallReceiptJSON,
   ConfirmedTransaction,
@@ -44,6 +45,7 @@ import {
   OracleResponseJSON,
   RawAction,
   RawApplicationLogData,
+  RawBlockData,
   RawCallReceipt,
   RawExecutionData,
   RawExecutionResult,
@@ -181,6 +183,7 @@ export function convertAction(
   if (action.type === 'Log') {
     return {
       type: 'Log',
+      source: action.source,
       version: action.version,
       blockIndex,
       blockHash,
@@ -196,6 +199,7 @@ export function convertAction(
 
   return {
     type: 'Notification',
+    source: action.source,
     version: action.version,
     blockIndex,
     blockHash,
@@ -311,6 +315,26 @@ export function convertBlock(block: BlockJSON): Block {
     witnesses: block.witnesses,
     size: block.size,
     transactions: block.tx.map(convertConfirmedTransaction),
+    blockData: convertBlockData(block, block.blockData),
+  };
+}
+
+export function convertBlockData(block: BlockJSON, data?: BlockDataJSON): RawBlockData {
+  if (data === undefined) {
+    throw new Error('Expected to get block data');
+  }
+
+  return {
+    blockActions: data.blockActions.map((action, idx) =>
+      convertAction(
+        block.hash,
+        block.index,
+        '0x​​​​​0000000000000000000000000000000000000000000000000000000000000000​​​​​',
+        0,
+        idx,
+        action,
+      ),
+    ),
   };
 }
 

--- a/packages/neo-one-client-core/src/sc/common.ts
+++ b/packages/neo-one-client-core/src/sc/common.ts
@@ -236,7 +236,6 @@ export const convertAction = ({
     throw new InvalidEventError('Notification had no arguments');
   }
 
-  // TODO: check this
   const eventSpec = events[event];
   if (eventSpec === undefined) {
     return event;
@@ -244,6 +243,7 @@ export const convertAction = ({
 
   return {
     version: action.version,
+    source: action.source,
     blockIndex: action.blockIndex,
     blockHash: action.blockHash,
     transactionIndex: action.transactionIndex,

--- a/packages/neo-one-client-core/src/sc/createSmartContract.ts
+++ b/packages/neo-one-client-core/src/sc/createSmartContract.ts
@@ -313,11 +313,11 @@ const createInvoke = ({
 export const createSmartContract = ({
   definition,
   client,
-  isNEOONEContract = true,
+  isNEOONEContract,
 }: {
   readonly definition: SmartContractDefinition;
   readonly client: Client;
-  readonly isNEOONEContract?: boolean;
+  readonly isNEOONEContract: boolean;
 }): SmartContractAny => {
   const {
     manifest: {

--- a/packages/neo-one-node-blockchain/src/errors.ts
+++ b/packages/neo-one-node-blockchain/src/errors.ts
@@ -26,11 +26,15 @@ export const ConsensusPayloadVerifyError = makeErrorWithCode(
 );
 export const PersistNativeContractsError = makeErrorWithCode(
   'PERSIST_NATIVE_CONTRACTS_FAILED',
-  () => 'Engine state !== HALT when persisting native contract scripts',
+  (message?: string) =>
+    `Engine state !== HALT when persisting native contract scripts${
+      message !== undefined ? `. Message: ${message}` : ''
+    }`,
 );
 export const PostPersistError = makeErrorWithCode(
   'POST_PERSIST_SCRIPT_FAILED',
-  () => 'Engine state !== HALT when running post persist scripts',
+  (message?: string) =>
+    `Engine state !== HALT when running post persist scripts${message !== undefined ? `. Message: ${message}` : ''}`,
 );
 export const ContractStateFetchError = makeErrorWithCode(
   'FETCH_CONTRACT_FAILED',

--- a/packages/neo-one-node-blockchain/src/getExecutionResult.ts
+++ b/packages/neo-one-node-blockchain/src/getExecutionResult.ts
@@ -20,13 +20,13 @@ export function getExecutionResult(result: {
     return new ExecutionResultError({
       gasConsumed: result.gasConsumed,
       stack: result.stack.map((item) => item.toContractParameter()),
-      message: result.exception === undefined ? 'Unknown Error' : result.exception,
+      message: result.exception === undefined ? 'Unknown execution error' : result.exception,
     });
   } catch (error) {
     return new ExecutionResultError({
       gasConsumed: utils.ZERO,
-      stack: [],
-      message: error.message,
+      stack: result.stack.map((item) => item.toContractParameter()),
+      message: `Error while converting execution result: ${error.message}`,
     });
   }
 }

--- a/packages/neo-one-node-core/src/Block.ts
+++ b/packages/neo-one-node-core/src/Block.ts
@@ -172,10 +172,17 @@ export class Block implements SerializableContainer, SerializableJSON<BlockJSON>
   }
 
   public async serializeJSON(context: SerializeJSONContext): Promise<BlockJSON> {
+    const maybeBlockData = await context.tryGetBlockData(this.hash);
+    const blockData =
+      maybeBlockData === undefined
+        ? undefined
+        : { blockActions: maybeBlockData.blockActions.map((action) => action.serializeJSON()) };
+
     return {
       ...this.header.serializeJSON(context),
       size: this.size,
       tx: await Promise.all(this.transactions.map(async (tx) => tx.serializeJSONWithData(context))),
+      blockData,
     };
   }
 }

--- a/packages/neo-one-node-core/src/BlockData.ts
+++ b/packages/neo-one-node-core/src/BlockData.ts
@@ -22,6 +22,7 @@ export interface BlockDataAdd {
   readonly hash: UInt256;
   readonly lastGlobalTransactionIndex: BN;
   readonly lastGlobalActionIndex: BN;
+  readonly blockActionsCount: number;
 }
 
 export class BlockData implements Equatable, SerializableWire {
@@ -29,11 +30,13 @@ export class BlockData implements Equatable, SerializableWire {
     const hash = reader.readUInt256();
     const lastGlobalTransactionIndex = reader.readInt64LE();
     const lastGlobalActionIndex = reader.readInt64LE();
+    const blockActionsCount = reader.readUInt32LE();
 
     return new this({
       hash,
       lastGlobalTransactionIndex,
       lastGlobalActionIndex,
+      blockActionsCount,
     });
   }
 
@@ -48,16 +51,18 @@ export class BlockData implements Equatable, SerializableWire {
   public readonly hashHex: UInt256Hex;
   public readonly lastGlobalTransactionIndex: BN;
   public readonly lastGlobalActionIndex: BN;
+  public readonly blockActionsCount: number;
   public readonly equals: Equals = utils.equals(BlockData, this, (other) => common.uInt256Equal(this.hash, other.hash));
   public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
   private readonly sizeInternal: () => number;
 
-  public constructor({ hash, lastGlobalTransactionIndex, lastGlobalActionIndex }: BlockDataAdd) {
+  public constructor({ hash, lastGlobalTransactionIndex, lastGlobalActionIndex, blockActionsCount }: BlockDataAdd) {
     this.hash = hash;
     this.hashHex = common.uInt256ToHex(hash);
     this.lastGlobalTransactionIndex = lastGlobalTransactionIndex;
     this.lastGlobalActionIndex = lastGlobalActionIndex;
-    this.sizeInternal = utils.lazy(() => IOHelper.sizeOfUInt256);
+    this.blockActionsCount = blockActionsCount;
+    this.sizeInternal = utils.lazy(() => IOHelper.sizeOfUInt256 + IOHelper.sizeOfUInt32LE);
   }
 
   public get size(): number {
@@ -68,5 +73,6 @@ export class BlockData implements Equatable, SerializableWire {
     writer.writeUInt256(this.hash);
     writer.writeInt64LE(this.lastGlobalTransactionIndex);
     writer.writeInt64LE(this.lastGlobalActionIndex);
+    writer.writeUInt32LE(this.blockActionsCount);
   }
 }

--- a/packages/neo-one-node-core/src/Serializable.ts
+++ b/packages/neo-one-node-core/src/Serializable.ts
@@ -83,6 +83,7 @@ export interface SerializeJSONContext {
   readonly addressVersion: number;
   readonly network: number;
   readonly tryGetTransactionData: (hash: UInt256) => Promise<SerializableTransactionData | undefined>;
+  readonly tryGetBlockData: (hash: UInt256) => Promise<SerializableBlockData | undefined>;
 }
 
 export interface SerializableTransactionData {
@@ -95,6 +96,10 @@ export interface SerializableTransactionData {
   readonly updatedContracts: readonly ContractState[];
   readonly executionResult: ExecutionResult;
   readonly actions: readonly Action[];
+}
+
+export interface SerializableBlockData {
+  readonly blockActions: readonly Action[];
 }
 
 export type SerializeJSON<TJSON> = (context: SerializeJSONContext) => TJSON | Promise<TJSON>;

--- a/packages/neo-one-node-core/src/StackItems/InteropInterface.ts
+++ b/packages/neo-one-node-core/src/StackItems/InteropInterface.ts
@@ -1,4 +1,5 @@
 import { StackItemType } from '@neo-one/client-common';
+import { ContractParameter, InteropInterfaceContractParameter } from '../contractParameter';
 import { InvalidInteropInterfaceValueError, InvalidStackItemCastError } from '../errors';
 import { StackItemBase } from './StackItemBase';
 
@@ -29,5 +30,9 @@ export class InteropInterface extends StackItemBase {
     }
 
     throw new InvalidStackItemCastError();
+  }
+
+  public toContractParameter(): ContractParameter {
+    return new InteropInterfaceContractParameter();
   }
 }

--- a/packages/neo-one-node-core/src/StackItems/StackItemBase.ts
+++ b/packages/neo-one-node-core/src/StackItems/StackItemBase.ts
@@ -1,4 +1,4 @@
-import { StackItemType } from '@neo-one/client-common';
+import { StackItemType, toStackItemTypeJSON } from '@neo-one/client-common';
 import { BN } from 'bn.js';
 import { ContractParameter } from '../contractParameter';
 
@@ -17,20 +17,20 @@ export abstract class StackItemBase {
   }
 
   public getBoolean(): boolean {
-    throw new Error('method not implemented');
+    throw new Error(`getBoolean method not implemented for ${toStackItemTypeJSON(this.type)} stack item`);
   }
 
   public getInteger(): BN {
-    throw new Error('method not implemented');
+    throw new Error(`getInteger method not implemented for ${toStackItemTypeJSON(this.type)} stack item`);
   }
 
   // tslint:disable-next-line: no-any
   public getInterface<T>(_isFunc?: (value: any) => value is T): T | undefined {
-    throw new Error('method not implemented');
+    throw new Error(`getInterface method not implemented for ${toStackItemTypeJSON(this.type)} stack item`);
   }
 
   public getBuffer(): Buffer {
-    throw new Error('method not implemented');
+    throw new Error(`getBuffer method not implemented for ${toStackItemTypeJSON(this.type)} stack item`);
   }
 
   public getString(): string {
@@ -39,6 +39,6 @@ export abstract class StackItemBase {
 
   public toContractParameter(): ContractParameter {
     /* istanbul ignore next */
-    throw new Error('method not implemented');
+    throw new Error(`toContractParameter method not implemented for ${toStackItemTypeJSON(this.type)} stack item`);
   }
 }

--- a/packages/neo-one-node-core/src/action/ActionType.ts
+++ b/packages/neo-one-node-core/src/action/ActionType.ts
@@ -1,3 +1,4 @@
+import { InvalidFormatError } from '@neo-one/client-common';
 import { InvalidActionTypeError } from '../errors';
 
 export enum ActionType {
@@ -16,3 +17,23 @@ export const assertActionType = (value: number): ActionType => {
 
   throw new InvalidActionTypeError(value);
 };
+
+export enum ActionSource {
+  Block = 0x00,
+  Transaction = 0x01,
+}
+
+type ActionSourceJSON = keyof typeof ActionSource;
+
+// tslint:disable-next-line: strict-type-predicates no-any
+const isActionSourceJSON = (source: string): source is ActionSourceJSON => ActionSource[source as any] !== undefined;
+
+const assertActionSourceJSON = (source: string): ActionSourceJSON => {
+  if (isActionSourceJSON(source)) {
+    return source;
+  }
+
+  throw new InvalidFormatError();
+};
+
+export const actionSourceToJSON = (source: ActionSource) => assertActionSourceJSON(ActionSource[source]);

--- a/packages/neo-one-node-core/src/action/LogAction.ts
+++ b/packages/neo-one-node-core/src/action/LogAction.ts
@@ -21,19 +21,21 @@ export class LogAction extends ActionBase<ActionType.Log> implements Serializabl
       scriptHash: action.scriptHash,
       message,
       position,
+      source: action.source,
     });
   }
 
   public readonly message: string;
   public readonly position: number;
 
-  public constructor({ version, index, scriptHash, message, position }: LogAdd) {
+  public constructor({ version, index, scriptHash, message, position, source }: LogAdd) {
     const options = {
       // tslint:disable-next-line no-useless-cast
       type: ActionType.Log as ActionType.Log,
       version,
       index,
       scriptHash,
+      source,
     };
     super(options);
 
@@ -52,6 +54,7 @@ export class LogAction extends ActionBase<ActionType.Log> implements Serializabl
 
     return {
       type: 'Log',
+      source: action.source,
       version: action.version,
       index: action.index,
       scriptHash: action.scriptHash,

--- a/packages/neo-one-node-core/src/action/NotificationAction.ts
+++ b/packages/neo-one-node-core/src/action/NotificationAction.ts
@@ -25,19 +25,21 @@ export class NotificationAction
       scriptHash: action.scriptHash,
       eventName,
       args,
+      source: action.source,
     });
   }
 
   public readonly args: readonly ContractParameter[];
   public readonly eventName: string;
 
-  public constructor({ version, index, scriptHash, eventName, args }: NotificationActionAdd) {
+  public constructor({ version, index, scriptHash, eventName, args, source }: NotificationActionAdd) {
     const options = {
       // tslint:disable-next-line no-useless-cast
       type: ActionType.Notification as ActionType.Notification,
       version,
       index,
       scriptHash,
+      source,
     };
     super(options);
 
@@ -56,6 +58,7 @@ export class NotificationAction
 
     return {
       type: 'Notification',
+      source: action.source,
       version: action.version,
       index: action.index,
       scriptHash: action.scriptHash,

--- a/packages/neo-one-node-storage-common/src/keys.ts
+++ b/packages/neo-one-node-storage-common/src/keys.ts
@@ -99,8 +99,10 @@ const createTransactionDataKey = getCreateKey<TransactionDataKey>({
   prefix: Prefix.TransactionData,
 });
 
+const serializeActionKey = (key: ActionKey) => key.index.toArrayLike(Buffer, 'be', 8);
+
 const createActionKey = getCreateKey<ActionKey>({
-  serializeKey: (key) => key.index.toBuffer(),
+  serializeKey: serializeActionKey,
   prefix: Prefix.Action,
 });
 
@@ -151,6 +153,7 @@ export const keys = {
   createStorageKey,
   createBlockDataKey,
   createTransactionDataKey,
+  serializeActionKey,
   createActionKey,
   getStorageSearchRange,
   getNep17BalanceSearchRange,


### PR DESCRIPTION
### Description of the Change

- Adds blockActions to blocks so that we can see what actions were produced by the postPersist and onPersist scripts run when persisting every block. This is primarily to get the burn and mint info from NEO and GAS native contracts.
- Adds apis to digest this information from the client.
- Updates NEP17 and client smart contract APIs to be more accurate and bug free.
- Updates node errors to be more descriptive.
- Updates Interop stack item to have toContractParameter method.

### Test Plan

Use with NEO Tracker locally.

### Alternate Designs

None.

### Benefits

Appropriate info produced and stored by node.

### Possible Drawbacks

None.

### Applicable Issues

None.