### PR TITLE
fix(node): add more info to nep17transfers

### DIFF
--- a/packages/neo-one-client-common/src/models/nep17/Nep17TransferModel.ts
+++ b/packages/neo-one-client-common/src/models/nep17/Nep17TransferModel.ts
@@ -1,12 +1,21 @@
 import { BinaryWriter } from '../../BinaryWriter';
 import { UInt160, UInt256 } from '../../common';
 import { createSerializeWire, SerializableWire, SerializeWire } from '../Serializable';
+import { VMState } from '../vm';
+
+export enum Nep17TransferSource {
+  All = 0xff,
+  Transaction = 0x00,
+  Block = 0x01,
+}
 
 export interface Nep17TransferModelAdd {
   readonly userScriptHash: UInt160;
   readonly blockIndex: number;
   readonly txHash: UInt256;
   readonly amountBuffer: Buffer;
+  readonly source: 'Block' | 'Transaction';
+  readonly state: VMState;
 }
 
 export class Nep17TransferModel implements SerializableWire {
@@ -14,13 +23,17 @@ export class Nep17TransferModel implements SerializableWire {
   public readonly blockIndex: number;
   public readonly txHash: UInt256;
   public readonly amountInternal: Buffer;
+  public readonly source: Nep17TransferSource;
+  public readonly state: VMState;
   public readonly serializeWire: SerializeWire = createSerializeWire(this.serializeWireBase.bind(this));
 
-  public constructor({ userScriptHash, blockIndex, txHash, amountBuffer }: Nep17TransferModelAdd) {
+  public constructor({ userScriptHash, blockIndex, txHash, amountBuffer, source, state }: Nep17TransferModelAdd) {
     this.userScriptHash = userScriptHash;
     this.blockIndex = blockIndex;
     this.txHash = txHash;
     this.amountInternal = amountBuffer;
+    this.source = source === 'Block' ? Nep17TransferSource.Block : Nep17TransferSource.Transaction;
+    this.state = state;
   }
 
   public serializeWireBase(writer: BinaryWriter): void {
@@ -28,5 +41,7 @@ export class Nep17TransferModel implements SerializableWire {
     writer.writeUInt32LE(this.blockIndex);
     writer.writeUInt256(this.txHash);
     writer.writeVarBytesLE(this.amountInternal);
+    writer.writeUInt8(this.source);
+    writer.writeUInt8(this.state);
   }
 }

--- a/packages/neo-one-client-common/src/models/types.ts
+++ b/packages/neo-one-client-common/src/models/types.ts
@@ -5,6 +5,7 @@ import { ContractParameterTypeModel } from './ContractParameterTypeModel';
 import { AttributeTypeModel } from './transaction';
 import { TriggerTypeJSON } from './trigger';
 import { VerifyResultModel } from './VerifyResultModel';
+import { VMStateJSON } from './vm';
 import { WitnessScopeModel } from './WitnessScopeModel';
 
 export interface AnyContractParameterJSON {
@@ -398,11 +399,13 @@ export interface Nep17BalanceJSON {
 export interface Nep17TransferJSON {
   readonly timestamp: number;
   readonly assethash: string;
-  readonly transferaddress: string;
+  readonly transferaddress: string | null;
   readonly amount: string;
   readonly blockindex: number;
   readonly transfernotifyindex: number;
   readonly txhash: string;
+  readonly source: string;
+  readonly state: VMStateJSON;
 }
 
 export interface HeaderJSON {

--- a/packages/neo-one-client-common/src/types.ts
+++ b/packages/neo-one-client-common/src/types.ts
@@ -1796,7 +1796,7 @@ export interface NefFile {
   /**
    * The script of the contract.
    */
-  readonly script: string;
+  readonly script: BufferString;
   /**
    * The methods to be called statically.
    */
@@ -2528,8 +2528,8 @@ export interface Peer {
  * Raw storage value
  */
 export interface StorageItem {
-  readonly key: string;
-  readonly value: string;
+  readonly key: BufferString;
+  readonly value: BufferString;
 }
 
 /* END LOW-LEVEL API */

--- a/packages/neo-one-client-full-common/src/models/manifest/ContractGroupModel.ts
+++ b/packages/neo-one-client-full-common/src/models/manifest/ContractGroupModel.ts
@@ -17,7 +17,7 @@ export class ContractGroupModel implements SerializableJSON<ContractGroupJSON> {
   public serializeJSON(): ContractGroupJSON {
     return {
       publicKey: JSONHelper.writeECPoint(this.publicKey),
-      signature: JSONHelper.writeBuffer(this.signature),
+      signature: JSONHelper.writeBase64Buffer(this.signature),
     };
   }
 }

--- a/packages/neo-one-client-full/src/index.ts
+++ b/packages/neo-one-client-full/src/index.ts
@@ -116,6 +116,7 @@ export {
   ObjectABI,
   ObjectABIParameter,
   ObjectABIReturn,
+  OracleResponse,
   Param,
   Peer,
   PrivateKeyString,

--- a/packages/neo-one-client/src/index.ts
+++ b/packages/neo-one-client/src/index.ts
@@ -127,6 +127,7 @@ export {
   RawVMNotification,
   InvocationResultSuccess,
   InvocationResultError,
+  OracleResponse,
   RelayTransactionResult,
   Return,
   ScriptBuilderParam,

--- a/packages/neo-one-node-blockchain/src/PersistingBlockchain.ts
+++ b/packages/neo-one-node-blockchain/src/PersistingBlockchain.ts
@@ -232,7 +232,7 @@ export class PersistingBlockchain {
         const appExecuted = this.persistTransaction(transaction, main, clone, block);
         const { actions: newActions, lastGlobalActionIndex } = this.getActionsFromAppExecuted(
           appExecuted,
-          lastGlobalActionIndexIn,
+          acc.lastGlobalActionIndex,
           ActionSource.Transaction,
         );
 
@@ -250,7 +250,7 @@ export class PersistingBlockchain {
           deployedContractHashes,
           updatedContractHashes,
           executionResult,
-          actionIndexStart: lastGlobalActionIndexIn,
+          actionIndexStart: acc.lastGlobalActionIndex,
           actionIndexStop: lastGlobalActionIndex,
           transactionIndex,
           blockIndex: block.index,

--- a/packages/neo-one-node-core/src/Nep17Balance.ts
+++ b/packages/neo-one-node-core/src/Nep17Balance.ts
@@ -3,11 +3,6 @@ import { BN } from 'bn.js';
 import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
 import { utils } from './utils';
 
-export interface Nep17BalanceAdd {
-  readonly balanceBuffer: Buffer;
-  readonly lastUpdatedBlock: number;
-}
-
 export class Nep17Balance extends Nep17BalanceModel {
   public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep17Balance {
     const { reader } = options;

--- a/packages/neo-one-node-core/src/Nep17BalanceKey.ts
+++ b/packages/neo-one-node-core/src/Nep17BalanceKey.ts
@@ -1,11 +1,6 @@
-import { BinaryReader, createSerializeWire, IOHelper, Nep17BalanceKeyModel, UInt160 } from '@neo-one/client-common';
+import { BinaryReader, createSerializeWire, IOHelper, Nep17BalanceKeyModel } from '@neo-one/client-common';
 import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
 import { utils } from './utils';
-
-export interface Nep17BalanceKeyAdd {
-  readonly userScriptHash: UInt160;
-  readonly assetScriptHash: UInt160;
-}
 
 export class Nep17BalanceKey extends Nep17BalanceKeyModel {
   public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep17BalanceKey {

--- a/packages/neo-one-node-core/src/Nep17TransferKey.ts
+++ b/packages/neo-one-node-core/src/Nep17TransferKey.ts
@@ -1,14 +1,6 @@
-import { BinaryReader, createSerializeWire, IOHelper, Nep17TransferKeyModel, UInt160 } from '@neo-one/client-common';
-import { BN } from 'bn.js';
+import { BinaryReader, createSerializeWire, IOHelper, Nep17TransferKeyModel } from '@neo-one/client-common';
 import { DeserializeWireBaseOptions, DeserializeWireOptions } from './Serializable';
 import { utils } from './utils';
-
-export interface Nep17TransferKeyAdd {
-  readonly userScriptHash: UInt160;
-  readonly timestampMS: BN;
-  readonly assetScriptHash: UInt160;
-  readonly blockTransferNotificationIndex: number;
-}
 
 export class Nep17TransferKey extends Nep17TransferKeyModel {
   public static deserializeWireBase(options: DeserializeWireBaseOptions): Nep17TransferKey {

--- a/packages/neo-one-node-core/src/StorageItem.ts
+++ b/packages/neo-one-node-core/src/StorageItem.ts
@@ -4,6 +4,7 @@ import {
   createSerializeWire,
   InvalidFormatError,
   JSONHelper,
+  StorageItemJSON,
 } from '@neo-one/client-common';
 import { BN } from 'bn.js';
 import { DeserializeWireBaseOptions, DeserializeWireOptions, SerializableWire } from './Serializable';
@@ -96,7 +97,7 @@ export class StorageItem implements SerializableWire {
     });
   }
 
-  public serializeJSON(key: StorageKey) {
+  public serializeJSON(key: StorageKey): StorageItemJSON {
     return {
       key: JSONHelper.writeBase64Buffer(key.serializeWire()),
       value: JSONHelper.writeBase64Buffer(this.value),

--- a/packages/neo-one-node-core/src/contractParameter/ByteArrayContractParameter.ts
+++ b/packages/neo-one-node-core/src/contractParameter/ByteArrayContractParameter.ts
@@ -42,7 +42,7 @@ export class ByteArrayContractParameter extends ContractParameterBase<
   public serializeJSON(): ByteArrayContractParameterJSON {
     return {
       type: 'ByteArray',
-      value: JSONHelper.writeBuffer(this.value),
+      value: JSONHelper.writeBase64Buffer(this.value),
     };
   }
 }

--- a/packages/neo-one-node-core/src/contractParameter/ContractParameter.ts
+++ b/packages/neo-one-node-core/src/contractParameter/ContractParameter.ts
@@ -24,6 +24,7 @@ export type ContractParameter =
   | Hash160ContractParameter
   | Hash256ContractParameter
   | ByteArrayContractParameter
+  | SignatureContractParameter
   | PublicKeyContractParameter
   | StringContractParameter
   | ArrayContractParameter

--- a/packages/neo-one-node-storage-common/src/keys.ts
+++ b/packages/neo-one-node-storage-common/src/keys.ts
@@ -38,6 +38,7 @@ const getCreateKey = <Key>({
 };
 
 /* Daniel Byrne: This is a crude method but it does what we want it to do */
+/* Spencer: This is terrible and needs to be removed */
 const generateSearchRange = (lookupKey: Buffer): Required<StreamOptions> => {
   const asBN = new BN(lookupKey);
   const lte = asBN.addn(1).toBuffer();

--- a/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
+++ b/packages/neo-one-node-vm/lib/Dispatcher.Engine.cs
@@ -296,7 +296,7 @@ namespace NEOONE
 
     private string _getFaultException()
     {
-      return this.engine.FaultException?.ToString();
+      return this.engine.FaultException?.Message.ToString();
     }
 
     private bool _push(string item)


### PR DESCRIPTION
### Description of the Change

- Adds information to Nep17Transfer object so that it's easier to debug when transfers go wrong in our node in the future.
- Fixes some client code/types.
- Fixes global action indexes.
- Converts all base64 buffer strings from node into hex buffer strings.
- Commits almost all storages changes all at once instead of separately.
- Gets only the Fault error message from the VM instead of the entire stack trace as well.

### Test Plan

None. Tested locally and in production.

### Alternate Designs

None.

### Benefits

More transfer information stored. Bug fixes. Better types. Cleaner code.

### Possible Drawbacks

None.

### Applicable Issues

None.