### PR TITLE
fix: client-switch shouldnt initialize sourcemaps

### DIFF
--- a/common/changes/@neo-one/client-switch/fix-switch-2_2021-10-09-05-35.json
+++ b/common/changes/@neo-one/client-switch/fix-switch-2_2021-10-09-05-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@neo-one/client-switch",
+      "comment": "Remove intialize sourcemap from common",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@neo-one/client-switch",
+  "email": "29364457+spencercorwin@users.noreply.github.com"
+}

--- a/packages/neo-one-client-switch/src/common/processTrace.ts
+++ b/packages/neo-one-client-switch/src/common/processTrace.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import { RawSourceMap, SourceMapConsumer } from 'source-map';
-import { initializeSourceMap } from '../node';
 import { SourceMaps } from './processActionsAndMessage';
 import { getChunk } from './utils';
 
@@ -78,8 +77,6 @@ export const processTrace = async ({
     }
 
     const [currentAddress, currentSourceMap] = remainingSourceMaps[0];
-
-    initializeSourceMap();
 
     return SourceMapConsumer.with(currentSourceMap, undefined, async (consumer) =>
       withSourceMaps(


### PR DESCRIPTION
### Description of the Change

Minor fix to client-switch so we don't import from common and then from node in browser package.