### PR TITLE
fix(client): allow nep17 and smart contract APIs for non-neo-one calls

### DIFF
--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -488,6 +488,11 @@ export interface ValidatorJSON {
   readonly votes: string;
 }
 
+export interface ValidateAddressJSON {
+  readonly address: string;
+  readonly isvalid: boolean;
+}
+
 export interface PluginJSON {
   readonly name: string;
   readonly version: string;

--- a/packages/neo-one-client-core/src/Client.ts
+++ b/packages/neo-one-client-core/src/Client.ts
@@ -420,10 +420,14 @@ export class Client<
   /**
    * Constructs a `SmartContract` instance for the provided `definition` backed by this `Client` instance.
    */
-  public smartContract<T extends SmartContract<any, any> = SmartContractAny>(definition: SmartContractDefinition): T {
+  public smartContract<T extends SmartContract<any, any> = SmartContractAny>(
+    definition: SmartContractDefinition,
+    isNEOONEContract: boolean | undefined = true,
+  ): T {
     return createSmartContract({
       definition: args.assertSmartContractDefinition('definition', definition),
       client: this,
+      isNEOONEContract,
       // tslint:disable-next-line no-any
     }) as any;
   }

--- a/packages/neo-one-client-core/src/__tests__/nep17.test.ts
+++ b/packages/neo-one-client-core/src/__tests__/nep17.test.ts
@@ -1,9 +1,11 @@
 // tslint:disable no-object-mutation no-any
+import { common } from '@neo-one/client-common';
 import BigNumber from 'bignumber.js';
 import { data, factory } from '../__data__';
 import { Client } from '../Client';
 import * as nep17 from '../nep17';
-
+import { NEOONEDataProvider, NEOONEProvider } from '../provider';
+import { LocalKeyStore, LocalMemoryStore, LocalUserAccountProvider } from '../user';
 describe('nep17', () => {
   test('abi', () => {
     expect(nep17.abi(4)).toMatchSnapshot();
@@ -28,5 +30,37 @@ describe('nep17', () => {
 
     expect(contract).toEqual(smartContract);
     expect(clientSmartContract.mock.calls).toMatchSnapshot();
+  });
+
+  test.only('nep17 with native contracts GAS', async () => {
+    const myClient = new Client({
+      memory: new LocalUserAccountProvider({
+        keystore: new LocalKeyStore(new LocalMemoryStore()),
+        provider: new NEOONEProvider([
+          new NEOONEDataProvider({ network: 'main', rpcURL: 'http://localhost:8080/rpc' }),
+        ]),
+      }),
+    });
+    const gasNetwork = { main: { address: common.nativeScriptHashes.GAS } };
+    const gas = nep17.createNEP17SmartContract(myClient, gasNetwork, 8, false);
+
+    const [symbol, totalSupply] = await Promise.all([gas.symbol(), gas.totalSupply()]);
+    console.log(symbol, totalSupply);
+  });
+
+  test.only('nep17 with NEO', async () => {
+    const myClient = new Client({
+      memory: new LocalUserAccountProvider({
+        keystore: new LocalKeyStore(new LocalMemoryStore()),
+        provider: new NEOONEProvider([
+          new NEOONEDataProvider({ network: 'main', rpcURL: 'http://localhost:8080/rpc' }),
+        ]),
+      }),
+    });
+    const neoNetwork = { main: { address: common.nativeScriptHashes.NEO } };
+    const neo = nep17.createNEP17SmartContract(myClient, neoNetwork, 0, false);
+
+    const [symbol, totalSupply] = await Promise.all([neo.symbol(), neo.totalSupply()]);
+    console.log(symbol, totalSupply);
   });
 });

--- a/packages/neo-one-client-core/src/nep17.ts
+++ b/packages/neo-one-client-core/src/nep17.ts
@@ -43,21 +43,24 @@ export interface NEP17SmartContract<TClient extends Client = Client> extends Sma
 
 const DEFAULT_NEO_ONE_PARAM: ABIParameter = { type: 'String', name: NEO_ONE_METHOD_RESERVED_PARAM };
 
-const getDecimalsMethod = (decimals: number): ContractMethodDescriptorClient => ({
+const getDecimalsMethod = (
+  decimals: number,
+  isNEOONEContract: boolean | undefined = true,
+): ContractMethodDescriptorClient => ({
   name: 'decimals',
   constant: true,
-  parameters: [DEFAULT_NEO_ONE_PARAM],
+  parameters: isNEOONEContract ? [DEFAULT_NEO_ONE_PARAM] : [],
   returnType: { type: 'Integer', decimals },
   offset: 0,
   safe: true,
 });
 
-export const abi = (decimals: number): ContractABIClient => ({
+export const abi = (decimals: number, isNEOONEContract: boolean | undefined = true): ContractABIClient => ({
   methods: [
     {
       name: 'name',
       constant: true,
-      parameters: [DEFAULT_NEO_ONE_PARAM],
+      parameters: isNEOONEContract ? [DEFAULT_NEO_ONE_PARAM] : [],
       returnType: { type: 'String' },
       offset: 0,
       safe: true,
@@ -65,16 +68,16 @@ export const abi = (decimals: number): ContractABIClient => ({
     {
       name: 'symbol',
       constant: true,
-      parameters: [DEFAULT_NEO_ONE_PARAM],
+      parameters: isNEOONEContract ? [DEFAULT_NEO_ONE_PARAM] : [],
       returnType: { type: 'String' },
       offset: 0,
       safe: true,
     },
-    getDecimalsMethod(decimals),
+    getDecimalsMethod(decimals, isNEOONEContract),
     {
       name: 'totalSupply',
       constant: true,
-      parameters: [DEFAULT_NEO_ONE_PARAM],
+      parameters: isNEOONEContract ? [DEFAULT_NEO_ONE_PARAM] : [],
       returnType: { type: 'Integer', decimals },
       offset: 0,
       safe: true,
@@ -142,11 +145,11 @@ export const abi = (decimals: number): ContractABIClient => ({
   ],
 });
 
-export const manifest = (decimals: number): ContractManifestClient => ({
+export const manifest = (decimals: number, isNEOONEContract: boolean | undefined = true): ContractManifestClient => ({
   name: 'A NEO•ONE NEP-17 Smart Contract',
   groups: [],
   supportedStandards: ['NEP-17'],
-  abi: abi(decimals),
+  abi: abi(decimals, isNEOONEContract),
   permissions: [],
   trusts: '*',
 });
@@ -155,12 +158,13 @@ export const getDecimals = async (
   client: Client,
   networksDefinition: SmartContractNetworksDefinition,
   network: NetworkType,
+  isNEOONEContract: boolean | undefined = true,
 ): Promise<number> => {
   const decimalsBigNumber = await client
     .smartContract({
       networks: networksDefinition,
       manifest: {
-        ...manifest(0),
+        ...manifest(0, isNEOONEContract),
         abi: { events: [], methods: [getDecimalsMethod(0)] },
       },
     })
@@ -173,8 +177,12 @@ export const createNEP17SmartContract = <TClient extends Client>(
   client: TClient,
   networksDefinition: SmartContractNetworksDefinition,
   decimals: number,
+  isNEOONEContract: boolean | undefined = true,
 ): NEP17SmartContract =>
-  client.smartContract<NEP17SmartContract<TClient>>({
-    networks: networksDefinition,
-    manifest: manifest(decimals),
-  });
+  client.smartContract<NEP17SmartContract<TClient>>(
+    {
+      networks: networksDefinition,
+      manifest: manifest(decimals, isNEOONEContract),
+    },
+    isNEOONEContract,
+  );

--- a/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
+++ b/packages/neo-one-client-core/src/provider/JSONRPCClient.ts
@@ -24,6 +24,7 @@ import {
   TransactionReceiptJSON,
   TriggerTypeJSON,
   UnclaimedGASJSON,
+  ValidateAddressJSON,
   ValidatorJSON,
   VerificationCostJSON,
   VersionJSON,
@@ -228,7 +229,7 @@ export class JSONRPCClient {
     );
   }
 
-  public async getBlockHash(index: number): Promise<string> {
+  public async getBlockHash(index: number): Promise<string | undefined> {
     return this.withInstance(async (provider) =>
       provider.request({
         method: 'getblockhash',
@@ -250,7 +251,7 @@ export class JSONRPCClient {
     return this.withInstance(async (provider) => provider.request({ method: 'getnextblockvalidators' }));
   }
 
-  public async validateAddress(address: string): Promise<{ readonly address: string; readonly isvalid: boolean }> {
+  public async validateAddress(address: string): Promise<ValidateAddressJSON> {
     return this.withInstance(async (provider) => provider.request({ method: 'validateaddress', params: [address] }));
   }
 

--- a/packages/neo-one-client-core/src/sc/createSmartContract.ts
+++ b/packages/neo-one-client-core/src/sc/createSmartContract.ts
@@ -198,10 +198,12 @@ const createCall =
     definition,
     client,
     func: { name, parameters = [], returnType, receive = false },
+    isNEOONEContract,
   }: {
     readonly definition: SmartContractDefinition;
     readonly client: Client;
     readonly func: ContractMethodDescriptorClient;
+    readonly isNEOONEContract: boolean;
   }) =>
   // tslint:disable-next-line no-any
   async (...args: any[]): Promise<Return | undefined> => {
@@ -215,7 +217,7 @@ const createCall =
 
     // For NEO•ONE contracts we need to add method name as the first param. This should be fixed
     const paramsIn = [name, ...params];
-    const receipt = await client.__call(network, address, name, paramsIn);
+    const receipt = await client.__call(network, address, name, isNEOONEContract ? paramsIn : params);
 
     return common.convertCallResult({
       returnType,
@@ -229,10 +231,12 @@ const createInvoke = ({
   definition,
   client,
   func: { name, parameters = [], returnType, receive = false },
+  isNEOONEContract,
 }: {
   readonly definition: SmartContractDefinition;
   readonly client: Client;
   readonly func: ContractMethodDescriptorClient;
+  readonly isNEOONEContract: boolean;
 }) => {
   const invoke = async (
     // tslint:disable-next-line no-any
@@ -246,10 +250,12 @@ const createInvoke = ({
       client,
     });
 
+    // For NEO•ONE contracts we need to add method name as the first param. This should be fixed
+    const paramsIn = [name, ...params];
     const result: TransactionResult<RawInvokeReceipt> = await client.__invoke(
       address,
       name,
-      [name, ...params], // For NEO•ONE contracts we need to add method name as the first param. This should be fixed
+      isNEOONEContract ? paramsIn : params,
       paramsZipped,
       receive,
       options,
@@ -307,9 +313,11 @@ const createInvoke = ({
 export const createSmartContract = ({
   definition,
   client,
+  isNEOONEContract = true,
 }: {
   readonly definition: SmartContractDefinition;
   readonly client: Client;
+  readonly isNEOONEContract?: boolean;
 }): SmartContractAny => {
   const {
     manifest: {
@@ -378,11 +386,13 @@ export const createSmartContract = ({
                 definition,
                 client,
                 func,
+                isNEOONEContract,
               })
             : createInvoke({
                 definition,
                 client,
                 func,
+                isNEOONEContract,
               }),
       }),
     {


### PR DESCRIPTION
### Description of the Change

- Update `createSmartContract` and `Client` and `nep17` to allow users to call non-NEO•ONE contracts with these APIs. This is necessary because NEO•ONE contracts are currently called differently than other contracts. See #2476. This should be reversed when 2476 is fixed later.
- Add types to RPC handlers and fix return values for a few.

### Test Plan



### Alternate Designs

None.

### Benefits

More flexible client APIs

### Possible Drawbacks

None.

### Applicable Issues

#2476