### PR TITLE
fix(node): fix node contracttask issue and others

### DIFF
--- a/packages/neo-one-node-blockchain/src/PersistingBlockchain.ts
+++ b/packages/neo-one-node-blockchain/src/PersistingBlockchain.ts
@@ -77,7 +77,7 @@ export class PersistingBlockchain {
           engine.loadScript({ script: this.onPersistNativeContractScript });
           const result = engine.execute();
           if (result !== VMState.HALT) {
-            throw new PersistNativeContractsError();
+            throw new PersistNativeContractsError(engine.faultException);
           }
 
           return utils.getApplicationExecuted(engine);
@@ -311,7 +311,7 @@ export class PersistingBlockchain {
         engine.loadScript({ script: this.postPersistNativeContractScript });
         const result = engine.execute();
         if (result !== VMState.HALT) {
-          throw new PostPersistError();
+          throw new PostPersistError(engine.faultException);
         }
 
         return utils.getApplicationExecuted(engine);

--- a/packages/neo-one-node-core/src/ContractState.ts
+++ b/packages/neo-one-node-core/src/ContractState.ts
@@ -17,9 +17,11 @@ export type ContractKey = UInt160;
 export class ContractState extends ContractStateModel<ContractManifest, NefFile> {
   public static fromStackItem(stackItem: StackItem): ContractState {
     const { array } = assertArrayStackItem(stackItem);
-    const id = array[0].getInteger().toNumber();
-    const updateCounter = array[1].getInteger().toNumber();
     const hash = common.bufferToUInt160(array[2].getBuffer());
+    const isNative = Object.values(common.nativeScriptHashes).includes(common.uInt160ToString(hash));
+    const idBN = array[0].getInteger();
+    const id = isNative ? idBN.fromTwos(idBN.byteLength() * 8).toNumber() : idBN.toNumber();
+    const updateCounter = array[1].getInteger().toNumber();
     const nef = NefFile.deserializeWire({ buffer: array[3].getBuffer() });
     const manifest = ContractManifest.fromStackItem(array[4]);
 

--- a/packages/neo-one-node-rpc-handler/src/createHandler.ts
+++ b/packages/neo-one-node-rpc-handler/src/createHandler.ts
@@ -785,12 +785,15 @@ export const createHandler = ({
         source = Nep17TransferSource.Block;
       }
 
+      const useMaxVal = args[4] !== undefined;
+      const ULONG_MAX = new BN('18446744073709551615', 10); // 64-bit unsigned int
+
       if (endTime < startTime) {
         throw new JSONRPCError(-32602, 'Invalid params');
       }
 
       const startTimeBytes = new BinaryWriter().writeUInt64LE(new BN(startTime)).toBuffer();
-      const endTimeBytes = new BinaryWriter().writeUInt64LE(new BN(endTime)).toBuffer();
+      const endTimeBytes = new BinaryWriter().writeUInt64LE(new BN(useMaxVal ? ULONG_MAX : endTime)).toBuffer();
       const gte = Buffer.concat([scriptHash, startTimeBytes]);
       const lte = Buffer.concat([scriptHash, endTimeBytes]);
 

--- a/packages/neo-one-node-vm/lib/Dispatcher.csproj
+++ b/packages/neo-one-node-vm/lib/Dispatcher.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="RocksDbNative" Version="6.2.2" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
     <PackageReference Include="Neo-VM-N1-Fork" Version="3.0.0" />
-    <PackageReference Include="Neo-NEO-ONE-Fork" Version="3.0.2.1" />
+    <PackageReference Include="Neo-NEO-ONE-Fork" Version="3.0.2.2" />
     <!-- <ProjectReference Include="/Users/spencercorwin/neo/src/neo/neo.csproj" /> -->
     <!-- <ProjectReference Include="/Users/spencercorwin/neo-vm/src/neo-vm/neo-vm.csproj" /> -->
   </ItemGroup>

--- a/packages/neo-one-node-vm/lib/ReturnHelpers.cs
+++ b/packages/neo-one-node-vm/lib/ReturnHelpers.cs
@@ -28,6 +28,16 @@ namespace NEOONE
       }
     }
 
+    public class IntegerReturn : PrimitiveReturn
+    {
+      public readonly int Sign;
+
+      public IntegerReturn(PrimitiveType item, byte[] value) : base(item, value)
+      {
+        this.Sign = item.GetInteger().Sign;
+      }
+    }
+
     public class PointerReturn
     {
       public readonly byte[] value;
@@ -136,7 +146,7 @@ namespace NEOONE
       return item.Type switch
       {
         StackItemType.Boolean => new PrimitiveReturn(item, item.GetBoolean()),
-        StackItemType.Integer => new PrimitiveReturn(item, item.GetInteger().ToByteArray()),
+        StackItemType.Integer => new IntegerReturn(item, item.GetInteger().ToByteArray()),
         StackItemType.ByteString => new PrimitiveReturn(item, item.GetSpan().ToArray()),
         _ => throw new ArgumentException($"{item.Type} is not a valid StackItem argument")
       };

--- a/packages/neo-one-node-vm/src/converters/stackItems.ts
+++ b/packages/neo-one-node-vm/src/converters/stackItems.ts
@@ -13,6 +13,7 @@ import {
   StackItem,
   StructStackItem,
 } from '@neo-one/node-core';
+import { utils } from '@neo-one/utils';
 import { BN } from 'bn.js';
 
 export interface StackItemReturnBase {
@@ -40,6 +41,7 @@ export interface IntegerStackItemReturn extends StackItemReturnBase {
   readonly Type: 'Integer';
   readonly value: string | number;
   readonly Size: number;
+  readonly Sign: number; // -1 is negative, 1 is positive, 0 is zero
 }
 
 export interface ByteStringStackItemReturn extends StackItemReturnBase {
@@ -144,6 +146,7 @@ const parsePrimitiveStackItem = (item: PrimitiveStackItemReturn): PrimitiveStack
       return new IntegerStackItem(new BN(item.value, 'le'));
 
     default:
-      throw new Error(`invalid stack item when parsing, found type ${item}`);
+      utils.assertNever(item);
+      throw new Error(`Invalid stack item type when parsing stack item return, found type ${item}`);
   }
 };


### PR DESCRIPTION
### Description of the Change

- There was a major problem appearing on the N3 MainNet sync around block 151,000. The block was not persisting due to an account error, which was due to a GhostMarket contract execution not going through properly in a previous block, which caused a balance discrepancy. I dug down and had to log all the contract storage changes for contract ids 7 and 8 on our node and the official C# node. Finally I got to the very first divergence in storage changes around block 128,000. A transaction FAULed on theirs but not on ours. This was due to a minor difference in the C# application engine due to us using a different C# runtime target. The fix was published to our Neo fork in version 3.0.2.2.
- Add args to getnep17transfers for easier usage.
- Add fault exception to persist errors.
- Add sign to integer stack item return.
- Fix a small issue where contract IDs for native contracts come out as positive ints instead of negative as they should.

### Test Plan

Tested locally and deployed.

### Alternate Designs

None.

### Benefits

Bug fixes.

### Possible Drawbacks

None.

### Applicable Issues

None.